### PR TITLE
BIG-20779 Order Detail for Partially Returned & Refunded order should…

### DIFF
--- a/assets/scss/components/stencil/account/_order-details.scss
+++ b/assets/scss/components/stencil/account/_order-details.scss
@@ -8,6 +8,7 @@
 // -----------------------------------------------------------------------------
 
 .order-contents {
+    @include grid-row;
     @include u-listReset;
 
     font-size: 0;   // 1.
@@ -15,12 +16,11 @@
 }
 
 .order-contents-item {
-    display: inline-block;
+    @include grid-column(6);
     font-size: $body-fontSize;
-    width: 50%;
 
     @include breakpoint("small") {
-        width: 33.33%;
+        @include grid-column(4);
     }
 }
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -229,6 +229,8 @@
                 "action": "Return Action",
                 "comments": "Comments"
             },
+            "refunded": "(Refunded)",
+            "refunded_quantity": "({qty} refunded)",
             "return_item": "Return",
             "return_items": "Return Items?",
             "order_placed": "Order Placed",

--- a/templates/components/account/order-contents.html
+++ b/templates/components/account/order-contents.html
@@ -1,11 +1,11 @@
-<h3 class="account-heading">{{lang 'account.orders.details.order_contents' }}</h3>
+<h3 class="account-heading">{{lang 'account.orders.details.order_contents'}}</h3>
 <ul class="order-contents">
     {{#each this.items}}
     <li class="order-contents-item">
         {{#if image}}
             <img class="order-contents-image" src="{{getImage image}}" alt="{{image.alt}}">
         {{/if}}
-        <h6 class="order-contents-name">{{name}}</h6>
+        <h6 class="order-contents-name">{{quantity}} &#215; {{name}}</h6>
         <span class="order-contents-price">{{price.formatted}}</span>
         <ul class="order-contents-options">
             {{#each options}}
@@ -18,10 +18,20 @@
 
         <!--
         TODO: Add this button when we're able to specify individual items for return
-            <a href="{{return_url}}" class="order-contents-return button secondary">{{lang 'account.orders.return_item' }}</a>
+            <a href="{{return_url}}" class="order-contents-return button secondary">{{lang 'account.orders.return_item'}}</a>
         -->
-        {{#if download_url}}
-            <a href="{{download_url}}" class="button button--primary">{{lang 'account.orders.details.download_items' }}</a>
+
+        {{#if refunded}}
+            <!-- Hide download link if fully refunded -->
+            <div class="order-contents-refunded">{{lang 'account.orders.refunded_quantity' qty=refunded_qty}}</div>
+        {{else}}
+            {{#if refunded_qty}}
+                <!-- Partially refunded -->
+                <div class="order-contents-refundedQty">{{lang 'account.orders.refunded_quantity' qty=refunded_qty}}</div>
+            {{/if}}
+            {{#if download_url}}
+                <a href="{{download_url}}" class="button button--primary">{{lang 'account.orders.details.download_items'}}</a>
+            {{/if}}
         {{/if}}
     </li>
     {{/each}}


### PR DESCRIPTION
… show special styling for returned

@SiTaggart @bc-miko-ademagic @bc-chris-roper @davidchin @bc-jordansim @hegrec @mickr @mcampa @meenie 
- Need to add quantity in front of the order otherwise the customer will not know how many they ordered and how many was returned
- Also added product grid with @bc-miko-ademagic 

![screen shot 2015-08-06 at 4 49 24 pm](https://cloud.githubusercontent.com/assets/8482478/9125941/39ef1d4a-3c5b-11e5-9d54-8b0ba265202b.png)

https://github.com/bigcommerce/stapler/pull/174
