### PR TITLE
BIG-19948 Fix to toggle menu

### DIFF
--- a/assets/js/theme/global/toggle-menu.js
+++ b/assets/js/theme/global/toggle-menu.js
@@ -14,10 +14,11 @@ export default function () {
 
     function menuClicked(e) {
         e.preventDefault();
+        e.stopPropagation();
 
         closeOtherMenus();
 
-        $targetMenuItem = $(e.target);
+        $targetMenuItem = $(e.currentTarget);
 
         if (!$targetMenuItem.hasClass('is-open')) {
             toggleThisMenu($targetMenuItem);


### PR DESCRIPTION
Guarantee show hide on the right item including child icons.

`stopPropagation` stops the blur event firing when you click on a child icon.
`currentTarget` ensures you select the correct menu to show even iff you click on the icon.

@christopher-hegre @mickr @haubc 
