### PR TITLE
BIG-19976 Fix inventory levels not showing

### DIFF
--- a/assets/scss/components/citadel/forms/_forms.scss
+++ b/assets/scss/components/citadel/forms/_forms.scss
@@ -155,10 +155,6 @@
     width: 4.5rem;
 }
 
-.form-field--stock {
-    display: none;
-}
-
 .form-file {
     margin-bottom: spacing("third");
 }

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -206,7 +206,7 @@
                     </div>
                 {{/if}}
 
-                <div class="form-field form-field--stock">
+                <div class="form-field form-field--stock{{#unless product.stock_level}} u-hiddenVisually{{/unless}}">
                     <label class="form-label form-label--alternate">{{lang 'products.current_stock'}}</label>
                     <span data-product-stock>{{product.stock_level}}</span>
                 </div>


### PR DESCRIPTION
When stock level is present, show it, otherwise hide the elements because clicking on a different product option/variant can show the stock level.
