### PR TITLE
BIG-21203: Hide quick view button if configured

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,6 +28,8 @@
     "homepage_featured_products_column_count": 4,
     "homepage_top_products_column_count": 4,
 
+    "show_product_quick_view": true,
+
     "default_image_brand": "/assets/img/BrandDefault.gif",
     "default_image_product": "/assets/img/ProductDefault.gif",
 

--- a/templates/components/cart/preview.html
+++ b/templates/components/cart/preview.html
@@ -93,7 +93,7 @@
         <ul class="productGrid">
             {{#each cart.suggested_products}}
                 <li class="product">
-                    {{> components/products/card theme_settings=../theme_settings}}
+                    {{> components/products/card hide_product_quick_view=true theme_settings=../theme_settings}}
                 </li>
             {{/each}}
         </ul>

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -3,7 +3,11 @@
             <img class="card-image" src="{{getImage image 'gallery' (cdn theme_settings.default_image_product)}}" alt="{{image.alt}}">
         <figcaption class="card-figcaption">
             <div class="card-figcaption-body">
-                <a href="#" class="button button--small card-figcaption-button quickview" data-product-id="{{id}}">{{lang 'products.quick_view'}}</a>
+                {{#unless hide_product_quick_view}}
+                    {{#if theme_settings.show_product_quick_view}}
+                        <a href="#" class="button button--small card-figcaption-button quickview" data-product-id="{{id}}">{{lang 'products.quick_view'}}</a>
+                    {{/if}}
+                {{/unless}}
                 {{#if show_compare}}
                     <label class="button button--small card-figcaption-button" for="compare-{{id}}">
                         {{lang 'products.compare'}} <input type="checkbox" name="products[]" value="{{id}}" id="compare-{{id}}" data-compare-id="{{id}}">


### PR DESCRIPTION
- Hide Quick View Button if configured in config.json (I have been told that it is moved out of Store Settings for Stencil)
- Hide Quick View Button in Quick Cart modal so that clicking on a suggested item always opens a new page
