### PR TITLE
BIG-21458: Fix ESLint errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,40 @@
+{
+    "rules": {
+        "indent": [
+            2,
+            4
+        ],
+        "quotes": [
+            2,
+            "single"
+        ],
+        "linebreak-style": [
+            2,
+            "unix"
+        ],
+        "semi": [
+            2,
+            "always"
+        ],
+        "comma-dangle": [
+            2,
+            "never"
+        ],
+        "no-use-before-define": [
+            2,
+            "nofunc"
+        ],
+        "no-alert": 0,
+        "no-param-reassign": 0,
+        "no-shadow": 0,
+        "one-var": 0,
+        "prefer-const": 0,
+        "func-names": 0,
+        "consistent-return": 0
+    },
+    "env": {
+        "es6": true,
+        "browser": true
+    },
+    "extends": "airbnb/base"
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,10 +1,8 @@
-import stencilUtils from 'bigcommerce/stencil-utils';
 import async from 'caolan/async';
 import account from './theme/account';
 import auth from './theme/auth';
 import blog from './theme/blog';
 import brand from './theme/brand';
-import brands from './theme/brands';
 import cart from './theme/cart';
 import category from './theme/category';
 import contactUs from './theme/contact-us';
@@ -25,47 +23,47 @@ import wishlist from './theme/wishlist';
 
 let PageClasses = {
     mapping: {
-        "pages/account/orders/all": account,
-        "pages/account/orders/details": account,
-        "pages/account/addresses": account,
-        "pages/account/add-address": account,
-        "pages/account/add-return": account,
-        "pages/account/add-wishlist": wishlist,
-        "pages/account/recent-items": account,
-        "pages/account/download-item": account,
-        "pages/account/edit": account,
-        "pages/account/inbox": account,
-        "pages/account/return-saved": account,
-        "pages/account/returns": account,
-        "pages/auth/login": auth,
-        "pages/auth/account-created": auth,
-        "pages/auth/create-account": auth,
-        "pages/auth/new-password": auth,
-        "pages/auth/forgot-password": auth,
-        "pages/blog": blog,
-        "pages/blog-post": blog,
-        "pages/brand": brand,
-        "pages/brands": brand,
-        "pages/cart": cart,
-        "pages/category": category,
-        "pages/compare": compare,
-        "pages/contact-us": contactUs,
-        "pages/errors": errors,
-        "pages/errors/404": errors404,
-        "pages/gift-certificate/purchase": giftCertificate,
-        "pages/gift-certificate/balance": giftCertificate,
-        "pages/gift-certificate/redeem": giftCertificate,
-        "global": global,
-        "pages/home": home,
-        "pages/order-complete": orderComplete,
-        "pages/page": page,
-        "pages/product": product,
-        "pages/search": search,
-        "pages/rss": rss,
-        "pages/sitemap": sitemap,
-        "pages/subscribed": subscribe,
-        "pages/account/wishlist-details": wishlist,
-        "pages/account/wishlists": wishlist
+        'pages/account/orders/all': account,
+        'pages/account/orders/details': account,
+        'pages/account/addresses': account,
+        'pages/account/add-address': account,
+        'pages/account/add-return': account,
+        'pages/account/add-wishlist': wishlist,
+        'pages/account/recent-items': account,
+        'pages/account/download-item': account,
+        'pages/account/edit': account,
+        'pages/account/inbox': account,
+        'pages/account/return-saved': account,
+        'pages/account/returns': account,
+        'pages/auth/login': auth,
+        'pages/auth/account-created': auth,
+        'pages/auth/create-account': auth,
+        'pages/auth/new-password': auth,
+        'pages/auth/forgot-password': auth,
+        'pages/blog': blog,
+        'pages/blog-post': blog,
+        'pages/brand': brand,
+        'pages/brands': brand,
+        'pages/cart': cart,
+        'pages/category': category,
+        'pages/compare': compare,
+        'pages/contact-us': contactUs,
+        'pages/errors': errors,
+        'pages/errors/404': errors404,
+        'pages/gift-certificate/purchase': giftCertificate,
+        'pages/gift-certificate/balance': giftCertificate,
+        'pages/gift-certificate/redeem': giftCertificate,
+        'global': global,
+        'pages/home': home,
+        'pages/order-complete': orderComplete,
+        'pages/page': page,
+        'pages/product': product,
+        'pages/search': search,
+        'pages/rss': rss,
+        'pages/sitemap': sitemap,
+        'pages/subscribed': subscribe,
+        'pages/account/wishlist-details': wishlist,
+        'pages/account/wishlists': wishlist
     },
     /**
      * Getter method to ensure a good page type is accessed.
@@ -89,11 +87,11 @@ function series(pageObj) {
         pageObj.before.bind(pageObj), // Executed first after constructor()
         pageObj.loaded.bind(pageObj), // Main module logic
         pageObj.after.bind(pageObj) // Clean up method that can be overridden for cleanup.
-    ], function (err) {
+    ], function(err) {
         if (err) {
             throw new Error(err);
         }
-    })
+    });
 }
 
 /**
@@ -103,8 +101,9 @@ function series(pageObj) {
  * @returns {*}
  */
 function loadGlobal(pages) {
-    let global = pages.get('global');
-    return new global;
+    let Global = pages.get('global');
+
+    return new Global;
 }
 
 /**
@@ -138,15 +137,18 @@ window.stencilBootstrap = function stencilBootstrap(templateFile, context) {
     return {
         load() {
             $(() => {
-                let pageTypeFn = pages.get(templateFile); // Finds the appropriate module from the pageType object and store the result as a function.
-                if (pageTypeFn) {
-                    let pageType = new pageTypeFn();
+                let PageTypeFn = pages.get(templateFile); // Finds the appropriate module from the pageType object and store the result as a function.
+
+                if (PageTypeFn) {
+                    let pageType = new PageTypeFn();
+
                     pageType.context = context;
+
                     return loader(pageType, pages);
-                } else {
-                    throw new Error(templateFile + ' Module not found')
                 }
+
+                throw new Error(templateFile + ' Module not found');
             });
         }
-    }
+    };
 };

--- a/assets/js/page-manager.js
+++ b/assets/js/page-manager.js
@@ -53,9 +53,9 @@ export default class PageManager {
                     return callback(err, {
                         modal: modal
                     });
-                } else {
-                    throw err;
                 }
+
+                throw err;
             }
 
             modal.$content.html(content);

--- a/assets/js/theme/account.js
+++ b/assets/js/theme/account.js
@@ -3,7 +3,6 @@ import nod from './common/nod';
 import Wishlist from './wishlist';
 import validation from './common/form-validation';
 import stateCountry from './common/state-country';
-import forms from './common/models/forms';
 import {classifyForm, Validators, insertStateHiddenField} from './common/form-utils';
 
 export default class Account extends PageManager {
@@ -19,12 +18,12 @@ export default class Account extends PageManager {
             $inboxForm = classifyForm('form[data-inbox-form]'),
             $accountReturnForm = classifyForm('[data-account-return-form]'),
             $reorderForm = classifyForm('[data-account-reorder-form]');
-        
+
         // Injected via template
         this.passwordRequirements = this.context.passwordRequirements;
 
         // Instantiates wish list JS
-        new Wishlist();
+        this.wishlist = new Wishlist();
 
         if ($editAccountForm.length) {
             this.registerEditAccountValidation($editAccountForm);
@@ -151,7 +150,7 @@ export default class Account extends PageManager {
 
             // Iterate until we find a non-zero value in the dropdown for quantity
             $('[name^="return_qty"]', $accountReturnForm).each((i, ele) => {
-                if ($(ele).val() != 0) {
+                if ($(ele).val() !== 0) {
                     formSubmit = true;
 
                     // Exit out of loop if we found at least one return
@@ -161,11 +160,12 @@ export default class Account extends PageManager {
 
             if (formSubmit) {
                 return true;
-            } else {
-                alert('Please select one or more items to return');
-                return false;
             }
-        })
+
+            alert('Please select one or more items to return');
+
+            return false;
+        });
     }
 
     registerEditAccountValidation($editAccountForm) {
@@ -183,7 +183,7 @@ export default class Account extends PageManager {
             currentPasswordSelector = `${formEditSelector} [data-field-type="CurrentPassword"]`,
             $currentPassword = $(currentPasswordSelector);
 
-        //This only handles the custom fields, standard fields are added below
+        // This only handles the custom fields, standard fields are added below
         editValidator.add(validationModel);
 
         if ($emailElement) {
@@ -215,34 +215,34 @@ export default class Account extends PageManager {
 
                     cb(result);
                 },
-                errorMessage: "You must enter your current password"
+                errorMessage: 'You must enter your current password'
             });
         }
 
         editValidator.add([
             {
-                selector: `${formEditSelector} input[name="account_firstname"]`,
+                selector: `${formEditSelector} input[name='account_firstname']`,
                 validate: (cb, val) => {
                     let result = val.length;
                     cb(result);
                 },
-                errorMessage: "You must enter a first name"
+                errorMessage: 'You must enter a first name'
             },
             {
-                selector: `${formEditSelector} input[name="account_lastname"]`,
+                selector: `${formEditSelector} input[name='account_lastname']`,
                 validate: (cb, val) => {
                     let result = val.length;
                     cb(result);
                 },
-                errorMessage: "You must enter a last name"
+                errorMessage: 'You must enter a last name'
             },
             {
-                selector: `${formEditSelector} input[name="account_phone"]`,
+                selector: `${formEditSelector} input[name='account_phone']`,
                 validate: (cb, val) => {
                     let result = val.length;
                     cb(result);
                 },
-                errorMessage: "You must enter a Phone Number"
+                errorMessage: 'You must enter a Phone Number'
             }
         ]);
 
@@ -259,7 +259,6 @@ export default class Account extends PageManager {
     }
 
     registerInboxValidation($inboxForm) {
-
         let inboxValidator = nod({
             submit: 'form[data-inbox-form] input[type="submit"]'
         });
@@ -271,7 +270,7 @@ export default class Account extends PageManager {
                     let result = Number(val) !== 0;
                     cb(result);
                 },
-                errorMessage: "You must select an order"
+                errorMessage: 'You must select an order'
             },
             {
                 selector: 'form[data-inbox-form] input[name="message_subject"]',
@@ -279,7 +278,7 @@ export default class Account extends PageManager {
                     let result = val.length;
                     cb(result);
                 },
-                errorMessage: "You must enter a subject"
+                errorMessage: 'You must enter a subject'
             },
             {
                 selector: 'form[data-inbox-form] textarea[name="message_content"]',
@@ -287,7 +286,7 @@ export default class Account extends PageManager {
                     let result = val.length;
                     cb(result);
                 },
-                errorMessage: "You must enter a message"
+                errorMessage: 'You must enter a message'
             }
         ]);
 

--- a/assets/js/theme/auth.js
+++ b/assets/js/theme/auth.js
@@ -1,5 +1,4 @@
 import PageManager from '../page-manager';
-import _ from 'lodash';
 import stateCountry from './common/state-country';
 import $ from 'jquery';
 import nod from './common/nod';
@@ -27,7 +26,7 @@ export default class Auth extends PageManager {
                     let result = loginModel.email(val);
                     cb(result);
                 },
-                errorMessage: "Please type in a valid email address, such as joe@aol.com"
+                errorMessage: 'Please type in a valid email address, such as joe@aol.com'
             },
             {
                 selector: '.login-form input[name="login_pass"]',
@@ -35,7 +34,7 @@ export default class Auth extends PageManager {
                     let result = loginModel.password(val);
                     cb(result);
                 },
-                errorMessage: "You must enter a password"
+                errorMessage: 'You must enter a password'
             }
         ]);
 
@@ -62,7 +61,7 @@ export default class Auth extends PageManager {
                     let result = forms.email(val);
                     cb(result);
                 },
-                errorMessage: "Please type in a valid email address, such as joe@aol.com"
+                errorMessage: 'Please type in a valid email address, such as joe@aol.com'
             }
         ]);
 
@@ -80,14 +79,14 @@ export default class Auth extends PageManager {
     registerCreateAccountValidator($createAccountForm) {
         let validationModel = validation($createAccountForm),
             createAccountValidator = nod({
-                submit: `${this.formCreateSelector} input[type="submit"]`
+                submit: `${this.formCreateSelector} input[type='submit']`
             }),
             $stateElement = $('[data-field-type="State"]'),
-            emailSelector = `${this.formCreateSelector} [data-field-type="EmailAddress"]`,
+            emailSelector = `${this.formCreateSelector} [data-field-type='EmailAddress']`,
             $emailElement = $(emailSelector),
-            passwordSelector = `${this.formCreateSelector} [data-field-type="Password"]`,
+            passwordSelector = `${this.formCreateSelector} [data-field-type='Password']`,
             $passwordElement = $(passwordSelector),
-            password2Selector = `${this.formCreateSelector} [data-field-type="ConfirmPassword"]`,
+            password2Selector = `${this.formCreateSelector} [data-field-type='ConfirmPassword']`,
             $password2Element = $(password2Selector);
 
         createAccountValidator.add(validationModel);

--- a/assets/js/theme/brand.js
+++ b/assets/js/theme/brand.js
@@ -14,11 +14,11 @@ export default class Brand extends PageManager {
 
         super();
 
-        new FacetedSearch(requestOptions, function(content) {
+        this.facetedSearch = new FacetedSearch(requestOptions, function(content) {
             $productListingContainer.html(content.productListing);
             $facetedSearchContainer.html(content.sidebar);
 
-            $("html, body").animate({
+            $('html, body').animate({
                 scrollTop: 0
             }, 100);
         });

--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -14,7 +14,7 @@ export default class Cart extends PageManager {
         this.bindEvents();
 
         // initiate shipping estimator module
-        new ShippingEstimator($('[data-shipping-estimator]'));
+        this.shippingEstimator = new ShippingEstimator($('[data-shipping-estimator]'));
 
         next();
     }
@@ -59,14 +59,14 @@ export default class Cart extends PageManager {
                 template: {
                     content: 'cart/content',
                     totals: 'cart/totals',
-                    pageTitle: 'cart/page-title',
+                    pageTitle: 'cart/page-title'
                 }
             };
 
         this.$overlay.show();
 
         // Remove last item from cart? Reload
-        if (remove && $cartItemsRows.length == 1) {
+        if (remove && $cartItemsRows.length === 1) {
             return window.location.reload();
         }
 
@@ -185,7 +185,7 @@ export default class Cart extends PageManager {
                 id = $select.val(),
                 index = $select.data('index'),
                 allowMessage;
-                
+
             if (!id) {
                 return;
             }
@@ -205,7 +205,7 @@ export default class Cart extends PageManager {
         $('.giftWrapping-select').trigger('change');
 
         function toggleViews() {
-            var value = $("input:radio[name ='giftwraptype']:checked").val(),
+            let value = $('input:radio[name ="giftwraptype"]:checked').val(),
                 $singleForm = $('.giftWrapping-single'),
                 $multiForm = $('.giftWrapping-multiple');
 

--- a/assets/js/theme/cart/shipping-estimator.js
+++ b/assets/js/theme/cart/shipping-estimator.js
@@ -14,7 +14,7 @@ export default class ShippingEstimator {
 
     bindStateCountryChange() {
         // Requests the states for a country with AJAX
-        stateCountry(this.$state, this.context, {useIdForStates: true}, (err, field) => {
+        stateCountry(this.$state, this.context, {useIdForStates: true}, (err) => {
             if (err) {
                 alert(err);
                 throw new Error(err);
@@ -44,7 +44,7 @@ export default class ShippingEstimator {
 
                     event.preventDefault();
 
-                    utils.api.cart.submitShippingQuote(quoteId, (response) => {
+                    utils.api.cart.submitShippingQuote(quoteId, () => {
                         location.reload();
                     });
                 });

--- a/assets/js/theme/category.js
+++ b/assets/js/theme/category.js
@@ -20,11 +20,11 @@ export default class Category extends PageManager {
 
         super();
 
-        new FacetedSearch(requestOptions, function(content) {
+        this.facetedSearch = new FacetedSearch(requestOptions, function(content) {
             $productListingContainer.html(content.productListing);
             $facetedSearchContainer.html(content.sidebar);
 
-            $("html, body").animate({
+            $('html, body').animate({
                 scrollTop: 0
             }, 100);
         });

--- a/assets/js/theme/common/carousel.js
+++ b/assets/js/theme/common/carousel.js
@@ -1,12 +1,10 @@
 import $ from 'jquery';
 import 'slick-carousel/slick/slick';
 
-export default function () {
-
+export default function() {
     let $carousel = $('[data-slick]');
 
     if ($carousel.length) {
         $carousel.slick();
     }
-
 }

--- a/assets/js/theme/common/collapsible.js
+++ b/assets/js/theme/common/collapsible.js
@@ -5,7 +5,7 @@ const CollapsibleEvents = {
     close: 'close.collapsible',
     toggle: 'toggle.collapsible',
     click: 'click.collapsible'
-}
+};
 
 /**
  * Collapse/Expand toggle

--- a/assets/js/theme/common/faceted-search.js
+++ b/assets/js/theme/common/faceted-search.js
@@ -34,14 +34,13 @@ export default class FacetedSearch {
      * let facetedSearch = new FacetedSearch(requestOptions, templatesDidLoad);
      */
     constructor(requestOptions, callback, options) {
-
         let defaultOptions = {
-           accordionToggleSelector: '#facetedSearch .accordion-navigation, #facetedSearch .facetedSearch-toggle',
-           blockerSelector: '#facetedSearch .blocker',
-           clearFacetSelector: '#facetedSearch .facetedSearch-clearLink',
-           componentSelector: '#facetedSearch-navList',
-           facetNavListSelector: '#facetedSearch .navList',
-           showMoreToggleSelector: '#facetedSearch .accordion-content .toggleLink'
+            accordionToggleSelector: '#facetedSearch .accordion-navigation, #facetedSearch .facetedSearch-toggle',
+            blockerSelector: '#facetedSearch .blocker',
+            clearFacetSelector: '#facetedSearch .facetedSearch-clearLink',
+            componentSelector: '#facetedSearch-navList',
+            facetNavListSelector: '#facetedSearch .navList',
+            showMoreToggleSelector: '#facetedSearch .accordion-content .toggleLink'
         };
 
         // Private properties
@@ -167,11 +166,11 @@ export default class FacetedSearch {
             this.expandFacetItems($navList);
 
             return true;
-        } else {
-            this.collapseFacetItems($navList);
-
-            return false;
         }
+
+        this.collapseFacetItems($navList);
+
+        return false;
     }
 
     expandFacet($accordionToggle) {
@@ -249,7 +248,7 @@ export default class FacetedSearch {
         $(window).on('statechange', this.onStateChange);
         $(document).on('click', this.options.showMoreToggleSelector, this.onToggleClick);
         $(document).on('toggle.collapsible', this.options.accordionToggleSelector, this.onAccordionToggle);
-        $(this.options.clearFacetSelector).on('click', this.onClearFacet)
+        $(this.options.clearFacetSelector).on('click', this.onClearFacet);
 
         // Hooks
         hooks.on('facetedSearch-facet-clicked', this.onFacetClick);
@@ -262,7 +261,7 @@ export default class FacetedSearch {
         $(window).off('statechange', this.onStateChange);
         $(document).off('click', this.options.showMoreToggleSelector, this.onToggleClick);
         $(document).off('toggle.collapsible', this.options.accordionToggleSelector, this.onAccordionToggle);
-        $(this.options.clearFacetSelector).off('click', this.onClearFacet)
+        $(this.options.clearFacetSelector).off('click', this.onClearFacet);
 
         // Hooks
         hooks.off('facetedSearch-facet-clicked', this.onFacetClick);
@@ -318,14 +317,14 @@ export default class FacetedSearch {
             queryParams = $(event.currentTarget).serialize().split('=');
 
         url.query[queryParams[0]] = queryParams[1];
-        delete url.query['page'];
+        delete url.query.page;
 
         event.preventDefault();
 
         goToUrl(Url.format({ pathname: url.pathname, query: url.query }));
     }
 
-    onStateChange(event) {
+    onStateChange() {
         this.updateView();
     }
 

--- a/assets/js/theme/common/form-utils.js
+++ b/assets/js/theme/common/form-utils.js
@@ -9,9 +9,6 @@ let inputTagNames = [
     'textarea'
 ];
 
-const VALIDATION_PASSWORD_ALPHA_REGEX = /[A-Za-z]/;
-const VALIDATION_PASSWORD_NUMERIC_REGEX = /[0-9]/;
-
 /**
  * Apply class name to an input element on its type
  * @param {object} input
@@ -31,10 +28,10 @@ function classifyInput(input, formFieldClass) {
 
         if (_.contains(['radio', 'checkbox', 'submit'], inputType)) {
             // ie: .form-field--checkbox, .form-field--radio
-            className = `${formFieldClass}--${_.camelCase(inputType)}`
+            className = `${formFieldClass}--${_.camelCase(inputType)}`;
         } else {
             // ie: .form-field--input .form-field--inputText
-            specificClassName = `${className}${_.capitalize(inputType)}`
+            specificClassName = `${className}${_.capitalize(inputType)}`;
         }
     }
 
@@ -107,9 +104,9 @@ function insertStateHiddenField($stateField) {
             type: 'hidden',
             name: `FormFieldIsText${fieldId}`,
             value: '1'
-    };
+        };
 
-    $stateField.after($('<input />', stateFieldAttrs))
+    $stateField.after($('<input />', stateFieldAttrs));
 }
 
 let Validators = {
@@ -127,7 +124,7 @@ let Validators = {
                     cb(result);
                 },
                 errorMessage: 'You must enter a valid email'
-            })
+            });
         }
     },
 
@@ -139,14 +136,8 @@ let Validators = {
      * @param requirements
      * @param isOptional
      */
-    setPasswordValidation: (
-        validator,
-        passwordSelector,
-        password2Selector,
-        requirements,
-        isOptional) => {
+    setPasswordValidation: (validator, passwordSelector, password2Selector, requirements, isOptional) => {
         let $password = $(passwordSelector),
-            $password2 = $(password2Selector),
             passwordValidations = [
                 {
                     selector: passwordSelector,
@@ -215,7 +206,7 @@ let Validators = {
                 selector: field,
                 validate: 'presence',
                 errorMessage: 'The State/Province field cannot be blank'
-            })
+            });
         }
     },
 
@@ -230,8 +221,8 @@ let Validators = {
             if ($fieldClassElement.hasClass(nod.classes[value])) {
                 $fieldClassElement.removeClass(nod.classes[value]);
             }
-        })
+        });
     }
 };
 
