### PR TITLE
BIG-19710 Fix add to wishlist nested forms

### DIFF
--- a/assets/js/theme/product.js
+++ b/assets/js/theme/product.js
@@ -36,6 +36,8 @@ export default class Product extends PageManager {
 
         this.addProductToCart();
 
+        this.addProductToWishlist();
+
         next();
     }
 
@@ -130,6 +132,24 @@ export default class Product extends PageManager {
                     $modalContent.html(response.content);
                 });
             });
+        });
+    }
+
+    /**
+     * Add to wishlist form submission javascript workaround
+     *
+     * In order for the wishlist button to be next to the add cart button and not we cannot have nested forms,
+     * we have to use javascript to perform a different form submission
+     */
+    addProductToWishlist() {
+        let $wishListForm = $('#form-wishlish-add');
+
+        $('#form-wishlish-submit').click((e) => {
+            // stop form submission
+            e.preventDefault();
+
+            // submit wishlist form
+            $wishListForm.submit();
         });
     }
 

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -39,7 +39,6 @@
             {{#if product.release_date }}
             <p>{{product.release_date}}</p>
             {{/if}}
-
             <form class="form" method="post" action="{{product.cart_url}}" enctype="multipart/form-data" data-cart-item-add>
                 <fieldset class="form-fieldset">
                     <input type="hidden" name="action" value="add">
@@ -68,12 +67,16 @@
                             <input class="button button--primary" type="submit" data-bind="enable: canAddToCart" value="Add to cart">
                         </div>
                         <div class="form-action">
-                            <form method="post" action="{{product.add_to_wishlist_url}}">
-                                <input class="button" type="submit" value="{{@lang 'account.wishlists.add_item'}}">
-                            </form>
+                            <input id="form-wishlish-submit" class="button" type="submit" value="{{@lang 'account.wishlists.add_item'}}">
                         </div>
                     </div>
                 </fieldset>
+            </form>
+
+            <!-- Add to wishlist form -->
+            <form id="form-wishlish-add" method="post" action="{{product.add_to_wishlist_url}}">
+                <input type="hidden" name="action" value="add">
+                <input type="hidden" name="product_id" value="{{product.id}}">
             </form>
         </div>
 


### PR DESCRIPTION
Problem: 
- Nested forms
  When the user submits the form, it will only submit the parent form and not the child's.
- Workaround
  Using javascript (similar to the legacy code) we submit a hidden form at a different location. 

Other workarounds I thought of:
- Use absolute position so the buttons can be next to each other, but that will cause responsive-layout issues.

@mickr @christopher-hegre @bc-miko-ademagic @SiTaggart
