### PR TITLE
BIG-20511 Tab state that allows for tab-content to not collapse when hidden

### DIFF
--- a/assets/scss/components/foundation/tabs/_tabs.scss
+++ b/assets/scss/components/foundation/tabs/_tabs.scss
@@ -45,3 +45,27 @@
         padding: spacing("half") spacing("single");
     }
 }
+
+
+//
+// State for when tab-content has js generated of calculated content, like carousel
+//
+// Purpose: The content being display: none, means any js calculated dimensions
+// are incorrect as the elements inside the tab-content have no dimensions to grab.
+// Carousel is a prime example. It needs widths to calculate the layout and slides
+// -----------------------------------------------------------------------------
+
+.tab-content.has-jsContent {
+    display: block;
+    height: 0;
+    overflow: hidden;
+    padding: 0;
+    visibility: hidden;
+
+    &.is-active {
+        height: auto;
+        overflow: visible;
+        padding: $tabs-content-padding;
+        visibility: visible;
+    }
+}

--- a/templates/components/products/tabs.html
+++ b/templates/components/products/tabs.html
@@ -13,13 +13,13 @@
 
 <div class="tabs-contents">
 {{#if product.related_products}}
-    <div role="tabpanel" aria-hidden="false" class="tab-content is-active" id="tab-related">
+    <div role="tabpanel" aria-hidden="false" class="tab-content has-jsContent is-active" id="tab-related">
         {{> components/products/carousel products=product.related_products columns=6}}
     </div>
 {{/if}}
 
 {{#if product.similar_by_views}}
-    <div role="tabpanel" aria-hidden="true" class="tab-content" id="tab-similar">
+    <div role="tabpanel" aria-hidden="true" class="tab-content has-jsContent" id="tab-similar">
         {{> components/products/carousel products=product.similar_by_views columns=6}}
     </div>
 {{/if}}


### PR DESCRIPTION
Code comment speaks for itself. Basically prevents the following from happening:

![](https://dl.dropboxusercontent.com/spa/tkd7j6cqqsnwksf/2q4ta60-.png)

@bc-miko-ademagic @bc-chris-roper @hegrec 

cc/ @meenie 
