### PR TITLE
BIG-20880 bulk pricing

### DIFF
--- a/assets/scss/settings/foundation/modal/_settings.scss
+++ b/assets/scss/settings/foundation/modal/_settings.scss
@@ -22,7 +22,7 @@ $modal-backdrop-color:             color("greys", "darkest");
 $modal-border:                     container("border");
 
 // Size Variables
-$modal-width--small:               900px;
+$modal-width--small:               500px;
 $modal-width--large:               1280px;
 
 
@@ -80,7 +80,7 @@ $reveal-overlay-bg-old:            $modal-backdrop-color;
 // We use these to control the style of the modal itself.
 $reveal-modal-bg:                  $body-bg;
 $reveal-position-top:              50% !important;
-$reveal-default-width:             $modal-width--small;
+$reveal-default-width:             900px;
 $reveal-max-width:                 80%;
 $reveal-modal-paddingTop:          spacing("half");
 $reveal-modal-paddingHorizontal:   spacing("single") * 1.5;

--- a/lang/en.json
+++ b/lang/en.json
@@ -531,6 +531,7 @@
         "bulk_pricing": {
             "title": "Bulk Pricing:",
             "view": "Buy in bulk and save",
+            "modal_title": "Bulk discount rates",
             "instructions": "Below are the available bulk discount rates for each individual item when you purchase a certain amount",
             "range": "Buy {min} {max, plural, =0{or above} other {- #}}",
             "percent": "and get {discount} off",

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -36,8 +36,12 @@
                     <span class="productView-reviewLink"><a href="{{product.url}}#product-reviews">{{lang 'products.reviews.link_to_review' total=product.num_reviews}}</a></span>
                 {{/if}}
                 {{#if settings.show_product_reviews}}
-                    <span class="productView-reviewLink"><a href="{{product.url}}"
-                                                            {{#if product.reviews}}data-reveal-id="modal-review-form"{{/if}}>{{lang 'products.reviews.new'}}</a></span>
+                    <span class="productView-reviewLink">
+                        <a href="{{product.url}}"
+                           {{#unless is_ajax }}data-reveal-id="modal-review-form"{{/unless}}>
+                           {{lang 'products.reviews.new'}}
+                        </a>
+                    </span>
                     {{> components/products/modals/writeReview}}
                 {{/if}}
             </div>
@@ -79,11 +83,20 @@
                 {{/if}}
                 {{#if product.bulk_discount_rates.length}}
                     <dt class="productView-info-name">{{lang 'products.bulk_pricing.title'}}</dt>
-                    <dd class="productView-info-value"><a href="#" data-reveal-id="bulkPricingModal">{{lang 'products.bulk_pricing.view'}}</a></dd>
+                    <dd class="productView-info-value">
+                        <a href="{{product.url}}"
+                            {{#unless is_ajax }}data-reveal-id="bulkPricingModal" {{/unless}}>
+                            {{lang 'products.bulk_pricing.view'}}
+                        </a>
+                    </dd>
 
-                    <div id="bulkPricingModal" class="modal" data-reveal>
-                        <div class="modal-content">
-                            <h2>{{lang 'products.bulk_pricing.instructions'}}</h2>
+                    <div id="bulkPricingModal" class="modal modal--small" data-reveal>
+                        <div class="modal-header">
+                            <h2 class="modal-header-title">{{lang 'products.bulk_pricing.modal_title'}}</h2>
+                            <a href="#" class="modal-close" aria-label="Close"><span aria-hidden="true">&#215;</span></a>
+                        </div>
+                        <div class="modal-body">
+                            <p>{{lang 'products.bulk_pricing.instructions'}}</p>
                             <ul>
                             {{#each product.bulk_discount_rates}}
                                 <li>


### PR DESCRIPTION
- Switch the default modal to be it's own size
- Reduce the small modal option to being actually small.
- Use new small modal for bulk buying options
- Use the new `is_ajax` context for preventing modals being loaded in modals for bulk and reviews
