### PR TITLE
Fix to product card rating value

### DIFF
--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -22,7 +22,7 @@
         </figcaption>
     </figure>
     <div class="card-body">
-        <p class="card-text">{{> components/products/ratings rating=product.rating}}</p>
+        <p class="card-text">{{> components/products/ratings rating=rating}}</p>
         {{#if brand.name}}
         <p class="card-text">{{brand.name}}</p>
         {{/if}}


### PR DESCRIPTION
One more product card thing, rating was still scoped to `product.`

@christopher-hegre @bc-chris-roper @bc-miko-ademagic @haubc 
