### PR TITLE
BIG-21009 Better consistent alignment of wishlist buttons

### DIFF
--- a/templates/components/account/wishlist-list.html
+++ b/templates/components/account/wishlist-list.html
@@ -22,12 +22,12 @@
             <td class="table-actions">
                 <form method="post" action="{{delete_url}}" class="form">
                     <fieldset class="form-fieldset">
-                        <a href="{{edit_url}}" class="button button--small" data-wishlist>{{lang 'common.edit'}}</a>
-                        <input type="submit" value="{{lang 'common.delete'}}" class="button button--small" data-wishlist-delete>
                         {{#if is_public}}
                             <a href="{{share_url}}" class="button button--primary button--small"
                            role="button">{{lang 'common.share'}}</a>
                         {{/if}}
+                        <a href="{{edit_url}}" class="button button--small" data-wishlist>{{lang 'common.edit'}}</a>
+                        <input type="submit" value="{{lang 'common.delete'}}" class="button button--small" data-wishlist-delete>
                     </fieldset>
                 </form>
             </td>


### PR DESCRIPTION
I cheated a bit, I just swapped the order of the buttons to get the alignment I wanted. Improves scalability as the edit and delete buttons are always present and now always inline with each other.

Right aligned, buttons align:
![](https://dl.dropboxusercontent.com/spa/tkd7j6cqqsnwksf/c-n-n6y-.png)

I kept this, instead of left aligning the content and fixing the width of the cell, to match the designs of the table in cart. Seemed too snowflakey.

Cart design is also right aligned:
![](https://dl.dropboxusercontent.com/spa/tkd7j6cqqsnwksf/04lmpt7u.png)

@bc-miko-ademagic @bc-chris-roper @davidchin 
