### PR TITLE
BIG-19851: Add in image switchout for product option rules.

### DIFF
--- a/assets/config.js
+++ b/assets/config.js
@@ -19,7 +19,7 @@ System.config({
     "babel": "npm:babel-core@5.6.15",
     "babel-runtime": "npm:babel-runtime@5.6.15",
     "bigcommerce/citadel": "github:bigcommerce/citadel@2.4.0",
-    "bigcommerce/stencil-utils": "github:bigcommerce/stencil-utils@0.1.7",
+    "bigcommerce/stencil-utils": "github:bigcommerce/stencil-utils@0.2.0",
     "browserstate/history.js": "github:browserstate/history.js@1.8.0",
     "caolan/async": "github:caolan/async@0.9.2",
     "casperin/nod": "github:casperin/nod@2.0.4",
@@ -27,16 +27,16 @@ System.config({
     "foundation": "github:bigcommerce-labs/foundation@5.5.3",
     "jackmoore/zoom": "github:jackmoore/zoom@1.7.14",
     "jquery": "github:components/jquery@2.1.4",
-    "lodash": "npm:lodash@3.9.3",
+    "lodash": "npm:lodash@3.10.0",
     "slick-carousel": "github:kenwheeler/slick@1.5.5",
     "url": "github:jspm/nodelibs-url@0.1.0",
     "github:bigcommerce-labs/foundation@5.5.3": {
       "jquery": "github:components/jquery@2.1.4"
     },
-    "github:bigcommerce/stencil-utils@0.1.7": {
+    "github:bigcommerce/stencil-utils@0.2.0": {
       "asyncly/EventEmitter2": "github:asyncly/EventEmitter2@0.4.14",
       "jquery": "github:components/jquery@2.1.4",
-      "lodash": "npm:lodash@3.9.3"
+      "lodash": "npm:lodash@3.10.0"
     },
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.3.0"
@@ -64,7 +64,7 @@ System.config({
     "npm:inherits@2.0.1": {
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
-    "npm:lodash@3.9.3": {
+    "npm:lodash@3.10.0": {
       "process": "github:jspm/nodelibs-process@0.1.1"
     },
     "npm:punycode@1.3.2": {

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -5,35 +5,37 @@ import $ from 'jquery';
 import utils from 'bigcommerce/stencil-utils';
 import 'foundation/js/foundation/foundation';
 import 'foundation/js/foundation/foundation.reveal';
-import imageGallery from '../product/image-gallery';
+import ImageGallery from '../product/image-gallery';
 
 export default class Product {
-    constructor() {
-
+    constructor($scope, context) {
+        this.$scope = $scope;
+        this.context = context;
         this.productOptions();
         this.quantityChange();
         this.addProductToCart();
-        this.setImageGallery();
+        this.imageGallery = new ImageGallery($('[data-image-gallery]', this.$scope));
+        this.imageGallery.init();
     }
 
     /**
      * Since $productView can be dynamically inserted using render_with,
      * We have to retrieve the respective elements
      *
-     * @param $productView
+     * @param $scope
      */
-    getViewModel($productView) {
+    getViewModel($scope) {
         return {
-            $price: $('.productView-price [data-product-price]', $productView),
-            $increments: $('.form-field--increments :input', $productView),
-            $addToCart: $('#form-action-addToCart', $productView),
+            $price: $('.productView-price [data-product-price]', $scope),
+            $increments: $('.form-field--increments :input', $scope),
+            $addToCart: $('#form-action-addToCart', $scope),
             stock: {
-                $container: $('.form-field--stock', $productView),
-                $input: $('[data-product-stock]', $productView)
+                $container: $('.form-field--stock', $scope),
+                $input: $('[data-product-stock]', $scope)
             },
             quantity: {
-                $text: $('.incrementTotal', $productView),
-                $input: $('[name=qty\\[\\]]', $productView)
+                $text: $('.incrementTotal', $scope),
+                $input: $('[name=qty\\[\\]]', $scope)
             }
         }
     }
@@ -45,21 +47,36 @@ export default class Product {
      */
     productOptions() {
         // product options
-        $('body').on('change', '[data-product-options]', (event) => {
+        this.$scope.on('change', '[data-product-options]', (event) => {
             let $target = $(event.target),     // actual element that is clicked
                 $ele = $(event.currentTarget), // the element that has the data-tag
-                $productView = $target.parents('.productView'), // find the productView in context of what was clicked.
                 targetVal = $target.val(),     // value of the target
                 options = {},
-                productId = $('[name="product_id"]', $productView).val();
+                productId = $('[name="product_id"]', this.$scope).val();
 
             if (targetVal) {
                 options = this.getOptionValues($ele);
 
                 // check inventory when the option has changed
                 utils.api.productAttributes.optionChange(options, productId, (err, response) => {
-                    let viewModel = this.getViewModel($productView);
+                    let viewModel = this.getViewModel(this.$scope);
                     viewModel.$price.html(response.data.price);
+
+                    if (response.data.image) {
+                        let zoomImageUrl = utils.tools.image.getSrc(
+                                response.data.image.data,
+                                this.context.themeImageSizes.zoom
+                            ),
+                            mainImageUrl = utils.tools.image.getSrc(
+                                response.data.image.data,
+                                this.context.themeImageSizes.product
+                            );
+
+                        this.imageGallery.setMainImage({
+                            mainImageUrl: mainImageUrl,
+                            zoomImageUrl: zoomImageUrl
+                        });
+                    }
 
                     // if stock view is on (CP settings)
                     if (viewModel.stock.$container.length && response.data.stock) {
@@ -88,11 +105,10 @@ export default class Product {
      *
      */
     quantityChange() {
-        $('body').on('click', '[data-quantity-change] button', (event) => {
+        this.$scope.on('click', '[data-quantity-change] button', (event) => {
             event.preventDefault();
             let $target = $(event.currentTarget),
-                $productView = $target.parents('.productView'),
-                viewModel = this.getViewModel($productView),
+                viewModel = this.getViewModel(this.$scope),
                 qty = viewModel.quantity.$input.val();
 
             if ($target.data('action') === 'inc') {
@@ -117,16 +133,14 @@ export default class Product {
         utils.hooks.on('cart-item-add', (event) => {
             event.preventDefault();
 
-            let $target = $(event.currentTarget),
-                $productView = $target.parents('.productView'),
-                quantity = $productView.find('[name=qty\\[\\]]').val(),
-                $optionsContainer = $productView.find('[data-product-options]'),
+            let quantity = this.$scope.find('[name=qty\\[\\]]').val(),
+                $optionsContainer = this.$scope.find('[data-product-options]'),
                 options,
                 $modal = $('#modal'),
                 $modalContent = $('.modal-content', $modal),
                 $modalOverlay = $('.loadingOverlay', $modal),
-                productId = $('[name="product_id"]', $productView).val(),
-                $cartCounter = $('.navUser-action .cart-count');
+                $cartCounter = $('.navUser-action .cart-count'),
+                productId = $('[name="product_id"]', this.$scope).val();
 
             options = this.getOptionValues($optionsContainer);
 
@@ -183,20 +197,11 @@ export default class Product {
         // iterate over values
         $optionValues.each((index, ele) => {
             let $ele = $(ele),
-                name = $ele.attr('name'),
-                val = $ele.val();
+                name = $ele.attr('name');
 
-            params[name] = val;
+            params[name] = $ele.val();
         });
 
         return params;
-    }
-
-    setImageGallery() {
-        let $gallery = $('[data-image-gallery]');
-
-        if ($gallery.length) {
-            new imageGallery($gallery);
-        }
     }
 }

--- a/assets/js/theme/global.js
+++ b/assets/js/theme/global.js
@@ -24,7 +24,7 @@ export default class Global extends PageManager {
         quickSearch();
         currencySelector();
         foundation();
-        quickView();
+        quickView(this.context);
         cartPreview();
         carousel();
         toggleMenu();

--- a/assets/js/theme/global/quick-view.js
+++ b/assets/js/theme/global/quick-view.js
@@ -2,18 +2,14 @@ import $ from 'jquery';
 import 'foundation/js/foundation/foundation';
 import 'foundation/js/foundation/foundation.dropdown';
 import 'foundation/js/foundation/foundation.reveal';
-import product from '../common/product';
 import utils from 'bigcommerce/stencil-utils';
-import imageGallery from '../product/image-gallery';
+import ProductDetails from '../common/product-details';
 
-export default function () {
+export default function (context) {
     let $modal = $('#modal'),
         $modalContent = $('.modal-content', $modal),
         $modalOverlay = $('.loadingOverlay', $modal),
         modalModifierClasses = 'modal--large';
-
-    // init shared product functionality
-    new product();
 
     $('body').on('click', '.quickview', (event) => {
         let productId = $(event.currentTarget).data('product-id');
@@ -35,15 +31,11 @@ export default function () {
             $modalOverlay.hide();
             $modalContent.html(response);
             $modalContent.find('.productView').addClass('productView--quickView');
-            setNewImageGallery();
+            new ProductDetails($modalContent, context);
         });
     });
 
-    $modal.on('close.fndtn.reveal', (event) => {
+    $modal.on('close.fndtn.reveal', () => {
         $modal.removeClass(modalModifierClasses);
     });
-
-    function setNewImageGallery() {
-        new imageGallery($modalContent.find('[data-image-gallery]'));
-    };
 }

--- a/assets/js/theme/product.js
+++ b/assets/js/theme/product.js
@@ -1,8 +1,10 @@
 /*
  Import all product specific js
  */
+import $ from 'jquery';
 import PageManager from '../page-manager';
 import collapsible from './common/collapsible';
+import ProductDetails from './common/product-details';
 
 export default class Product extends PageManager {
     constructor() {
@@ -12,6 +14,7 @@ export default class Product extends PageManager {
     loaded(next) {
         // Init collapsible
         collapsible();
+        new ProductDetails($('.productView'), this.context);
 
         next();
     }

--- a/assets/js/theme/product/image-gallery.js
+++ b/assets/js/theme/product/image-gallery.js
@@ -4,24 +4,18 @@ import 'jackmoore/zoom';
 export default class ImageGallery {
 
     constructor($gallery) {
-        this.$gallery = $gallery;
         this.$mainImage = $gallery.find('[data-image-gallery-main]');
         this.$selectableImages = $gallery.find('[data-image-gallery-item]');
         this.currentImage = {};
+    }
+
+    init() {
         this.bindEvents();
         this.setImageZoom();
     }
 
-    selectNewImage(e) {
-        e.preventDefault();
-
-        let $target = $(e.currentTarget);
-
-        this.currentImage = {
-            mainImageUrl: $target.attr('data-image-gallery-new-image-url'),
-            zoomImageUrl: $target.attr('data-image-gallery-zoom-image-url'),
-            $selectedThumb: $target
-        };
+    setMainImage(imgObj) {
+        this.currentImage = imgObj;
 
         this.destroyImageZoom();
         this.setActiveThumb();
@@ -29,9 +23,24 @@ export default class ImageGallery {
         this.setImageZoom();
     }
 
+    selectNewImage(e) {
+        e.preventDefault();
+
+        let $target = $(e.currentTarget),
+            imgObj = {
+                mainImageUrl: $target.attr('data-image-gallery-new-image-url'),
+                zoomImageUrl: $target.attr('data-image-gallery-zoom-image-url'),
+                $selectedThumb: $target
+            };
+
+        this.setMainImage(imgObj);
+    }
+
     setActiveThumb() {
         this.$selectableImages.removeClass('is-active');
-        this.currentImage.$selectedThumb.addClass('is-active');
+        if (this.currentImage.$selectedThumb) {
+            this.currentImage.$selectedThumb.addClass('is-active');
+        }
     }
 
     swapMainImage() {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
       "asyncly/EventEmitter2": "github:asyncly/EventEmitter2@^0.4.14",
       "bigcommerce/citadel": "github:bigcommerce/citadel@^2.4.0",
-      "bigcommerce/stencil-utils": "github:bigcommerce/stencil-utils@^0.1.7",
+      "bigcommerce/stencil-utils": "github:bigcommerce/stencil-utils@0.2.0",
       "browserstate/history.js": "github:browserstate/history.js@^1.8.0",
       "caolan/async": "github:caolan/async@^0.9.2",
       "casperin/nod": "github:casperin/nod@^2.0.4",

--- a/templates/components/products/customizations/checkbox.html
+++ b/templates/components/products/customizations/checkbox.html
@@ -1,4 +1,4 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate" for="customization_{{this.id}}">{{ this.display_name }}</label>
-    <input class="form-checkbox" type="checkbox" id="customization_{{this.id}}" {{#if this.checked}}checked{{/if}}>
+    <label class="form-label form-label--alternate" for="customization_{{this.id}}_{{../id}}">{{ this.display_name }}</label>
+    <input class="form-checkbox" type="checkbox" id="customization_{{this.id}}_{{../id}}" {{#if this.checked}}checked{{/if}}>
 </div>

--- a/templates/components/products/customizations/file.html
+++ b/templates/components/products/customizations/file.html
@@ -1,5 +1,5 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate" for="customization_{{this.id}}">{{ this.display_name }}</label>
-    <input class="form-file" type="file" id="customization_{{this.id}}" name="ProductFields[{{this.id}}]">
+    <label class="form-label form-label--alternate" for="customization_{{this.id}}_{{../id}}">{{ this.display_name }}</label>
+    <input class="form-file" type="file" id="customization_{{this.id}}_{{../id}}" name="ProductFields[{{this.id}}]">
     <p class="form-fileDescription">{{@lang 'products.max_filesize'}} <strong>{{file_size}}</strong>, {{@lang 'products.filetypes'}} <strong>{{file_types}}</strong></p>
 </div>

--- a/templates/components/products/customizations/select.html
+++ b/templates/components/products/customizations/select.html
@@ -1,6 +1,6 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate" for="customization_{{this.id}}">{{ this.display_name }}</label>
-    <select class="form-select" name="ProductFields[{{this.id}}]" id="customization_{{this.id}}">
+    <label class="form-label form-label--alternate" for="customization_{{this.id}}_{{../id}}">{{ this.display_name }}</label>
+    <select class="form-select" name="ProductFields[{{this.id}}]" id="customization_{{this.id}}_{{../id}}">
         <option>{{@lang 'products.choose_an_option'}}</option>
         {{#each this.values}}
         <option value="{{id}}" {{#if selected}}selected{{/if}}>{{label}}</option>

--- a/templates/components/products/customizations/text.html
+++ b/templates/components/products/customizations/text.html
@@ -1,4 +1,4 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate" for="customization_{{this.id}}">{{ this.display_name }}</label>
-    <input class="form-input" type="text" id="customization_{{this.id}}" value="{{this.prefill}}">
+    <label class="form-label form-label--alternate" for="customization_{{this.id}}_{{../id}}">{{ this.display_name }}</label>
+    <input class="form-input" type="text" id="customization_{{this.id}}_{{../id}}" value="{{this.prefill}}">
 </div>

--- a/templates/components/products/customizations/textarea.html
+++ b/templates/components/products/customizations/textarea.html
@@ -1,4 +1,4 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate" for="customization_{{this.id}}">{{this.display_name}}</label>
-    <textarea class="form-input" id="customization_{{this.id}}" name="ProductFields[{{this.id}}]">{{this.prefill}}</textarea>
+    <label class="form-label form-label--alternate" for="customization_{{this.id}}_{{../id}}">{{this.display_name}}</label>
+    <textarea class="form-input" id="customization_{{this.id}}_{{../id}}" name="ProductFields[{{this.id}}]">{{this.prefill}}</textarea>
 </div>

--- a/templates/components/products/options/input-checkbox.html
+++ b/templates/components/products/options/input-checkbox.html
@@ -1,7 +1,7 @@
 <div class="form-field">
     <label class="form-label form-label--alternate">{{display_name}}:</label>
     {{#each this.values}}
-    <input class="form-checkbox" type="checkbox" name="attribute[{{this.id}}]" id="attribute_{{this.id}}" {{#if this.checked}}checked{{/if}}>
-    <label class="form-label {{class}}" for="attribute_{{this.id}}">{{label}}</label>
+    <input class="form-checkbox" type="checkbox" name="attribute[{{this.id}}]" id="attribute_{{this.id}}_{{../id}}" {{#if this.checked}}checked{{/if}}>
+    <label class="form-label {{class}}" for="attribute_{{this.id}}_{{../id}}">{{label}}</label>
     {{/each}}
 </div>

--- a/templates/components/products/options/input-file.html
+++ b/templates/components/products/options/input-file.html
@@ -1,5 +1,5 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate" for="attribute_{{this.id}}">{{ this.display_name }}</label>
-    <input class="form-file" type="file" id="attribute_{{this.id}}" name="attribute[{{this.id}}]">
+    <label class="form-label form-label--alternate" for="attribute_{{this.id}}_{{../id}}">{{ this.display_name }}</label>
+    <input class="form-file" type="file" id="attribute_{{this.id}}_{{../id}}" name="attribute[{{this.id}}]">
     <p class="form-fileDescription">{{@lang 'products.max_filesize'}} <strong>{{file_size}}</strong>, {{@lang 'products.filetypes'}} <strong>{{file_types}}</strong></p>
 </div>

--- a/templates/components/products/options/input-numbers.html
+++ b/templates/components/products/options/input-numbers.html
@@ -1,4 +1,4 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate">{{ this.display_name }}</label>
-    <input class="form-input" type="number" name="attribute[{{this.id}}]" value="{{this.prefill}}">
+    <label class="form-label form-label--alternate" for="attribute_{{this.id}}_{{../id}}">{{ this.display_name }}</label>
+    <input class="form-input" type="number" id="attribute_{{this.id}}_{{../id}}" name="attribute[{{this.id}}]" value="{{this.prefill}}">
 </div>

--- a/templates/components/products/options/input-text.html
+++ b/templates/components/products/options/input-text.html
@@ -1,4 +1,4 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate" for="attribute[{{this.id}}]">{{ this.display_name }}</label>
-    <input class="form-input" type="text" id="attribute[{{this.id}}]" name="attribute[{{this.id}}]" value="{{this.prefill}}">
+    <label class="form-label form-label--alternate" for="attribute_{{this.id}}_{{../id}}">{{ this.display_name }}</label>
+    <input class="form-input" type="text" id="attribute_{{this.id}}_{{../id}}" name="attribute[{{this.id}}]" value="{{this.prefill}}">
 </div>

--- a/templates/components/products/options/set-radio.html
+++ b/templates/components/products/options/set-radio.html
@@ -1,7 +1,7 @@
 <div class="form-field">
     <label class="form-label form-label--alternate">{{ this.display_name }}:</label>
     {{#each this.values}}
-    <input class="form-radio" type="radio" id="attribute[{{id}}]" name="attribute[{{../id}}]" value="{{id}}" {{#if selected}}checked{{/if}}>
-    <label class="form-label" for="attribute[{{id}}]">{{this.label}}</label>
+    <input class="form-radio" type="radio" id="attribute_{{id}}_{{../id}}" name="attribute[{{../id}}]" value="{{id}}" {{#if selected}}checked{{/if}}>
+    <label class="form-label" for="attribute_{{id}}_{{../id}}">{{this.label}}</label>
     {{/each}}
 </div>

--- a/templates/components/products/options/set-rectangle.html
+++ b/templates/components/products/options/set-rectangle.html
@@ -1,8 +1,8 @@
 <div class="form-field">
     <label class="form-label form-label--alternate">{{this.display_name}}: <span data-option-value></span></label>
     {{#each this.values}}
-    <input class="form-radio" type="radio" id="attribute[{{id}}]" name="attribute[{{../id}}]" value="{{id}}" {{#if selected}}checked{{/if}}>
-    <label class="form-option" for="attribute[{{id}}]">
+    <input class="form-radio" type="radio" id="attribute_{{id}}_{{../id}}" name="attribute[{{../id}}]" value="{{id}}" {{#if selected}}checked{{/if}}>
+    <label class="form-option" for="attribute_{{id}}_{{../id}}">
         <div class="form-option-variant">{{this.label}}</div>
     </label>
     {{/each}}

--- a/templates/components/products/options/set-select.html
+++ b/templates/components/products/options/set-select.html
@@ -1,6 +1,6 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate" for="attribute_{{this.id}}">{{ this.display_name }}</label>
-    <select class="form-select" name="attribute[{{this.id}}]" id="attribute_{{this.id}}">
+    <label class="form-label form-label--alternate" for="attribute_{{this.id}}_{{../id}}">{{ this.display_name }}</label>
+    <select class="form-select" name="attribute[{{this.id}}]" id="attribute_{{this.id}}_{{../id}}">
         {{#each this.values}}
         <option value="{{id}}" {{#if selected}}selected{{/if}}>{{label}}</option>
         {{/each}}

--- a/templates/components/products/options/swatch.html
+++ b/templates/components/products/options/swatch.html
@@ -1,8 +1,8 @@
 <div class="form-field">
     <label class="form-label form-label--alternate">{{this.display_name}}: <span data-option-value></span></label>
     {{#each this.values}}
-    <input class="form-input form-radio" type="radio" name="attribute[{{../id}}]" value="{{id}}" id="attribute_{{../id}}_{{this.id}}" {{#if selected}}checked{{/if}}>
-    <label class="form-option" for="attribute_{{../id}}_{{this.id}}">
+    <input class="form-input form-radio" type="radio" name="attribute[{{../id}}]" value="{{id}}" id="attribute_{{this.id}}_{{../id}}" {{#if selected}}checked{{/if}}>
+    <label class="form-option" for="attribute_{{this.id}}_{{../id}}">
     {{#if pattern}}
         <span class='form-option-variant form-option-variant--pattern' title="{{this.label}}" style="background-image: url('{{pattern}}');"></span>
     {{/if}}

--- a/templates/components/products/options/textarea.html
+++ b/templates/components/products/options/textarea.html
@@ -1,4 +1,4 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate" for="attribute_{{this.id}}">{{this.display_name}}</label>
-    <textarea class="form-input" id="attribute_{{this.id}}" name="attribute[{{this.id}}]">{{this.prefill}}</textarea>
+    <label class="form-label form-label--alternate" for="attribute_{{this.id}}_{{../id}}">{{this.display_name}}</label>
+    <textarea class="form-input" id="attribute_{{this.id}}_{{../id}}" name="attribute[{{this.id}}]">{{this.prefill}}</textarea>
 </div>

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -26,7 +26,7 @@
             data-zoom-image="{{@image product.main_image 'zoom'}}"
         >
             <a href="{{@image product.main_image 'zoom'}}">
-                <img src="{{@image product.main_image 'product'}}" alt="{{image.alt}}">
+                <img src="{{@image product.main_image 'product'}}" alt="{{image.alt}}" data-main-image>
             </a>
         </figure>
         <ul class="productView-thumbnails">

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -13,6 +13,7 @@
 
         {{{ head.scripts }}}
         {{{ head.rsslinks }}}
+        {{@inject 'themeImageSizes' theme_images}}
     </head>
     <body>
         {{> components/common/icons/icon-defs }}


### PR DESCRIPTION
This will switch out the current image and image zoom if a selected option combination has a rule to do so.  I've refactored a bit how the `ProductDetails` works in that I'm passing in a `$scope` that it should confine itself to when doing it's selectors.  This works in the quick view, product page, and the quick view when on a product page.

I've also fixed the label/input ID's to be more unique so there are no clashes when opening a quick view while on a product page.

This PR relies on:
https://github.com/bigcommerce/stencil-utils/pull/33
https://github.com/bigcommerce/bigcommerce/pull/9193
