### PR TITLE
BIG-21305: Make cart dropdown follow cart button

### DIFF
--- a/assets/scss/components/stencil/navUser/_navUser.scss
+++ b/assets/scss/components/stencil/navUser/_navUser.scss
@@ -113,9 +113,11 @@
 
 .navUser-item--cart {
     display: block;
+    position: relative;
 
     .dropdown-menu {
         max-width: 300px;
+        width: 300px;
     }
 
     .dropdown-menu.is-open {


### PR DESCRIPTION
BIG-21305: Make cart dropdown follow cart button

This keeps the dropdown in the right spot when window size changes
