### PR TITLE
BIG-20645 Improvements to textTruncate

### DIFF
--- a/assets/js/theme/global/text-truncate.js
+++ b/assets/js/theme/global/text-truncate.js
@@ -5,7 +5,7 @@ export default class TextTruncate {
     constructor($element) {
         this.$element = $element;
         this.contentClass = 'textTruncate--hidden';
-        this.$options = $element.data('text-truncate') || {
+        this.options = $element.data('text-truncate') || {
             css: {},
             text: {
                 viewMore: '',
@@ -25,38 +25,60 @@ export default class TextTruncate {
 
     setupAnchor() {
         // create "view more" anchor
-        this.$viewAnchor = $(`<a href="#" class="textTruncate-viewMore">${this.$options.text.viewMore}</a>`);
-        this.$element.append(this.$viewAnchor);
-        this.maxHeight = this.$element.css('max-height');
+        this.createViewAnchor();
+        this.appendViewAnchor();
+        this.toggleState();
+        this.bindAnchor();
+    }
 
-        this.bindAnchor()
+    createViewAnchor() {
+        this.$viewAnchor = $('<a />', {
+            'href': '#',
+            'class': 'textTruncate-viewMore',
+            'text': this.options.text.viewMore
+        });
+    }
+
+    appendViewAnchor() {
+        this.$element.append(this.$viewAnchor);
     }
 
     bindAnchor() {
         // bind anchor to this scope
         this.$viewAnchor.on('click', (e) => {
             e.preventDefault();
-
-            // toggle class
-            this.$element.toggleClass(this.contentClass);
-
-            this.swapAnchorText()
+            // toggle state
+            this.toggleState();
         });
     }
 
-    swapAnchorText() {
+    toggleState() {
+        this.$element.toggleClass(this.contentClass);
+
         if (this.$element.hasClass(this.contentClass)) {
-            this.$element.css('max-height', this.maxHeight);
-            this.$viewAnchor.text(this.$options.text.viewMore);
+            this.hideText();
         } else {
-            this.$element.css('max-height', '');
-            this.$viewAnchor.text(this.$options.text.viewLess);
+            this.showText();
         }
+    }
+
+    showText() {
+        if (this.options.css['max-height']) {
+            this.$element.css('max-height', '');
+        }
+        this.$viewAnchor.text(this.options.text.viewLess);
+    }
+
+    hideText() {
+        if (this.options.css['max-height']) {
+            this.$element.css('max-height', this.options.css['max-height']);
+        }
+        this.$viewAnchor.text(this.options.text.viewMore);
     }
 
     parseDataAttributes() {
         // override default css options
-        _.forOwn(this.$options.css, (value, key) => {
+        _.forOwn(this.options.css, (value, key) => {
             if (key in this.defaultCssOptions && value) {
                 this.$element.css(key, value);
             }

--- a/assets/scss/components/stencil/textTruncate/_textTruncate.scss
+++ b/assets/scss/components/stencil/textTruncate/_textTruncate.scss
@@ -8,6 +8,7 @@
 //
 // -----------------------------------------------------------------------------
 .textTruncate {
+    padding-bottom: spacing("single");
     position: relative;
 }
 

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -251,7 +251,7 @@
         </ul>
         <div class="tabs-contents">
             <div class="tab-content is-active" id="tab-description">
-                <div class="textTruncate textTruncate--hidden"
+                <div class="textTruncate"
                      data-text-truncate='{
                         "css": {
                             "max-height": "120px",


### PR DESCRIPTION
- Don't start closed, if JS fails you won't be able to see the content.
- Only set `max-height` if it's passed in as an option, otherwise let CSS handle it
- Padding on the bottom of the container prevents the view link from sitting on top of expanded content

@haubc @hegrec @bc-miko-ademagic 
