### PR TITLE
Clearing the description tabbed content to the right when images are shorter than the options

### DIFF
--- a/assets/scss/layouts/products/_productView.scss
+++ b/assets/scss/layouts/products/_productView.scss
@@ -45,6 +45,7 @@
     padding-right: spacing("base");
 
     @include breakpoint("large") {
+        clear: right;
         float: right;
         width: grid-calc(6, $total-columns);
     }


### PR DESCRIPTION
<img width="1265" alt="screen shot 2015-07-20 at 1 31 41 pm" src="https://cloud.githubusercontent.com/assets/2238295/8769583/b18a29ce-2ee3-11e5-9d10-4ccf7cb77aeb.png">
