### PR TITLE
BIG-19976 Fix stock level showing when settings is on

### DIFF
--- a/assets/js/theme/common/product.js
+++ b/assets/js/theme/common/product.js
@@ -27,6 +27,10 @@ export default class Product {
             $price: $('.productView-price [data-product-price]', $productView),
             $increments: $('.form-field--increments :input', $productView),
             $addToCart: $('#form-action-addToCart', $productView),
+            stock: {
+                $container: $('.form-field--stock', $productView),
+                $input: $('[data-product-stock]', $productView)
+            },
             quantity: {
                 $text: $('.incrementTotal', $productView),
                 $input: $('[name=qty\\[\\]]', $productView)
@@ -56,6 +60,15 @@ export default class Product {
                 utils.api.productAttributes.optionChange(options, productId, (err, response) => {
                     let viewModel = this.getViewModel($productView);
                     viewModel.$price.html(response.data.price);
+
+                    // if stock view is on (CP settings)
+                    if (viewModel.stock.$container.length) {
+                        // if the stock container is hidden, show
+                        if (viewModel.stock.$container.is(':hidden')) {
+                            viewModel.stock.$container.show();
+                        }
+                        viewModel.stock.$input.text(response.data.stock);
+                    }
 
                     if (!response.data.purchasable || !response.data.instock) {
                         viewModel.$addToCart.prop('disabled', true);

--- a/assets/scss/components/citadel/forms/_forms.scss
+++ b/assets/scss/components/citadel/forms/_forms.scss
@@ -141,6 +141,10 @@
     background-position: right spacing("third") top spacing("third");
 }
 
+.form-field--stock {
+    display: none;
+}
+
 .form-field--increments {
 
     .button {

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -65,12 +65,10 @@
                     {{/each}}
                 </div>
 
-                {{#if product.stock_level}}
-                    <div class="form-field form-field--increments">
-                        <label class="form-label form-label--alternate">{{@lang 'products.current_stock'}}</label>
-                        <span>{{product.stock_level}}</span>
-                    </div>
-                {{/if}}
+                <div class="form-field form-field--stock">
+                    <label class="form-label form-label--alternate">{{@lang 'products.current_stock'}}</label>
+                    <span data-product-stock>{{product.stock_level}}</span>
+                </div>
 
                 <div class="form-field form-field--increments">
                     <label class="form-label form-label--alternate">{{@lang 'products.quantity'}}</label>


### PR DESCRIPTION
The stock HTML element needs to be present at all times, but hidden. When the CP setting is on, and after the user selects the product variant, we can populate the HTML element with the proper data.

@christopher-hegre @meenie @mcampa @bc-chris-roper @SiTaggart 
