### PR TITLE
BIG-19697 Hide star ratings from quick search product cards

### DIFF
--- a/assets/scss/components/citadel/cards/_cards.scss
+++ b/assets/scss/components/citadel/cards/_cards.scss
@@ -74,6 +74,11 @@
         }
     }
 
+    .icon--starFull,
+    .icon--starEmpty {
+        display: none;
+    }
+
     &:hover {
         border-color: color("greys", "darker");
 


### PR DESCRIPTION
Designs actually show the stars are not included in the products on quick view

![](https://dl.dropboxusercontent.com/spa/tkd7j6cqqsnwksf/yrpr2f-_.png)

As we use the same partial, just hiding the stars in CSS

@bc-miko-ademagic @bc-chris-roper 
