### PR TITLE
Make date validation only if range is set

### DIFF
--- a/assets/js/theme/common/form-validation.js
+++ b/assets/js/theme/common/form-validation.js
@@ -8,6 +8,11 @@ import utils from 'bigcommerce/stencil-utils';
  * @returns {{selector: string, triggeredBy: string, validate: Function, errorMessage: string}}
  */
 function buildDateValidation($formField, validation) {
+    // No date range restriction, skip
+    if (!(validation.min_date && validation.max_date)) {
+        return;
+    }
+
     let invalidMessage = `Your chosen date must fall between ${validation.min_date} and ${validation.max_date}`,
         formElementId = $formField.attr('id'),
         minSplit = validation.min_date.split('-'),
@@ -95,7 +100,11 @@ function buildValidation($validateableElement) {
         formFieldSelector = `#${$validateableElement.attr('id')}`;
 
     if (validation.type === 'datechooser') {
-        fieldValidations.push(buildDateValidation($validateableElement, validation));
+        let dateValidation = buildDateValidation($validateableElement, validation);
+
+        if (dateValidation) {
+            fieldValidations.push(dateValidation);
+        }
     } else if (validation.required && (validation.type == 'checkboxselect' || validation.type == 'radioselect')) {
         fieldValidations.push(buildRequiredCheckboxValidation($validateableElement, validation));
     } else {


### PR DESCRIPTION
Make date validation only if range is set

This is the fix. Only the year element gets the error and message though so some CSS may need to be shuffled for that.

@bc-miko-ademagic @SiTaggart @mickr @haubc
