### PR TITLE
Only use SEO pricing data for main product and use valid review format

### DIFF
--- a/templates/components/products/price.html
+++ b/templates/components/products/price.html
@@ -1,9 +1,13 @@
 {{#if price.with_tax}}
-    <div class="price-section price-section--withTax">
+    <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
         {{#if price.rrp_with_tax}}
             <span class="price price--rrp">{{price.rrp_with_tax.formatted}}</span>
         {{/if}}
-        <meta itemprop="price" content="{{price.with_tax.value}}">
+        {{#if schema_org}}
+            <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
+            <meta itemprop="validAddedTaxIncluded" content="1">
+            <meta itemprop="price" content="{{price.with_tax.value}}">
+        {{/if}}
         <span data-product-price class="price">
             {{lang 'products.price_with_tax' price=price.with_tax.formatted tax_label=price.tax_label}}
         </span>
@@ -11,11 +15,15 @@
 {{/if}}
 
 {{#if price.without_tax}}
-    <div class="price-section price-section--withoutTax {{#if price.with_tax}}price-section--minor{{/if}}">
+    <div class="price-section price-section--withoutTax {{#if price.with_tax}}price-section--minor{{/if}}"  {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
         {{#if price.rrp_without_tax}}
             <span class="price price--rrp">{{price.rrp_without_tax.formatted}}</span>
         {{/if}}
-        <meta itemprop="price" content="{{price.without_tax.value}}">
+        {{#if schema_org}}
+            <meta itemprop="price" content="{{price.without_tax.value}}">
+            <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
+            <meta itemprop="validAddedTaxIncluded" content="0">
+        {{/if}}
         <span data-product-price class="price price--withoutTax">
             {{lang 'products.price_without_tax' price=price.without_tax.formatted tax_label=price.tax_label}}
         </span>

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -21,16 +21,17 @@
                 </p>
             {{/if}}
             {{#if product.price}}
-                <div class="productView-price" itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-                    <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
-                    {{> components/products/price price=product.price}}
+                <div class="productView-price">
+                    {{> components/products/price price=product.price schema_org=true}}
                 </div>
             {{/if}}
             <div class="productView-rating" itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">
                 {{#if settings.show_product_rating}}
-                    <meta itemprop="ratingValue" content="{{product.rating}}">
-                    <meta itemprop="ratingCount" content="{{product.num_reviews}}">
-                    <meta itemprop="reviewCount" content="{{product.num_reviews}}">
+                    {{#if product.num_reviews '>' 0}}
+                        <meta itemprop="ratingValue" content="{{product.rating}}">
+                        <meta itemprop="ratingCount" content="{{product.num_reviews}}">
+                        <meta itemprop="reviewCount" content="{{product.num_reviews}}">
+                    {{/if}}
                     {{> components/products/ratings rating=product.rating}}
                     <span class="productView-reviewLink"><a href="{{product.url}}#product-reviews">{{lang 'products.reviews.link_to_review' total=product.num_reviews}}</a></span>
                 {{/if}}


### PR DESCRIPTION
Only use SEO pricing data for main product and use valid review format

Because we share the pricing component, we need to wrap the itemprop inside an if statement that is only set true on the main product.

@haubc @meenie @davidchin @mickr @SiTaggart @bc-miko-ademagic 