-export {Validators, insertStateHiddenField}
+export {Validators, insertStateHiddenField};

--- a/assets/js/theme/common/form-validation.js
+++ b/assets/js/theme/common/form-validation.js
@@ -1,5 +1,4 @@
 import $ from 'jquery';
-import utils from 'bigcommerce/stencil-utils';
 
 /**
  * Validate that the given date for the day/month/year select inputs is within potential range
@@ -42,15 +41,14 @@ function buildDateValidation($formField, validation) {
  * @param validation
  */
 function buildRequiredCheckboxValidation($formField, validation) {
-    let primaryName = $formField.find('input').attr('name'),
-        formFieldId = $formField.attr('id'),
+    let formFieldId = $formField.attr('id'),
         primarySelector = `#${formFieldId} input:first-of-type`,
         secondarySelector = `#${formFieldId} input`;
 
     return {
         selector: primarySelector,
         triggeredBy: secondarySelector,
-        validate: (cb, val) => {
+        validate: (cb) => {
             let result = false;
 
             $(secondarySelector).each(function(index, checkbox) {
@@ -67,7 +65,6 @@ function buildRequiredCheckboxValidation($formField, validation) {
 }
 
 function buildRequiredValidation(validation, selector) {
-
     return {
         selector: selector,
         validate: (cb, val) => {
@@ -105,7 +102,7 @@ function buildValidation($validateableElement) {
         if (dateValidation) {
             fieldValidations.push(dateValidation);
         }
-    } else if (validation.required && (validation.type == 'checkboxselect' || validation.type == 'radioselect')) {
+    } else if (validation.required && (validation.type === 'checkboxselect' || validation.type === 'radioselect')) {
         fieldValidations.push(buildRequiredCheckboxValidation($validateableElement, validation));
     } else {
         $validateableElement.find('input, select, textarea').each(function(index, element) {
@@ -131,7 +128,7 @@ function buildValidation($validateableElement) {
  * @param $form
  * @returns {Array}
  */
-export default function ($form) {
+export default function($form) {
     let validationsToPerform = [];
 
     $form.find('[data-validation]').each(function(index, input) {

--- a/assets/js/theme/common/models/forms.js
+++ b/assets/js/theme/common/models/forms.js
@@ -1,6 +1,6 @@
 let forms = {
     email(value) {
-        var re = /^.+@.+\..+/;
+        const re = /^.+@.+\..+/;
         return re.test(value);
     },
 
@@ -22,6 +22,6 @@ let forms = {
     notEmpty(value) {
         return value.length > 0;
     }
-}
+};
 
 export default forms;

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -42,7 +42,7 @@ export default class Product {
                 $text: $('.incrementTotal', $scope),
                 $input: $('[name=qty\\[\\]]', $scope)
             }
-        }
+        };
     }
 
     /**
@@ -52,7 +52,7 @@ export default class Product {
      */
     productOptions() {
         utils.hooks.on('product-option-change', (event, changedOption) => {
-            var $changedOption = $(changedOption),
+            let $changedOption = $(changedOption),
                 $form = $changedOption.parents('form'),
                 productId = $('[name="product_id"]', $form).val();
 
@@ -77,7 +77,7 @@ export default class Product {
 
                 // Set variation_id if it exists for adding to wishlist
                 if (response.data.variantId) {
-                    viewModel.$wishlistVariation.val(response.data.variantId)
+                    viewModel.$wishlistVariation.val(response.data.variantId);
                 }
 
                 // If SKU is available
@@ -86,11 +86,12 @@ export default class Product {
                 }
 
                 if (data.image) {
-                    let zoomImageUrl = utils.tools.image.getSrc(
+                    const zoomImageUrl = utils.tools.image.getSrc(
                         data.image.data,
                         this.context.themeImageSizes.zoom
-                    ),
-                    mainImageUrl = utils.tools.image.getSrc(
+                    );
+
+                    const mainImageUrl = utils.tools.image.getSrc(
                         data.image.data,
                         this.context.themeImageSizes.product
                     );
@@ -193,9 +194,9 @@ export default class Product {
                 this.populateCartModal($previewModal, response.data.cart_item.hash, ($modalContent) => {
                     // Update cart counter
                     const $body = $('body'),
-                          $cartQuantity = $('[data-cart-quantity]', $modalContent),
-                          $cartCounter = $('.navUser-action .cart-count'),
-                          quantity = $cartQuantity.data('cart-quantity') || 0;
+                        $cartQuantity = $('[data-cart-quantity]', $modalContent),
+                        $cartCounter = $('.navUser-action .cart-count'),
+                        quantity = $cartQuantity.data('cart-quantity') || 0;
 
                     $cartCounter.addClass('cart-count--positive');
                     $body.trigger('cart-quantity-update', quantity);
@@ -228,7 +229,7 @@ export default class Product {
     populateCartModal($modal, cartItemHash, onComplete) {
         // Define options
         const $modalContent = $('.modal-content', $modal),
-              $modalOverlay = $('.loadingOverlay', $modal);
+            $modalOverlay = $('.loadingOverlay', $modal);
 
         const options = {
             template: 'cart/preview',

--- a/assets/js/theme/common/state-country.js
+++ b/assets/js/theme/common/state-country.js
@@ -27,7 +27,6 @@ function makeStateRequired(stateElement, context) {
 
     stateElement.replaceWith($('<select></select>', replacementAttributes));
 
-
     $newElement = $('[data-field-type="State"]');
     $hiddenInput = $('[name*="FormFieldIsText"]');
 
@@ -36,7 +35,6 @@ function makeStateRequired(stateElement, context) {
     }
 
     if ($newElement.prev().find('small').length === 0) {
-
         // String is injected from localizer
         $newElement.prev().append(`<small>${context.required}</small>`);
     } else {
@@ -50,7 +48,7 @@ function makeStateRequired(stateElement, context) {
  * If a country with states is the default, a select will be sent,
  * In this case we need to be able to switch to an input field and hide the required field
  */
-function makeStateOptional(stateElement, context) {
+function makeStateOptional(stateElement) {
     let attrs,
         $newElement;
 
@@ -108,7 +106,7 @@ function addOptions(statesArray, $selectElement, options) {
  * @param {Object} options
  * @param {Function} callback
  */
-export default function (stateElement, context, options, callback) {
+export default function(stateElement, context, options, callback) {
     context = context || {};
 
     /**
@@ -118,7 +116,7 @@ export default function (stateElement, context, options, callback) {
      *
      * useIdForStates {Bool} - Generates states dropdown using id for values instead of strings
      */
-    if (typeof options == 'function') {
+    if (typeof options === 'function') {
         callback = options;
         options = {};
     }
@@ -145,11 +143,10 @@ export default function (stateElement, context, options, callback) {
                 let $selectElement = makeStateRequired($currentInput, context);
                 addOptions(response.data, $selectElement, options);
                 callback(null, $selectElement);
-
             } else {
                 let newElement = makeStateOptional($currentInput, context);
                 callback(null, newElement);
             }
-        })
+        });
     });
 }

--- a/assets/js/theme/compare.js
+++ b/assets/js/theme/compare.js
@@ -7,8 +7,6 @@ export default class Compare extends PageManager {
 
     loaded() {
         $('body').on('click', '[data-comparison-remove]', (event) => {
-            let $this = $(event.currentTarget);
-
             if (this.context.comparisons.length <= 2) {
                 alert('You can only compare a minimum of two products');
                 event.preventDefault();

--- a/assets/js/theme/contact-us.js
+++ b/assets/js/theme/contact-us.js
@@ -13,7 +13,6 @@ export default class ContactUs extends PageManager {
     }
 
     registerContactFormValidation() {
-
         let formSelector = 'form[data-contact-form]',
             contactUsValidator = nod({
                 submit: `${formSelector} input[type="submit"]`
@@ -27,7 +26,7 @@ export default class ContactUs extends PageManager {
                     let result = forms.email(val);
                     cb(result);
                 },
-                errorMessage: "Please type in a valid email address, such as joe@aol.com"
+                errorMessage: 'Please type in a valid email address, such as joe@aol.com'
             },
             {
                 selector: `${formSelector} textarea[name="contact_question"]`,
@@ -35,7 +34,7 @@ export default class ContactUs extends PageManager {
                     let result = forms.notEmpty(val);
                     cb(result);
                 },
-                errorMessage: "You must enter your question"
+                errorMessage: 'You must enter your question'
             }
         ]);
 

--- a/assets/js/theme/gift-certificate.js
+++ b/assets/js/theme/gift-certificate.js
@@ -1,5 +1,6 @@
 import PageManager from '../page-manager';
 import nod from './common/nod';
+
 export default class GiftCertificate extends PageManager {
     constructor() {
         super();
@@ -9,14 +10,14 @@ export default class GiftCertificate extends PageManager {
                     return val.length;
                 },
                 recipientEmail: function(value) {
-                    var re = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
+                    const re = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
                     return re.test(value);
                 },
                 senderName: function(val) {
                     return val.length;
                 },
                 senderEmail: function(value) {
-                    var re = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
+                    const re = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
                     return re.test(value);
                 },
                 customAmount: function(value, min, max) {
@@ -26,7 +27,7 @@ export default class GiftCertificate extends PageManager {
                     let found = false;
 
                     options.forEach(function(option) {
-                        if (option == value) {
+                        if (option === value) {
                             found = true;
                             return false;
                         }
@@ -70,7 +71,7 @@ export default class GiftCertificate extends PageManager {
                     let result = purchaseModel.recipientName(val);
                     cb(result);
                 },
-                errorMessage: "You must enter a valid recipient name"
+                errorMessage: 'You must enter a valid recipient name'
             },
             {
                 selector: '#gift-certificate-form input[name="to_email"]',
@@ -78,7 +79,7 @@ export default class GiftCertificate extends PageManager {
                     let result = purchaseModel.recipientEmail(val);
                     cb(result);
                 },
-                errorMessage: "You must enter a valid recipient email"
+                errorMessage: 'You must enter a valid recipient email'
             },
             {
                 selector: '#gift-certificate-form input[name="from_name"]',
@@ -86,7 +87,7 @@ export default class GiftCertificate extends PageManager {
                     let result = purchaseModel.senderName(val);
                     cb(result);
                 },
-                errorMessage: "You must enter your name"
+                errorMessage: 'You must enter your name'
             },
             {
                 selector: '#gift-certificate-form input[name="from_email"]',
@@ -94,7 +95,7 @@ export default class GiftCertificate extends PageManager {
                     let result = purchaseModel.senderEmail(val);
                     cb(result);
                 },
-                errorMessage: "You must enter a valid email"
+                errorMessage: 'You must enter a valid email'
             },
             {
                 selector: '#gift-certificate-form input[name="certificate_theme"]:first-of-type',
@@ -104,7 +105,7 @@ export default class GiftCertificate extends PageManager {
 
                     cb(typeof(val) === 'string');
                 },
-                errorMessage: "You must select a gift certificate theme"
+                errorMessage: 'You must select a gift certificate theme'
             },
             {
                 selector: '#gift-certificate-form input[name="agree"]',
@@ -113,7 +114,7 @@ export default class GiftCertificate extends PageManager {
 
                     cb(val);
                 },
-                errorMessage: "You must agree to these terms"
+                errorMessage: 'You must agree to these terms'
             },
             {
                 selector: '#gift-certificate-form input[name="agree2"]',
@@ -122,7 +123,7 @@ export default class GiftCertificate extends PageManager {
 
                     cb(val);
                 },
-                errorMessage: "You must agree to these terms"
+                errorMessage: 'You must agree to these terms'
             }
         ]);
 

--- a/assets/js/theme/global.js
+++ b/assets/js/theme/global.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import PageManager from '../page-manager';
 import quickSearch from './global/quick-search';
 import currencySelector from './global/currency-selector';

--- a/assets/js/theme/global/cart-preview.js
+++ b/assets/js/theme/global/cart-preview.js
@@ -3,7 +3,7 @@ import 'foundation/js/foundation/foundation';
 import 'foundation/js/foundation/foundation.dropdown';
 import utils from 'bigcommerce/stencil-utils';
 
-export default function () {
+export default function() {
     let loadingClass = 'is-loading',
         $cart = $('[data-cart-preview]'),
         $cartDropdown = $('#cart-preview-dropdown'),
@@ -28,8 +28,6 @@ export default function () {
         event.preventDefault();
 
         utils.api.cart.getContent(options, (err, response) => {
-            let quantity;
-
             $cartDropdown
                 .removeClass(loadingClass)
                 .html(response);

--- a/assets/js/theme/global/compare-products.js
+++ b/assets/js/theme/global/compare-products.js
@@ -25,8 +25,7 @@ function updateCounterNav(counter, $link) {
     }
 }
 
-export default function () {
-
+export default function() {
     let $checked = $('body').find('input[name="products\[\]"]:checked'),
         $compareLink = $('a[data-compare-nav]'),
         products;
@@ -59,12 +58,12 @@ export default function () {
         }
     });
 
-    $('body').on('click', 'a[data-compare-nav]', (event) => {
+    $('body').on('click', 'a[data-compare-nav]', () => {
         let $checked = $('body').find('input[name="products\[\]"]:checked');
 
         if ($checked.length <= 1) {
             alert('You must select at least two products to compare');
             return false;
         }
-    })
+    });
 }

--- a/assets/js/theme/global/cookieNotification.js
+++ b/assets/js/theme/global/cookieNotification.js
@@ -1,16 +1,18 @@
-import utils from 'bigcommerce/stencil-utils';
+// import utils from 'bigcommerce/stencil-utils';
 
 /**
  * European websites must notify users of cookies to comply with European Union law.
  * This will alert shoppers that this website uses cookies.
  */
-export default function () {
+export default function() {
+    /*
     // Here you can override the default browser alert box by hooking to the 'cookie-privacy-notification' hook.
     utils.hooks.on('cookie-privacy-notification', (event, privacyMessage) => {
         // You can make your own custom modal or alert box appear in your theme using the privacyMessage provided
-        // myCustomAlert(privacyMessage);
+        myCustomAlert(privacyMessage);
 
         // Call event.preventDefault() to prevent the default browser alert from occurring in stencil-utils
-        //event.preventDefault();
+        event.preventDefault();
     });
+    */
 }

--- a/assets/js/theme/global/currency-selector.js
+++ b/assets/js/theme/global/currency-selector.js
@@ -1,5 +1,5 @@
-export default function () {
-    $(document.body).on('click', '.currencySelector', function() {
-        $('.currency-selection-list').toggleClass('active')
+export default function() {
+    $(document.body).on('click', '.currencySelector', function onClick() {
+        $('.currency-selection-list').toggleClass('active');
     });
-};
+}

--- a/assets/js/theme/global/loading-progress-bar.js
+++ b/assets/js/theme/global/loading-progress-bar.js
@@ -1,6 +1,6 @@
 import 'hubspot/pace';
 
-export default function () {
+export default function() {
     Pace.start({
         document: false,
         ajax: {

--- a/assets/js/theme/global/mobile-menu.js
+++ b/assets/js/theme/global/mobile-menu.js
@@ -1,46 +1,41 @@
 import $ from 'jquery';
 
-export default function () {
-
+export default function() {
     const $mobileMenuTrigger = $('[data-mobilemenu]');
     const $header = $('.header');
     const headerHeight = $('.header').outerHeight();
     const $mobileMenu = $('#mobile-menu');
 
-    let $targetMenuItem;
-    let targetMenuItemID;
-
     function mobileMenu() {
         $mobileMenuTrigger.on('click', toggleMobileMenu);
     }
 
-    function toggleMobileMenu (e) {
+    function toggleMobileMenu(e) {
         e.preventDefault();
 
         calculateMobileMenuOffset();
         targetMenuItemID = $mobileMenuTrigger.data('mobilemenu');
 
         $mobileMenuTrigger.toggleClass('is-open').attr('aria-expanded', (i, attr) => {
-            return attr == 'true' ? 'false' : 'true';
+            return attr === 'true' ? 'false' : 'true';
         });
 
         $mobileMenu.toggleClass('is-open').attr('aria-hidden', (i, attr) => {
-            return attr == 'true' ? 'false' : 'true';
+            return attr === 'true' ? 'false' : 'true';
         });
     }
 
-    function calculateMobileMenuOffset () {
+    function calculateMobileMenuOffset() {
         $mobileMenu.attr('style', (i, attr) => {
             return attr !== `top:${headerHeight}px` ? `top:${headerHeight}px` : 'top:auto';
         });
 
         $header.attr('style', (i, attr) => {
-            return attr == 'height:100%' ? 'height:auto' : 'height:100%';
+            return attr === 'height:100%' ? 'height:auto' : 'height:100%';
         });
     }
 
     if ($mobileMenuTrigger.length) {
         mobileMenu();
     }
-
 }

--- a/assets/js/theme/global/quick-search.js
+++ b/assets/js/theme/global/quick-search.js
@@ -1,9 +1,9 @@
 import $ from 'jquery';
 import _ from 'lodash';
 import utils from 'bigcommerce/stencil-utils';
-import stencilDropDown from './stencil-dropdown'
+import stencilDropDown from './stencil-dropdown';
 
-export default function () {
+export default function() {
     const TOP_STYLING = 'top: 49px;';
 
     let $quickSearchResults = $('.quickSearchResults');
@@ -11,7 +11,7 @@ export default function () {
 
     stencilDropDown.bind($('[data-search="quickSearch"]'), $quickSearchDiv, TOP_STYLING);
 
-    //stagger searching for 200ms after last input
+    // stagger searching for 200ms after last input
     let doSearch = _.debounce((searchQuery) => {
         utils.api.search.search(searchQuery, {template: 'search/quick-results'}, (err, response) => {
             if (err) {

--- a/assets/js/theme/global/quick-view.js
+++ b/assets/js/theme/global/quick-view.js
@@ -5,7 +5,7 @@ import 'foundation/js/foundation/foundation.reveal';
 import utils from 'bigcommerce/stencil-utils';
 import ProductDetails from '../common/product-details';
 
-export default function (context) {
+export default function(context) {
     let $modal = $('#modal'),
         $modalContent = $('.modal-content', $modal),
         $modalOverlay = $('.loadingOverlay', $modal),
@@ -27,11 +27,12 @@ export default function (context) {
         // open modal
         $modal.foundation('reveal', 'open');
 
-        utils.api.product.getById(productId, {template: 'products/quick-view'}, (err, response) => {
+        utils.api.product.getById(productId, {template: 'products/quick-view'}, function done(err, response) {
             $modalOverlay.hide();
             $modalContent.html(response);
             $modalContent.find('.productView').addClass('productView--quickView');
-            new ProductDetails($modalContent, context);
+
+            return new ProductDetails($modalContent, context);
         });
     });
 

--- a/assets/js/theme/global/reveal-extension.js
+++ b/assets/js/theme/global/reveal-extension.js
@@ -2,11 +2,11 @@ import _ from 'lodash';
 import $ from 'jquery';
 
 const revealCloseAttr = 'reveal-close',
-      revealResetAttr = 'reveal-onload-reset',
-      revealAttr = 'reveal',
-      revealCloseSelector = `[data-${revealCloseAttr}]`,
-      revealResetSelector = `[data-${revealResetAttr}]`,
-      revealSelector = `[data-${revealAttr}]`;
+    revealResetAttr = 'reveal-onload-reset',
+    revealAttr = 'reveal',
+    revealCloseSelector = `[data-${revealCloseAttr}]`,
+    revealResetSelector = `[data-${revealResetAttr}]`,
+    revealSelector = `[data-${revealAttr}]`;
 
 /*
  * Extend foundation.reveal with the ability to close a modal by clicking on any of its child element
@@ -22,10 +22,9 @@ const revealCloseAttr = 'reveal-close',
  * <button data-reveal-close="helloModal">Continue</button>
  */
 export function revealClose() {
-
     function onClick(event) {
         const $target = $(event.currentTarget),
-              modalId = $target.data(_.camelCase(revealCloseAttr));
+            modalId = $target.data(_.camelCase(revealCloseAttr));
 
         let $modal;
 
@@ -44,7 +43,7 @@ export function revealClose() {
 }
 
 /*
- * Extend foundation.reveal with the ability to reset a modal's content when it opens 
+ * Extend foundation.reveal with the ability to reset a modal's content when it opens
  *
  * @example
  *
@@ -54,7 +53,6 @@ export function revealClose() {
  * </div>
  */
 export function revealReset() {
-
     function onOpen(event) {
         const $modal = $(event.currentTarget);
 
@@ -63,7 +61,7 @@ export function revealReset() {
         }
 
         const $modalContent = $('.modal-content', $modal),
-              $modalOverlay = $('.loadingOverlay', $modal);
+            $modalOverlay = $('.loadingOverlay', $modal);
 
         $modalOverlay.show();
         $modalContent.html('');

--- a/assets/js/theme/global/stencil-dropdown.js
+++ b/assets/js/theme/global/stencil-dropdown.js
@@ -42,4 +42,4 @@ export default {
             modalOpened = false;
         });
     }
-}
+};

--- a/assets/js/theme/global/toggle-menu.js
+++ b/assets/js/theme/global/toggle-menu.js
@@ -1,11 +1,8 @@
 import $ from 'jquery';
 
-export default function () {
-
+export default function() {
     const $toggleMenu = $('[data-togglemenu]');
     const $body = $('body');
-    let $targetMenuItem;
-    let targetMenuItemID;
 
     function toggleMenu() {
         $toggleMenu.on('click', menuClicked);
@@ -18,23 +15,22 @@ export default function () {
 
         closeOtherMenus();
 
-        $targetMenuItem = $(e.currentTarget);
+        let $targetMenuItem = $(e.currentTarget);
 
         if (!$targetMenuItem.hasClass('is-open')) {
             toggleThisMenu($targetMenuItem);
         }
-
     }
 
     function toggleThisMenu($targetMenuItem) {
-        targetMenuItemID = $targetMenuItem.data('togglemenu');
+        let targetMenuItemID = $targetMenuItem.data('togglemenu');
 
         $targetMenuItem.toggleClass('is-open').attr('aria-expanded', (i, attr) => {
-            return attr == 'true' ? 'false' : 'true';
+            return attr === 'true' ? 'false' : 'true';
         });
 
         $(`#${targetMenuItemID}`).toggleClass('is-open').attr('aria-hidden', (i, attr) => {
-            return attr == 'true' ? 'false' : 'true';
+            return attr === 'true' ? 'false' : 'true';
         });
     }
 
@@ -54,5 +50,4 @@ export default function () {
     if ($toggleMenu.length) {
         toggleMenu();
     }
-
 }

--- a/assets/js/theme/product.js
+++ b/assets/js/theme/product.js
@@ -3,7 +3,7 @@
  */
 import $ from 'jquery';
 import PageManager from '../page-manager';
-import Review from './product/reviews'
+import Review from './product/reviews';
 import collapsible from './common/collapsible';
 import ProductDetails from './common/product-details';
 import videoGallery from './product/video-gallery';
@@ -18,21 +18,23 @@ export default class Product extends PageManager {
         // Init collapsible
         collapsible();
 
-        new ProductDetails($('.productView'), this.context);
+        this.productDetails = new ProductDetails($('.productView'), this.context);
 
         videoGallery();
+
         let $reviewForm = classifyForm('.writeReview-form'),
             validator;
 
-        $('body').on('click', '[data-reveal-id="modal-review-form"]', function (event) {
+        $('body').on('click', '[data-reveal-id="modal-review-form"]', () => {
             validator = new Review($reviewForm).registerValidation();
         });
 
-        $reviewForm.on('submit', function (event) {
+        $reviewForm.on('submit', () => {
             if (validator) {
                 validator.performCheck();
                 return validator.areAll('valid');
             }
+
             return false;
         });
 

--- a/assets/js/theme/product/quantity.js
+++ b/assets/js/theme/product/quantity.js
@@ -1,3 +1,3 @@
-export default function (window) {
+export default function() {
 
 }

--- a/assets/js/theme/product/reviews.js
+++ b/assets/js/theme/product/reviews.js
@@ -1,6 +1,4 @@
-import $ from 'jquery';
-import nod from '../common/nod'
-import validation from '../common/form-validation';
+import nod from '../common/nod';
 
 export default class {
     constructor($reviewForm) {

--- a/assets/js/theme/product/share.js
+++ b/assets/js/theme/product/share.js
@@ -1,3 +1,3 @@
-export default function (window) {
+export default function() {
 
 }

--- a/assets/js/theme/product/video-gallery.js
+++ b/assets/js/theme/product/video-gallery.js
@@ -1,8 +1,7 @@
 import $ from 'jquery';
 
 export class VideoGallery {
-
-    constructor($element){
+    constructor($element) {
         this.$player = $element.find('[data-video-player]');
         this.$videos = $element.find('[data-video-item]');
         this.currentVideo = {};
@@ -35,9 +34,6 @@ export class VideoGallery {
     bindEvents() {
         this.$videos.on('click', this.selectNewVideo.bind(this));
     }
-
-
-
 }
 
 export default function videoGallery() {
@@ -54,5 +50,4 @@ export default function videoGallery() {
 
         $el.data(pluginKey, new VideoGallery($el));
     });
-
 }

--- a/assets/js/theme/product/wishlist.js
+++ b/assets/js/theme/product/wishlist.js
@@ -1,3 +1,3 @@
-export default function (window) {
+export default function() {
 
 }

--- a/assets/js/theme/search.js
+++ b/assets/js/theme/search.js
@@ -1,6 +1,5 @@
 import PageManager from '../page-manager';
 import FacetedSearch from './common/faceted-search';
-import jstree from 'vakata/jstree';
 import collapsible from './common/collapsible';
 
 export default class Search extends PageManager {
@@ -17,11 +16,11 @@ export default class Search extends PageManager {
 
         super();
 
-        new FacetedSearch(requestOptions, function(content) {
+        this.facetedSearch = new FacetedSearch(requestOptions, (content) => {
             $productListingContainer.html(content.productListing);
             $facetedSearchContainer.html(content.sidebar);
 
-            $("html, body").animate({
+            $('html, body').animate({
                 scrollTop: 0
             }, 100);
         });
@@ -29,12 +28,12 @@ export default class Search extends PageManager {
         // Initially hidden via JS so non JS can see it at the start
         $contentResultsContainer.addClass('u-hiddenVisually');
 
-        $('[data-product-results-toggle]').click((event) => {
+        $('[data-product-results-toggle]').click(() => {
             $productListingContainer.removeClass('u-hiddenVisually');
             $contentResultsContainer.addClass('u-hiddenVisually');
         });
 
-        $('[data-content-results-toggle]').click((event) => {
+        $('[data-content-results-toggle]').click(() => {
             $contentResultsContainer.removeClass('u-hiddenVisually');
             $productListingContainer.addClass('u-hiddenVisually');
         });
@@ -50,7 +49,7 @@ export default class Search extends PageManager {
         };
 
         if (node.state) {
-            nodeData.state.opened = node.state == 'open';
+            nodeData.state.opened = node.state === 'open';
             nodeData.children = true;
         }
 
@@ -72,18 +71,17 @@ export default class Search extends PageManager {
         collapsible();
 
         this.context.categoryTree.forEach((node) => {
-           treeData.push(this.formatCategoryTreeForJSTree(node));
+            treeData.push(this.formatCategoryTreeForJSTree(node));
         });
 
         this.categoryTreeData = treeData;
         this.createCategoryTree($categoryTreeContainer);
 
-        $searchForm.submit((event) => {
+        $searchForm.submit(() => {
             let selectedCategoryIds = $categoryTreeContainer.jstree().get_selected();
             $searchForm.find('input[name="category\[\]"]').remove();
 
             for (let categoryId of selectedCategoryIds) {
-
                 let input = $('<input>', {
                     type: 'hidden',
                     name: 'category[]',
@@ -133,7 +131,7 @@ export default class Search extends PageManager {
             checkbox: {
                 three_state: false
             },
-            plugins: [ "checkbox" ]
+            plugins: [ 'checkbox' ]
         };
 
         $container.jstree(treeOptions);

--- a/assets/js/theme/wishlist.js
+++ b/assets/js/theme/wishlist.js
@@ -19,11 +19,12 @@ export default class WishList extends PageManager {
     wishlistDeleteConfirm() {
         $('body').on('click', '[data-wishlist-delete]', (event) => {
             let confirmed = confirm(this.context.wishlistDelete);
+
             if (confirmed) {
                 return true;
             }
 
-            event.preventDefault()
+            event.preventDefault();
         });
     }
 
@@ -36,10 +37,11 @@ export default class WishList extends PageManager {
             {
                 selector: '.wishlist-form input[name="wishlistname"]',
                 validate: (cb, val) => {
-                    let result = val.length > 0;
+                    const result = val.length > 0;
+
                     cb(result);
                 },
-                errorMessage: "You must enter a wishlist name"
+                errorMessage: 'You must enter a wishlist name'
             }
         ]);
 
@@ -73,7 +75,6 @@ export default class WishList extends PageManager {
     }
 
     loaded(next) {
-
         let $addWishListForm = $('.wishlist-form');
 
         if ($addWishListForm.length) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,20 +6,20 @@ module.exports = function (config) {
 
         // frameworks to use
         // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-        frameworks: ['jspm', 'jasmine'],
+        frameworks: ['jspm', 'jasmine', 'es6-shim'],
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: ['Chrome'],
+        browsers: ['PhantomJS2'],
 
         // test results reporter to use
         // possible values: 'dots', 'progress'
         // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-        reporters: ['progress', 'verbose'],
+        reporters: ['dots'],
 
         // Continuous Integration mode
         // if true, Karma captures browsers, runs the tests and exits
-        //singleRun: true,
+        singleRun: true,
 
         // enable / disable colors in the output (reporters and logs)
         colors: true,

--- a/package.json
+++ b/package.json
@@ -2,10 +2,6 @@
   "name": "bigcommerce-storefront",
   "description": "The new Bigcommerce Storefront",
   "version": "0.0.1",
-  "scripts": {
-    "test": "",
-    "test-cov-html": ""
-  },
   "private": true,
   "dependencies": {
     "jspm": "^0.15.1"
@@ -42,15 +38,20 @@
     }
   },
   "devDependencies": {
+    "babel-eslint": "^4.1.0",
+    "es6-shim": "^0.28.1",
+    "eslint-config-airbnb": "0.0.8",
     "grunt": "^0.4.5",
     "grunt-svgstore": "^0.5.0",
     "jasmine-core": "^2.2.0",
-    "karma": "^0.12.31",
-    "karma-babel-preprocessor": "^4.0.1",
+    "karma": "^0.13.9",
+    "karma-babel-preprocessor": "^5.2.1",
     "karma-chrome-launcher": "^0.1.7",
     "karma-coverage": "^0.2.7",
+    "karma-es6-shim": "^0.1.3",
     "karma-jasmine": "^0.3.5",
     "karma-jspm": "^1.1.4",
+    "karma-phantomjs2-launcher": "^0.3.2",
     "karma-verbose-reporter": "0.0.2",
     "load-grunt-config": "^0.17.1",
     "time-grunt": "^1.2.1"


### PR DESCRIPTION
Fix JS lint errors based on Airbnb styleguide (eslint-config-airbnb)

As you can see in `.eslintrc`, I cheated a bit by removing some of the rules, just to keep the ball rolling. However, there are some rules which I believe we should restore, unless we collectively decide not to. These include:

`comma-dangle`
`no-use-before-define`
`no-param-reassign`
`no-shadow`
`one-var`
`prefer-const`
`func-names`
`consistent-return`

@meenie @haubc @mickr @mcampa @hegrec 
