### PR TITLE
Quick fix to the related and similar product carousels on the product page

### DIFF
--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -32,10 +32,10 @@ product:
 
         <div class="tabs-contents">
             <div role="tabpanel" aria-hidden="false" class="tab-content is-active" id="tab-related">
-                {{> components/products/carousel product.related_products}}
+                {{> components/products/carousel product.related_products columns=6}}
             </div>
             <div role="tabpanel" aria-hidden="true" class="tab-content" id="tab-similar">
-                {{> components/products/carousel product.similar_by_views}}
+                {{> components/products/carousel product.similar_by_views columns=6}}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Since you can change the number of products in the carousel with a theme variant, the product pages we missing the columns setting which was added to enable the changes.

@bc-miko-ademagic @christopher-hegre @davidchin 
