### PR TITLE
BIG-20371: Indicate required fields on product page

### DIFF
--- a/templates/components/products/options/date.html
+++ b/templates/components/products/options/date.html
@@ -1,18 +1,24 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate" {{#if style}}style="{{style}}" {{/if}}>{{this.display_name}}</label>
-    <select class="form-select form-select--date" name="attribute[{{this.id}}][month]">
+    <label class="form-label form-label--alternate" {{#if style}}style="{{style}}" {{/if}}>
+        {{this.display_name}}
+
+        {{#if required}}
+            <small>{{@lang 'common.required'}}</small>
+        {{/if}}
+    </label>
+    <select class="form-select form-select--date" name="attribute[{{this.id}}][month]" {{#if required}}required{{/if}}>
         <option></option>
         {{#enumerate 1 12}}
         <option value="{{ this }}" {{#equals ../selected_date.month this}}selected="selected"{{/equals}}>{{@getShortMonth this }}</option>
         {{/enumerate}}
     </select>
-    <select class="form-select form-select--date" name="attribute[{{this.id}}][day]">
+    <select class="form-select form-select--date" name="attribute[{{this.id}}][day]" {{#if required}}required{{/if}}>
         <option></option>
         {{#enumerate 1 31}}
         <option value="{{ this }}" {{#equals ../selected_date.day this}}selected="selected"{{/equals}}>{{ this }}</option>
         {{/enumerate}}
     </select>
-    <select class="form-select form-select--date" name="attribute[{{this.id}}][year]">
+    <select class="form-select form-select--date" name="attribute[{{this.id}}][year]" {{#if required}}required{{/if}}>
         <option></option>
         {{#enumerate earliest_year latest_year}}
         <option value="{{ this }}" {{#equals ../selected_date.year this}}selected="selected"{{/equals}}>{{ this }}</option>

--- a/templates/components/products/options/input-checkbox.html
+++ b/templates/components/products/options/input-checkbox.html
@@ -1,7 +1,14 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate">{{display_name}}:</label>
+    <label class="form-label form-label--alternate">
+        {{display_name}}:
+
+        {{#if required}}
+            <small>{{@lang 'common.required'}}</small>
+        {{/if}}
+    </label>
+
     {{#each this.values}}
-    <input class="form-checkbox" type="checkbox" name="attribute[{{this.id}}]" id="attribute_{{this.id}}_{{../id}}" {{#if this.checked}}checked{{/if}}>
+    <input class="form-checkbox" type="checkbox" name="attribute[{{this.id}}]" id="attribute_{{this.id}}_{{../id}}" {{#if this.checked}}checked{{/if}} {{#if ../required}}required{{/if}}>
     <label class="form-label {{class}}" for="attribute_{{this.id}}_{{../id}}">{{label}}</label>
     {{/each}}
 </div>

--- a/templates/components/products/options/input-file.html
+++ b/templates/components/products/options/input-file.html
@@ -1,5 +1,12 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate" for="attribute_{{this.id}}_{{../id}}">{{ this.display_name }}</label>
-    <input class="form-file" type="file" id="attribute_{{this.id}}_{{../id}}" name="attribute[{{this.id}}]">
+    <label class="form-label form-label--alternate" for="attribute_{{this.id}}_{{../id}}">
+        {{ this.display_name }}
+
+        {{#if required}}
+            <small>{{@lang 'common.required'}}</small>
+        {{/if}}
+    </label>
+
+    <input class="form-file" type="file" id="attribute_{{this.id}}_{{../id}}" name="attribute[{{this.id}}]" {{#if required}}required{{/if}}>
     <p class="form-fileDescription">{{@lang 'products.max_filesize'}} <strong>{{file_size}}</strong>, {{@lang 'products.filetypes'}} <strong>{{file_types}}</strong></p>
 </div>

--- a/templates/components/products/options/input-numbers.html
+++ b/templates/components/products/options/input-numbers.html
@@ -1,4 +1,11 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate" for="attribute_{{this.id}}_{{../id}}">{{ this.display_name }}</label>
-    <input class="form-input" type="number" id="attribute_{{this.id}}_{{../id}}" name="attribute[{{this.id}}]" value="{{this.prefill}}">
+    <label class="form-label form-label--alternate" for="attribute_{{this.id}}_{{../id}}">
+        {{ this.display_name }}
+
+        {{#if required}}
+            <small>{{@lang 'common.required'}}</small>
+        {{/if}}
+    </label>
+
+    <input class="form-input" type="number" id="attribute_{{this.id}}_{{../id}}" name="attribute[{{this.id}}]" value="{{this.prefill}}" {{#if required}}required{{/if}}>
 </div>

--- a/templates/components/products/options/input-text.html
+++ b/templates/components/products/options/input-text.html
@@ -1,4 +1,11 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate" for="attribute_{{this.id}}_{{../id}}">{{ this.display_name }}</label>
-    <input class="form-input" type="text" id="attribute_{{this.id}}_{{../id}}" name="attribute[{{this.id}}]" value="{{this.prefill}}">
+    <label class="form-label form-label--alternate" for="attribute_{{this.id}}_{{../id}}">
+        {{ this.display_name }}
+
+        {{#if required}}
+            <small>{{@lang 'common.required'}}</small>
+        {{/if}}
+    </label>
+
+    <input class="form-input" type="text" id="attribute_{{this.id}}_{{../id}}" name="attribute[{{this.id}}]" value="{{this.prefill}}" {{#if required}}required{{/if}}>
 </div>

--- a/templates/components/products/options/set-radio.html
+++ b/templates/components/products/options/set-radio.html
@@ -1,7 +1,14 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate">{{ this.display_name }}:</label>
+    <label class="form-label form-label--alternate">
+        {{ this.display_name }}:
+
+        {{#if required}}
+            <small>{{@lang 'common.required'}}</small>
+        {{/if}}
+    </label>
+
     {{#each this.values}}
-    <input class="form-radio" type="radio" id="attribute_{{id}}_{{../id}}" name="attribute[{{../id}}]" value="{{id}}" {{#if selected}}checked{{/if}}>
+    <input class="form-radio" type="radio" id="attribute_{{id}}_{{../id}}" name="attribute[{{../id}}]" value="{{id}}" {{#if selected}}checked{{/if}} {{#if ../required}}required{{/if}}>
     <label class="form-label" for="attribute_{{id}}_{{../id}}">{{this.label}}</label>
     {{/each}}
 </div>

--- a/templates/components/products/options/set-rectangle.html
+++ b/templates/components/products/options/set-rectangle.html
@@ -1,7 +1,15 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate">{{this.display_name}}: <span data-option-value></span></label>
+    <label class="form-label form-label--alternate">
+        {{this.display_name}}:
+        <span data-option-value></span>
+
+        {{#if required}}
+            <small>{{@lang 'common.required'}}</small>
+        {{/if}}
+    </label>
+
     {{#each this.values}}
-    <input class="form-radio" type="radio" id="attribute_{{id}}_{{../id}}" name="attribute[{{../id}}]" value="{{id}}" {{#if selected}}checked{{/if}}>
+    <input class="form-radio" type="radio" id="attribute_{{id}}_{{../id}}" name="attribute[{{../id}}]" value="{{id}}" {{#if selected}}checked{{/if}} {{#if ../required}}required{{/if}}>
     <label class="form-option" for="attribute_{{id}}_{{../id}}">
         <div class="form-option-variant">{{this.label}}</div>
     </label>

--- a/templates/components/products/options/set-select.html
+++ b/templates/components/products/options/set-select.html
@@ -1,6 +1,13 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate" for="attribute_{{this.id}}_{{../id}}">{{ this.display_name }}</label>
-    <select class="form-select" name="attribute[{{this.id}}]" id="attribute_{{this.id}}_{{../id}}">
+    <label class="form-label form-label--alternate" for="attribute_{{this.id}}_{{../id}}">
+        {{ this.display_name }}
+
+        {{#if required}}
+            <small>{{@lang 'common.required'}}</small>
+        {{/if}}
+    </label>
+
+    <select class="form-select" name="attribute[{{this.id}}]" id="attribute_{{this.id}}_{{../id}}" {{#if required}}required{{/if}}>
         {{#each this.values}}
         <option value="{{id}}" {{#if selected}}selected{{/if}}>{{label}}</option>
         {{/each}}

--- a/templates/components/products/options/swatch.html
+++ b/templates/components/products/options/swatch.html
@@ -1,7 +1,15 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate">{{this.display_name}}: <span data-option-value></span></label>
+    <label class="form-label form-label--alternate">
+        {{this.display_name}}:
+        <span data-option-value></span>
+
+        {{#if required}}
+            <small>{{@lang 'common.required'}}</small>
+        {{/if}}
+    </label>
+
     {{#each this.values}}
-    <input class="form-input form-radio" type="radio" name="attribute[{{../id}}]" value="{{id}}" id="attribute_{{this.id}}_{{../id}}" {{#if selected}}checked{{/if}}>
+    <input class="form-input form-radio" type="radio" name="attribute[{{../id}}]" value="{{id}}" id="attribute_{{this.id}}_{{../id}}" {{#if selected}}checked{{/if}} {{#if ../required}}required{{/if}}>
     <label class="form-option" for="attribute_{{this.id}}_{{../id}}">
     {{#if pattern}}
         <span class='form-option-variant form-option-variant--pattern' title="{{this.label}}" style="background-image: url('{{pattern}}');"></span>

--- a/templates/components/products/options/textarea.html
+++ b/templates/components/products/options/textarea.html
@@ -1,4 +1,13 @@
 <div class="form-field">
-    <label class="form-label form-label--alternate" for="attribute_{{this.id}}_{{../id}}">{{this.display_name}}</label>
-    <textarea class="form-input" id="attribute_{{this.id}}_{{../id}}" name="attribute[{{this.id}}]">{{this.prefill}}</textarea>
+    <label class="form-label form-label--alternate" for="attribute_{{this.id}}_{{../id}}">
+        {{this.display_name}}
+
+        {{#if required}}
+            <small>{{@lang 'common.required'}}</small>
+        {{/if}}
+    </label>
+
+    <textarea class="form-input" id="attribute_{{this.id}}_{{../id}}" name="attribute[{{this.id}}]" {{#if required}}required{{/if}}>
+        {{this.prefill}}
+    </textarea>
 </div>


### PR DESCRIPTION
Indicate required fields on product page / quick view.

NOTE: There's no design for it. Just using the default styling for required fields.

![screen shot 2015-07-27 at 1 36 56 pm](https://cloud.githubusercontent.com/assets/667603/8898246/94f8aea8-3464-11e5-9d9d-060719e71090.png)

@SiTaggart @haubc @bc-chris-roper @christopher-hegre 
