### PR TITLE
Create generic toggle content component, for Videos, Reviews and Faceted Search

### DIFF
--- a/assets/js/theme/common/faceted-search.js
+++ b/assets/js/theme/common/faceted-search.js
@@ -102,7 +102,7 @@ export default class FacetedSearch {
         $navItems.show();
 
         // Set toggle state
-        $toggle.addClass('is-on');
+        $toggle.addClass('is-open');
 
         // Remove
         this.collapsedFacetItems = _.without(this.collapsedFacetItems, id);
@@ -118,7 +118,7 @@ export default class FacetedSearch {
         $navItems.show();
 
         // Set toggle state
-        $toggle.removeClass('is-on');
+        $toggle.removeClass('is-open');
 
         // Show only limited number of items, hide the rest
         if (itemsCount > maxItemsCount) {

--- a/assets/scss/components/stencil/productReviews/_productReviews.scss
+++ b/assets/scss/components/stencil/productReviews/_productReviews.scss
@@ -3,25 +3,6 @@
 // =============================================================================
 
 
-.productReviews {
-    border-top: 1px solid color("greys", "lightest");
-}
-
-.productReviews-heading {
-    margin-bottom: spacing("single") + spacing("eighth");
-}
-
-.productReviews-displayToggle {
-    color: color("greys", "light");
-    float: right;
-    margin-top: spacing("single") + spacing("base");
-
-    &:hover {
-        color: color("greys", "darker");
-    }
-}
-
-
 // Review list
 //
 // 1. Kill extra display inline-block spacing
@@ -30,13 +11,8 @@
 .productReviews-list {
     @include u-listBullets("none");
     @include grid-row($behavior: "nest");
-    display: none;
     font-size: 0; // 1
     margin-bottom: spacing("single");
-
-    &.is-open {
-        display: block;
-    }
 }
 
 

--- a/assets/scss/components/stencil/toggleLink/_toggleLink.scss
+++ b/assets/scss/components/stencil/toggleLink/_toggleLink.scss
@@ -5,27 +5,60 @@
 
 // Toggle link
 // -----------------------------------------------------------------------------
-//
-// 1. Override style in case it is nested
-//
-// -----------------------------------------------------------------------------
-.toggleLink {
-    &.is-open,
-    &.is-on {
-        .toggleLink-text--off {
-            display: none;
-        }
 
-        .toggleLink-text--on {
-            display: inline-block;
-        }
+$toggle-spacing: spacing("single") + spacing("half");
+
+.toggle {
+    border-top: container("border");
+    margin-bottom: $toggle-spacing;
+
+    &:last-of-type {
+        margin-bottom: $toggle-spacing * 2;
+    }
+}
+
+.toggle-title {
+    margin: $toggle-spacing 0 0;
+}
+
+.toggleLink {
+    .toggle-title & {
+        float: right;
+        line-height: 24px;
+    }
+}
+
+.toggleLink-text {
+    color: color("greys", "light");
+    font-size: fontSize("smallest");
+    font-weight: fontWeight("normal");
+
+    &:hover {
+        color: color("greys", "darker");
     }
 }
 
 .toggleLink-text--off {
     display: inline-block;
+
+    .toggleLink.is-open & {
+        display: none;
+    }
 }
 
 .toggleLink-text--on {
     display: none;
+
+    .toggleLink.is-open & {
+        display: inline-block;
+    }
+}
+
+.toggle-content {
+    display: none;
+    padding: $toggle-spacing 0;
+
+    &.is-open {
+        display: block;
+    }
 }

--- a/assets/scss/components/stencil/videoGallery/_videoGallery.scss
+++ b/assets/scss/components/stencil/videoGallery/_videoGallery.scss
@@ -2,11 +2,6 @@
 // VIDEO GALLERY
 // =============================================================================
 
-.videoGallery {
-    border-top: container("border");
-    margin-bottom: spacing("double");
-}
-
 .videoGallery-main {
     @include flex-video-container();
     margin-bottom: $videoGallery-spacing;
@@ -50,10 +45,6 @@
 
 .video-figure {
     margin-right: $videoGallery-spacing
-}
-
-.video-body {
-
 }
 
 .video-title {

--- a/lang/en.json
+++ b/lang/en.json
@@ -419,6 +419,11 @@
                 "submit_value": "Submit Review"
             }
         },
+        "videos": {
+            "header": "Videos",
+            "hide": "Hide Videos",
+            "show": "Show Videos"
+        },
         "add_to_cart": "Add to Cart",
         "options": "Options",
         "sku": "SKU",

--- a/templates/components/products/reviews.html
+++ b/templates/components/products/reviews.html
@@ -1,7 +1,8 @@
-
-<div class="productReviews" id="product-reviews" data-product-reviews>
-    {{#if reviews.total}}
-            <a href="#productReviews-list" class="productReviews-displayToggle toggleLink is-open" data-collapsible>
+{{#if reviews.total}}
+<section class="toggle productReviews" id="product-reviews" data-product-reviews>
+    <h4 class="toggle-title">
+        {{@lang 'products.reviews.header' total=reviews.total}}
+        <a class="toggleLink" data-collapsible href="#productReviews-list">
             <span class="toggleLink-text toggleLink-text--on">
                 {{@lang 'products.reviews.hide'}}
             </span>
@@ -9,34 +10,34 @@
                 {{@lang 'products.reviews.show'}}
             </span>
         </a>
+    </h4>
 
-        <h4 class="productReviews-heading">{{@lang 'products.reviews.header' total=reviews.total}}</h4>
-        <ul id="productReviews-list" class="productReviews-list is-open">
-            {{#each reviews.list}}
-            <li class="productReview">
-                <article itemprop="review" itemscope itemtype="http://schema.org/Review">
-                    <header>
-                        <span class="productReview-rating" itemprop="reviewRating" itemscope itemtype="http://schema.org/Rating">
-                            {{> components/products/ratings rating=rating}}
-                            <span class="productReview-ratingNumber" itemprop="ratingValue">{{ rating }}</span>
-                        </span>
-                        <h5 itemprop="name" class="productReview-title">{{ title }}</h5>
-                        {{#if name}}
-                            <meta itemprop="author" content="{{name}}">
-                            <p class="productReview-author">
-                                {{@lang 'products.reviews.post_on_by' date=date name=name }}
-                            </p>
-                        {{else}}
-                            <p class="productReview-author">
-                                {{@lang 'products.reviews.post_on_by' date=date name=(@lang 'products.reviews.anonymous_poster')}}
-                            </p>
-                        {{/if}}
-                    </header>
-                    <p itemprop="reviewBody" class="productReview-body">{{nl2br text}}</p>
-                </article>
-            </li>
-            {{/each}}
-        </ul>
-        {{> components/common/paginator pagination.reviews}}
-    {{/if}}
-</div>
+    <ul class="toggle-content productReviews-list" id="productReviews-list">
+        {{#each reviews.list}}
+        <li class="productReview">
+            <article itemprop="review" itemscope itemtype="http://schema.org/Review">
+                <header>
+                    <span class="productReview-rating" itemprop="reviewRating" itemscope itemtype="http://schema.org/Rating">
+                        {{> components/products/ratings rating=rating}}
+                        <span class="productReview-ratingNumber" itemprop="ratingValue">{{ rating }}</span>
+                    </span>
+                    <h5 itemprop="name" class="productReview-title">{{ title }}</h5>
+                    {{#if name}}
+                        <meta itemprop="author" content="{{name}}">
+                        <p class="productReview-author">
+                            {{@lang 'products.reviews.post_on_by' date=date name=name }}
+                        </p>
+                    {{else}}
+                        <p class="productReview-author">
+                            {{@lang 'products.reviews.post_on_by' date=date name=(@lang 'products.reviews.anonymous_poster')}}
+                        </p>
+                    {{/if}}
+                </header>
+                <p itemprop="reviewBody" class="productReview-body">{{nl2br text}}</p>
+            </article>
+        </li>
+        {{/each}}
+    </ul>
+    {{> components/common/paginator pagination.reviews}}
+</section>
+{{/if}}

--- a/templates/components/products/tabs.html
+++ b/templates/components/products/tabs.html
@@ -1,0 +1,26 @@
+<ul class="tabs" data-tab role="tablist">
+    {{#if product.related_products}}
+        <li class="tab is-active" role="presentational">
+            <a class="tab-title" href="#tab-related" role="tab" tabindex="0" aria-selected="true" controls="tab-related">{{@lang 'products.related_products'}}</a>
+        </li>
+    {{/if}}
+    {{#if product.similar_by_views}}
+        <li class="tab" role="presentational">
+            <a class="tab-title" href="#tab-similar" role="tab" tabindex="0" aria-selected="false" controls="tab-similar">{{@lang 'products.similar_by_views'}}</a>
+        </li>
+    {{/if}}
+</ul>
+
+<div class="tabs-contents">
+{{#if product.related_products}}
+    <div role="tabpanel" aria-hidden="false" class="tab-content is-active" id="tab-related">
+        {{> components/products/carousel products=product.related_products columns=6}}
+    </div>
+{{/if}}
+
+{{#if product.similar_by_views}}
+    <div role="tabpanel" aria-hidden="true" class="tab-content" id="tab-similar">
+        {{> components/products/carousel products=product.similar_by_views columns=6}}
+    </div>
+{{/if}}
+</div>

--- a/templates/components/products/videos.html
+++ b/templates/components/products/videos.html
@@ -1,32 +1,46 @@
-<section class="videoGallery" data-video-gallery>
-    <h4>Videos</h4>
-    <div class="videoGallery-main">
-        <iframe
-            id="player"
-            type="text/html"
-            width="640"
-            height="390"
-            frameborder="0"
-            webkitAllowFullScreen
-            mozallowfullscreen
-            allowFullScreen
-            src="http://www.youtube.com/embed/{{this.featured.id}}"
-            data-video-player>
-        </iframe>
+<section class="toggle videoGallery" data-video-gallery>
+    <h4 class="toggle-title">
+        {{@lang 'products.videos.header'}}
+        <a href="#videoGallery-content" class="toggleLink" data-collapsible>
+            <span class="toggleLink-text toggleLink-text--on">
+                {{@lang 'products.videos.hide'}}
+            </span>
+            <span class="toggleLink-text toggleLink-text--off">
+                {{@lang 'products.videos.show'}}
+            </span>
+        </a>
+    </h4>
+
+    <div class="toggle-content" id="videoGallery-content">
+        <div class="videoGallery-main">
+            <iframe
+                id="player"
+                type="text/html"
+                width="640"
+                height="390"
+                frameborder="0"
+                webkitAllowFullScreen
+                mozallowfullscreen
+                allowFullScreen
+                src="http://www.youtube.com/embed/{{this.featured.id}}"
+                data-video-player>
+            </iframe>
+        </div>
+        <ul class="videoGallery-list">
+        {{#each this.list}}
+            <li class="videoGallery-item">
+                <a href="#" class="video {{#if @first}}is-active{{/if}}" data-video-item data-video-id="{{id}}">
+                    <div class="video-figure">
+                        <img src="//i.ytimg.com/vi/{{id}}/default.jpg"/>
+                    </div>
+                    <div class="video-body">
+                        <h5 class="video-title">{{title_long}}</h5>
+                        <p class="video-description">{{description_short}}</p>
+                    </div>
+                </a>
+            </li>
+        {{/each}}
+        </ul>
     </div>
-    <ul class="videoGallery-list">
-    {{#each this.list}}
-        <li class="videoGallery-item">
-            <a href="#" class="video {{#if @first}}is-active{{/if}}" data-video-item data-video-id="{{id}}">
-                <div class="video-figure">
-                    <img src="//i.ytimg.com/vi/{{id}}/default.jpg"/>
-                </div>
-                <div class="video-body">
-                    <h5 class="video-title">{{title_long}}</h5>
-                    <p class="video-description">{{description_short}}</p>
-                </div>
-            </a>
-        </li>
-    {{/each}}
-    </ul>
+
 </section>

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -18,39 +18,15 @@ product:
         {{> components/products/product-view}}
 
         {{#if product.videos.list.length}}
-        {{> components/products/videos product.videos}}
+            {{> components/products/videos product.videos}}
         {{/if}}
 
         {{#if settings.show_product_rating}}
             {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
         {{/if}}
 
-        <ul class="tabs" data-tab role="tablist">
-            {{#if product.related_products}}
-                <li class="tab is-active" role="presentational">
-                    <a class="tab-title" href="#tab-related" role="tab" tabindex="0" aria-selected="true" controls="tab-related">{{@lang 'products.related_products'}}</a>
-                </li>
-            {{/if}}
-            {{#if product.similar_by_views}}
-                <li class="tab" role="presentational">
-                    <a class="tab-title" href="#tab-similar" role="tab" tabindex="0" aria-selected="false" controls="tab-similar">{{@lang 'products.similar_by_views'}}</a>
-                </li>
-            {{/if}}
-        </ul>
+        {{> components/products/tabs}}
 
-        <div class="tabs-contents">
-        {{#if product.related_products}}
-            <div role="tabpanel" aria-hidden="false" class="tab-content is-active" id="tab-related">
-                {{> components/products/carousel products=product.related_products columns=6}}
-            </div>
-        {{/if}}
-
-        {{#if product.similar_by_views}}
-            <div role="tabpanel" aria-hidden="true" class="tab-content" id="tab-similar">
-                {{> components/products/carousel products=product.similar_by_views columns=6}}
-            </div>
-        {{/if}}
-        </div>
     </div>
 
 {{/partial}}


### PR DESCRIPTION
Videos needed to be collapsable, Reviews already are but weren't really using a generic kind of way.

Thought about using `accordion` but that has some very specific styling for mobile Faceted Search and I was terrified of touching that.

I just extended `toggleLink` to have the ability to have a title and content block. This can then be used for both. 

Subsequently removed a bunch of stuff from reviews and videos which the new `toggle` component does.

I also consolidated the `toggleLink.is-on` feature, it was only used in FS and we already style `.is-open` everywhere else. Seems weird to have `.is-on`

@bc-miko-ademagic @bc-chris-roper @davidchin 
