### PR TITLE
BIG-19978: Fix close button not closing alert

### DIFF
--- a/assets/js/theme/global/foundation.js
+++ b/assets/js/theme/global/foundation.js
@@ -3,6 +3,7 @@ import 'foundation/js/foundation/foundation';
 import 'foundation/js/foundation/foundation.dropdown';
 import 'foundation/js/foundation/foundation.reveal';
 import 'foundation/js/foundation/foundation.tab';
+import 'foundation/js/foundation/foundation.alert';
 
 export default function() {
     $(document).foundation({

--- a/templates/components/common/alert-error.html
+++ b/templates/components/common/alert-error.html
@@ -1,4 +1,4 @@
-<div class="alertBox alertBox--error">
+<div data-alert class="alertBox alertBox--error">
     <div class="alertBox-column alertBox-icon">
         <icon glyph="ic-error" class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"></path></svg></icon>
 
@@ -6,7 +6,7 @@
     <p class="alertBox-column alertBox-message">
         <span>{{this}}</span>
     </p>
-    <a class="alertBox-column alertBox-close" tabindex="0" href="#">
+    <a class="alertBox-column alertBox-close close" tabindex="0" href="#">
         <icon glyph="ic-close" class="icon" aria-hidden="true">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path></svg>
         </icon>

--- a/templates/components/common/alert-generic.html
+++ b/templates/components/common/alert-generic.html
@@ -1,4 +1,4 @@
-<div class="alertBox">
+<div data-alert class="alertBox">
     <div class="alertBox-column alertBox-icon">
         <icon glyph="ic-success" class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"></path></svg></icon>
 
@@ -6,7 +6,7 @@
     <p class="alertBox-column alertBox-message">
         <span>{{this}}</span>
     </p>
-    <a class="alertBox-column alertBox-close" tabindex="0" href="#">
+    <a class="alertBox-column alertBox-close close" tabindex="0" href="#">
         <icon glyph="ic-close" class="icon" aria-hidden="true">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path></svg>
         </icon>

--- a/templates/components/common/alert-info.html
+++ b/templates/components/common/alert-info.html
@@ -1,4 +1,4 @@
-<div class="alertBox alertBox--info">
+<div data-alert class="alertBox alertBox--info">
     <div class="alertBox-column alertBox-icon">
         <icon glyph="ic-success" class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"></path></svg></icon>
 
@@ -6,7 +6,7 @@
     <p class="alertBox-column alertBox-message">
         <span>{{this}}</span>
     </p>
-    <a class="alertBox-column alertBox-close" tabindex="0" href="#">
+    <a class="alertBox-column alertBox-close close" tabindex="0" href="#">
         <icon glyph="ic-close" class="icon" aria-hidden="true">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path></svg>
         </icon>

--- a/templates/components/common/alert-success.html
+++ b/templates/components/common/alert-success.html
@@ -1,4 +1,4 @@
-<div class="alertBox alertBox--success">
+<div data-alert class="alertBox alertBox--success">
     <div class="alertBox-column alertBox-icon">
         <icon glyph="ic-success" class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"></path></svg></icon>
 
@@ -6,7 +6,7 @@
     <p class="alertBox-column alertBox-message">
         <span>{{this}}</span>
     </p>
-    <a class="alertBox-column alertBox-close" tabindex="0" href="#">
+    <a class="alertBox-column alertBox-close close" tabindex="0" href="#">
         <icon glyph="ic-close" class="icon" aria-hidden="true">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path></svg>
         </icon>


### PR DESCRIPTION
Add `foundation.alert` so that alerts can be closed. Note: Need to add `close` selector because `foundation.alert` cannot be configured.

@bc-chris-roper @SiTaggart @bc-miko-ademagic 
