### PR TITLE
BIG-19954 Fix bug where carousel buttons are in focus, and the background disappears

### DIFF
--- a/assets/scss/components/vendor/slick/_slick.scss
+++ b/assets/scss/components/vendor/slick/_slick.scss
@@ -30,7 +30,8 @@
         width: remCalc(20px);
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
         @include carouselOpaqueBackgrounds($slick-arrow-bgColor); // 1
         background-position: 50%;
         background-repeat: no-repeat;


### PR DESCRIPTION
Slick carousel by default hides the background of a next or previous button when it is hovered or focused, no idea why.

I caught the hover but completely forgot the focus styles.

@bc-miko-ademagic @christopher-hegre @haubc 
