### PR TITLE
BIG-20056: Only show sidebars if products.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -20,6 +20,12 @@
         "maintenance_title": "Down for Maintenance",
         "maintenance_message": "This store is currently unavailable due to maintenance. It should be available again shortly. We apologize for any inconvenience caused."
     },
+    "brands": {
+        "no_products": "There are no products listed under this brand."
+    },
+    "categories": {
+        "no_products": "There are no products listed under this category."
+    },
     "cart": {
         "items": "{NUM, plural, =0{(0 items)} one {(# item)} other {(# items)}}",
         "checkout": {

--- a/templates/components/brand/sidebar.html
+++ b/templates/components/brand/sidebar.html
@@ -1,6 +1,8 @@
 <nav>
     {{#if brand.faceted_search_enabled}}
-        {{> components/faceted-search/index brand}}
+        {{#if brand.products}}
+            {{> components/faceted-search/index brand}}
+        {{/if}}
     {{else}}
         {{#if shop_by_brand.links}}
         <div class="sidebarBlock">

--- a/templates/components/category/sidebar.html
+++ b/templates/components/category/sidebar.html
@@ -12,9 +12,11 @@
     </div>
     {{/if}}
 
-    {{#if category.faceted_search_enabled}}
-        {{> components/faceted-search/index category}}
-    {{else}}
-        {{> components/category/shop-by-price category.shop_by_price}}
+    {{#if category.products}}
+        {{#if category.faceted_search_enabled}}
+            {{> components/faceted-search/index category}}
+        {{else}}
+            {{> components/category/shop-by-price category.shop_by_price}}
+        {{/if}}
     {{/if}}
 </nav>

--- a/templates/pages/brand.html
+++ b/templates/pages/brand.html
@@ -12,7 +12,11 @@ shop_by_brand: true
     </aside>
 
     <main class="page-content" id="product-listing-container">
-        {{> components/brand/product-listing}}
+        {{#if brand.products}}
+            {{> components/brand/product-listing}}
+        {{else}}
+            <p>{{@lang 'brands.no_products'}}</p>
+        {{/if}}
     </main>
 </div>
 

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -15,7 +15,11 @@ category:
     </aside>
 
     <main class="page-content" id="product-listing-container">
-        {{> components/category/product-listing}}
+        {{#if category.products}}
+            {{> components/category/product-listing}}
+        {{else}}
+            <p>{{@lang 'categories.no_products'}}</p>
+        {{/if}}
     </main>
 </div>
 


### PR DESCRIPTION
I've also added some messaging around there not being any products in the listed category/brand.

I've checked the functionality against an existing theme with/without faceted search and it matches.  The only thing that is different is on Blueprint with an empty category, they don't show any messaging around the fact that there are no products; I've added that into Stencil.
