### PR TITLE
BIG-21431 Selectively make the store name in site header h1 for SEO

### DIFF
--- a/templates/components/common/header.html
+++ b/templates/components/common/header.html
@@ -14,15 +14,16 @@
 
     {{> components/common/navigation-user}}
 
-    <div class="header-logo">
-        <a href="{{urls.home}}">
-            {{#if settings.store_logo.image}}
-                <img class="header-logo-image" src="{{getImage settings.store_logo.image 'logo'}}" alt="{{settings.store_logo.title}}">
-            {{else}}
-                <span class="header-logo-text">{{settings.store_logo.title}}</span>
-            {{/if}}
-        </a>
-    </div>
+    {{#if template_file '===' 'pages/home'}}
+        <h1 class="header-logo">
+            {{> components/common/store-logo}}
+        </h1>
+    {{else}}
+        <div class="header-logo">
+            {{> components/common/store-logo}}
+        </div>
+    {{/if}}
+
 
     <div class="navPages-container" id="mobile-menu">
         {{> components/common/navigation-pages}}

--- a/templates/components/common/store-logo.html
+++ b/templates/components/common/store-logo.html
@@ -1,0 +1,7 @@
+<a href="{{urls.home}}">
+    {{#if settings.store_logo.image}}
+        <img class="header-logo-image" src="{{getImage settings.store_logo.image 'logo'}}" alt="{{settings.store_logo.title}}">
+    {{else}}
+        <span class="header-logo-text">{{settings.store_logo.title}}</span>
+    {{/if}}
+</a>


### PR DESCRIPTION
For SEO audit we should make the store name in the header the H1 tag but only when you are on the homepage. Otherwise it's not very preferable.

Attempt to tie into `page_type`, not sure how safe that is.
