### PR TITLE
BIG-21354 Make long blog titles be inline with blog content

### DIFF
--- a/assets/scss/layouts/blog/_blog.scss
+++ b/assets/scss/layouts/blog/_blog.scss
@@ -23,6 +23,14 @@
     }
 }
 
+.blog-header,
+.blog-post {
+    @include grid-column(
+        $columns: 9,
+        $center: true
+    );
+}
+
 .blog-title {
     font-size: fontSize("large");
     margin: 0 0 spacing("quarter");
@@ -44,11 +52,6 @@
 }
 
 .blog-post {
-    @include grid-column(
-        $columns: 9,
-        $center: true
-    );
-
     font-size: fontSize("smaller");
 }
 

--- a/templates/components/blog/post.html
+++ b/templates/components/blog/post.html
@@ -7,13 +7,15 @@
         </a>
     {{/if}}
 
-    <h2 class="blog-title">
-        <a href="{{url}}">{{title}}</a>
-    </h2>
-    <p class="blog-date">{{date_published}}</p>
-    {{#if author}}
-        <p class="blog-author">{{lang 'blog.posted_by' name=author}}</p>
-    {{/if}}
+    <header class="blog-header">
+        <h2 class="blog-title">
+            <a href="{{url}}">{{title}}</a>
+        </h2>
+        <p class="blog-date">{{date_published}}</p>
+        {{#if author}}
+            <p class="blog-author">{{lang 'blog.posted_by' name=author}}</p>
+        {{/if}}
+    </header>
 
     <div class="blog-post">
         {{#if body}}


### PR DESCRIPTION
Make blogs look less strange.

![screen shot 2015-08-24 at 11 32 30 am](https://cloud.githubusercontent.com/assets/368249/9476371/2f25a3be-4b21-11e5-8d02-fc467b3127ef.png)

Easy fix, get the text lining up but still allowing the overflow in the container for when we get big blog images. 
