### PR TITLE
BIG-21941 Firefox bug fix

### DIFF
--- a/assets/scss/components/stencil/account/_account.scss
+++ b/assets/scss/components/stencil/account/_account.scss
@@ -26,6 +26,10 @@
     border-bottom: container("border");
     padding: spacing("single") 0;
     position: relative;
+
+    img {
+        width: 100%;
+    }
 }
 
 .account-listShipping {

--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -69,6 +69,10 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
     display: block; // 1
     padding: $cart-item-spacing 0;
 
+    img {
+        width: 100%;
+    }
+
     @include breakpoint("small") {
         @include clearfix;
         padding-left: grid-calc(3, $total-columns);

--- a/templates/components/common/cart-preview.html
+++ b/templates/components/common/cart-preview.html
@@ -4,7 +4,11 @@
             {{#each cart.items}}
                 <li class="previewCartItem">
                     <div class="previewCartItem-image">
-                        <img src="{{getImage image 'thumb' (cdn ../theme_settings.default_image_product)}}" alt="{{image.alt}}" />
+                        {{#if type '==' 'GiftCertificate'}}
+                            <img src="{{cdn ../../theme_settings.default_image_gift_certificate}}" alt="GiftCertificate">
+                        {{else}}
+                            <img src="{{getImage image 'thumb' (cdn ../theme_settings.default_image_product)}}" alt="{{image.alt}}">
+                        {{/if}}
                     </div>
 
                     <div class="previewCartItem-content">


### PR DESCRIPTION
https://jira.bigcommerce.com/browse/BIG-21941
Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=975632

Plus, added giftcertificate image to the cart preview.

Order details:
![image](https://cloud.githubusercontent.com/assets/1934727/9888267/ee4b1250-5ba8-11e5-93e9-76d4d36b6c4a.png)

Cart Preview:
![image](https://cloud.githubusercontent.com/assets/1934727/9888287/0d08d3f8-5ba9-11e5-8959-8a7ae0cbdba4.png)

Cart Content:
![image](https://cloud.githubusercontent.com/assets/1934727/9888298/153d56d4-5ba9-11e5-82d6-9f42f9d325bf.png)

@SiTaggart @hegrec @bc-miko-ademagic @mickr 
