### PR TITLE
Bump Nod to 2.0.10

### DIFF
--- a/assets/config.js
+++ b/assets/config.js
@@ -22,7 +22,7 @@ System.config({
     "bigcommerce/stencil-utils": "github:bigcommerce/stencil-utils@0.2.0",
     "browserstate/history.js": "github:browserstate/history.js@1.8.0",
     "caolan/async": "github:caolan/async@0.9.2",
-    "casperin/nod": "github:casperin/nod@2.0.4",
+    "casperin/nod": "github:casperin/nod@2.0.10",
     "core-js": "npm:core-js@0.9.18",
     "foundation": "github:bigcommerce-labs/foundation@5.5.3",
     "hubspot/pace": "github:hubspot/pace@1.0.2",

--- a/assets/js/theme/gift-certificate.js
+++ b/assets/js/theme/gift-certificate.js
@@ -1,5 +1,5 @@
 import PageManager from '../page-manager';
-import nod from 'github:casperin/nod@2.0.4/nod';
+import nod from 'casperin/nod';
 export default class GiftCertificate extends PageManager {
     constructor() {
         super();

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "bigcommerce/stencil-utils": "github:bigcommerce/stencil-utils@0.2.0",
       "browserstate/history.js": "github:browserstate/history.js@^1.8.0",
       "caolan/async": "github:caolan/async@^0.9.2",
-      "casperin/nod": "github:casperin/nod@^2.0.4",
+      "casperin/nod": "github:casperin/nod@^2.0.10",
       "foundation": "github:bigcommerce-labs/foundation@^5.5.3",
       "hubspot/pace": "github:hubspot/pace@^1.0.2",
       "jackmoore/zoom": "github:jackmoore/zoom@^1.7.14",


### PR DESCRIPTION
Bump Nod to 2.0.10
- Removed hardcoding in gift-certs
- Changed config.js and package.json to use 2.0.10 version on Nod
