### PR TITLE
BIG-19967: Use breadcrumbs supplied by Stapler

### DIFF
--- a/templates/components/common/breadcrumbs.html
+++ b/templates/components/common/breadcrumbs.html
@@ -1,15 +1,10 @@
 <ul class="breadcrumbs">
-    <li class="breadcrumb">
-        <a class="breadcrumb-label" href="{{home}}">{{@lang 'home.heading'}}</a>
-    </li>
     {{#each this}}
         <li class="breadcrumb {{#if @last}}is-active{{/if}}">
             {{#if url}}
                 <a href="{{url}}" class="breadcrumb-label">{{name}}</a>
             {{else}}
-
-                    <span class="breadcrumb-label">{{name}}</span>
-
+                <span class="breadcrumb-label">{{name}}</span>
             {{/if}}
         </li>
     {{/each}}

--- a/templates/pages/blog-post.html
+++ b/templates/pages/blog-post.html
@@ -1,6 +1,6 @@
 {{#partial "page"}}
 
-{{> components/common/breadcrumbs breadcrumbs home=urls.home}}
+{{> components/common/breadcrumbs breadcrumbs}}
 
 {{> components/blog/post blog.post}}
 

--- a/templates/pages/blog.html
+++ b/templates/pages/blog.html
@@ -1,6 +1,6 @@
 {{#partial "page"}}
 
-{{> components/common/breadcrumbs breadcrumbs home=urls.home}}
+{{> components/common/breadcrumbs breadcrumbs}}
 
 <main class="page">
     <h1 class="page-heading">{{ blog.name }}</h1>

--- a/templates/pages/brand.html
+++ b/templates/pages/brand.html
@@ -4,7 +4,7 @@ shop_by_price: true
 shop_by_brand: true
 ---
 {{#partial "page"}}
-{{> components/common/breadcrumbs breadcrumbs home=urls.home}}
+{{> components/common/breadcrumbs breadcrumbs}}
 
 <div class="page">
     <aside class="page-sidebar" id="faceted-search-container">

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -5,7 +5,7 @@ category:
 
 {{#partial "page"}}
 
-{{> components/common/breadcrumbs breadcrumbs home=urls.home}}
+{{> components/common/breadcrumbs breadcrumbs}}
 
 <h1 class="page-heading">{{category.name}}</h1>
 

--- a/templates/pages/compare.html
+++ b/templates/pages/compare.html
@@ -1,6 +1,6 @@
 {{#partial "page"}}
 
-{{> components/common/breadcrumbs breadcrumbs home=urls.home}}
+{{> components/common/breadcrumbs breadcrumbs}}
 <h1 class="page-heading">{{@lang 'compare.header' products=comparisons.length}}</h1>
 
 <div class="page">

--- a/templates/pages/page.html
+++ b/templates/pages/page.html
@@ -1,6 +1,6 @@
 {{#partial "page"}}
 
-{{> components/common/breadcrumbs breadcrumbs home=urls.home}}
+{{> components/common/breadcrumbs breadcrumbs}}
 
 <main class="page">
 

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -10,9 +10,7 @@ product:
         limit: 10
 ---
 {{#partial "page"}}
-    {{#each breadcrumbs }}
-        {{> components/common/breadcrumbs this home=../urls.home}}
-    {{/each}}
+    {{> components/common/breadcrumbs breadcrumbs}}
 
     <div itemscope itemtype="http://schema.org/Product">
         {{> components/products/product-view}}


### PR DESCRIPTION
Currently, we render breadcrumbs like this `{{> components/common/breadcrumbs breadcrumbs home=urls.home}}`.

Handlebars actually turns the `breadcrumbs` array into a hash: For example: `{"0":{"name":"Blog"},"home":"/"}`. So we can either be explicit: `{{> components/common/breadcrumbs breadcrumbs=breadcrumbs home=urls.home}}` Or we can include `Home` in the `breadcrumbs` variable. I chose the latter so there's less logic in the template; and the variable can represent the full breadcrumbs.

@mickr can you have a look. This PR reverted some of your changes in https://github.com/bigcommerce/stencil/commit/f98cc2f76b7bcd7fd707902be89a873fab84b994

Ping @christopher-hegre @haubc 

This PR requires https://github.com/bigcommerce/stapler/pull/123
