### PR TITLE
BIG-21301 Improve card experience on smaller screens

### DIFF
--- a/assets/scss/components/citadel/cards/_cards.scss
+++ b/assets/scss/components/citadel/cards/_cards.scss
@@ -8,7 +8,12 @@
 }
 
 .card-figcaption {
+    display: none;
     margin: $card-figcaption-margin;
+
+    @include breakpoint("medium") {
+        display: block;
+    }
 }
 
 .card-figcaption-body {

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -1,6 +1,6 @@
 <article class="card {{#if alternate}}card--alternate{{/if}}">
     <figure class="card-figure">
-            <img class="card-image" src="{{getImage image 'gallery' (cdn theme_settings.default_image_product)}}" alt="{{image.alt}}">
+        <a href="{{url}}"><img class="card-image" src="{{getImage image 'gallery' (cdn theme_settings.default_image_product)}}" alt="{{image.alt}}"></a>
         <figcaption class="card-figcaption">
             <div class="card-figcaption-body">
                 {{#unless hide_product_quick_view}}


### PR DESCRIPTION
Help make the experience of quick view or product comparison better on small screens which are usually touch devices.

You can't get to those actions easily as they are hover actions, they work, but it's janky. 

So instead hide them on small screen, and make the image linked to the product page so there is some better improvement in experience. 

@bc-miko-ademagic @bc-chris-roper @davidchin 
