### PR TITLE
BIG-22032: Fix cart discounts number display

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -54,6 +54,7 @@
         "label": "Your Cart ({quantity, plural, one {# item} other {# items}})",
         "is_empty": "Your cart is empty",
         "coupon_code": "Coupon Code",
+        "discount": "Discount",
         "gift_certificate": "Gift Certificate",
         "remove_file": "Remove this file",
         "freeshipping": "Free Shipping",

--- a/templates/components/cart/coupon-input.html
+++ b/templates/components/cart/coupon-input.html
@@ -1,10 +1,7 @@
 <div class="cart-total-value">
 
-    {{#compare cart.discount 0 operator='>'}}
-        <a href="#">{{cart.discount.formatted}}</a>
-    {{else}}
-        <button class="coupon-code-add">{{lang 'cart.coupons.add_coupon'}}</button>
-    {{/compare}}
+
+    <button class="coupon-code-add">{{lang 'cart.coupons.add_coupon'}}</button>
 
     <button class="coupon-code-cancel" style="display: none;">{{lang 'cart.coupons.cancel'}}</button>
 </div>

--- a/templates/components/cart/totals.html
+++ b/templates/components/cart/totals.html
@@ -7,6 +7,16 @@
             <span>{{cart.sub_total.formatted}}</span>
         </div>
     </li>
+    {{#if cart.discount}}
+        <li class="cart-total">
+            <div class="cart-total-label">
+                <strong>{{lang 'cart.discount'}}:</strong>
+            </div>
+            <div class="cart-total-value">
+                {{cart.discount.formatted}}
+            </div>
+        </li>
+    {{/if}}
     {{#if cart.coupons}}
         {{#each cart.coupons}}
             <li class="cart-total">


### PR DESCRIPTION
BIG-22032: Fix cart discounts number display

This pulls discounts out of the coupon input and displays them just below the subtotal. This allows people to enter coupons on a discounted order just like they can on blueprint.

@mcampa 
