### PR TITLE
Remove init because import does the init already and init function isn't exposed

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -18,8 +18,6 @@ import sitemap from './theme/sitemap';
 import subscribe from './theme/subscribe';
 import wishlist from './theme/wishlist';
 
-stencilUtils.events.init();
-
 var modules = {
     "account": account,
     "auth": auth,


### PR DESCRIPTION
@mick @mcampa  @meenie @christopher-hegre
