### PR TITLE
Fix duplicate 'disabled' key map

### DIFF
--- a/assets/scss/settings/foundation/buttons/_settings.scss
+++ b/assets/scss/settings/foundation/buttons/_settings.scss
@@ -179,18 +179,6 @@ $buttonStyleMap: (
         borderColorActive:              $buttonStyle-primary-borderColorActive
     ),
 
-    disabled: (
-        color:                          $buttonStyle-disabled-color,
-        colorHover:                     $buttonStyle-disabled-colorHover,
-        colorActive:                    $buttonStyle-disabled-colorActive,
-        backgroundColor:                $buttonStyle-disabled-backgroundColor,
-        backgroundColorHover:           $buttonStyle-disabled-backgroundColorHover,
-        backgroundColorActive:          $buttonStyle-disabled-backgroundColorActive,
-        borderColor:                    $buttonStyle-disabled-borderColor,
-        borderColorHover:               $buttonStyle-disabled-borderColorHover,
-        borderColorActive:              $buttonStyle-disabled-borderColorActive
-    ),
-
     tertiary: (
         color:                          $buttonStyle-tertiary-color,
         colorHover:                     $buttonStyle-tertiary-colorHover,


### PR DESCRIPTION
@SiTaggart @bc-chris-roper @bc-miko-ademagic 

@christopher-hegre 

```
SASS Error: Duplicate key "disabled" in map (default: (color: $buttonStyle-default-color, colorHover: $buttonStyle-default-colorHover, colorActive: $buttonStyle-default-colorActive, backgroundColor: $buttonStyle-default-backgroundColor, backgroundColorHover: $buttonStyle-default-backgroundColorHover, backgroundColorActive: $buttonStyle-default-backgroundColorActive, borderColor: $buttonStyle-default-borderColor, borderColorHover: $buttonStyle-default-borderColorHover, borderColorActive: $buttonStyle-default-borderColorActive), primary: (color: $buttonStyle-primary-color, colorHover: $buttonStyle-primary-colorHover, colorActive: $buttonStyle-primary-colorActive, backgroundColor: $buttonStyle-primary-backgroundColor, backgroundColorHover: $buttonStyle-primary-backgroundColorHover, backgroundColorActive: $buttonStyle-primary-backgroundColorActive, borderColor: $buttonStyle-primary-borderColor, borderColorHover: $buttonStyle-primary-borderColorHover, borderColorActive: $buttonStyle-primary-borderColorActive), disabled: (color: $buttonStyle-disabled-color, colorHover: $buttonStyle-disabled-colorHover, colorActive: $buttonStyle-disabled-colorActive, backgroundColor: $buttonStyle-disabled-backgroundColor, backgroundColorHover: $buttonStyle-disabled-backgroundColorHover, backgroundColorActive: $buttonStyle-disabled-backgroundColorActive, borderColor: $buttonStyle-disabled-borderColor, borderColorHover: $buttonStyle-disabled-borderColorHover, borderColorActive: $buttonStyle-disabled-borderColorActive), tertiary: (color: $buttonStyle-tertiary-color, colorHover: $buttonStyle-tertiary-colorHover, colorActive: $buttonStyle-tertiary-colorActive, backgroundColor: $buttonStyle-tertiary-backgroundColor, backgroundColorHover: $buttonStyle-tertiary-backgroundColorHover, backgroundColorActive: $buttonStyle-tertiary-backgroundColorActive, borderColor: $buttonStyle-tertiary-borderColor, borderColorHover: $buttonStyle-tertiary-borderColorHover, borderColorActive: $buttonStyle-tertiary-borderColorActive), action: (color: $buttonStyle-action-color, colorHover: $buttonStyle-action-colorHover, colorActive: $buttonStyle-action-colorActive, backgroundColor: $buttonStyle-action-backgroundColor, backgroundColorHover: $buttonStyle-action-backgroundColorHover, backgroundColorActive: $buttonStyle-action-backgroundColorActive, borderColor: $buttonStyle-action-borderColor, borderColorHover: $buttonStyle-action-borderColorHover, borderColorActive: $buttonStyle-action-borderColorActive)). at /Users/hau.nguyen/dev/messedup-qamal/codebases/stencil/assets/scss/settings/foundation/buttons/_settings.scss@157:18
```
