### PR TITLE
Shipping estimate breaks with cart quantity updates

### DIFF
--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -13,9 +13,6 @@ export default class Cart extends PageManager {
 
         this.bindEvents();
 
-        // initiate shipping estimator module
-        this.shippingEstimator = new ShippingEstimator($('[data-shipping-estimator]'));
-
         next();
     }
 
@@ -264,5 +261,8 @@ export default class Cart extends PageManager {
         this.bindPromoCodeEvents();
         this.bindGiftWrappingEvents();
         this.bindGiftCertificateEvents();
+        
+        // initiate shipping estimator module
+        this.shippingEstimator = new ShippingEstimator($('[data-shipping-estimator]'));
     }
 }


### PR DESCRIPTION
When cart quantity is changed the "Add info" link to get shipping quote is broken.

https://jira.bigcommerce.com/browse/BIG-21781

@hegrec @mickr @haubc 
