### PR TITLE
BIG-21304: Add Fast Click library

### DIFF
--- a/assets/config.js
+++ b/assets/config.js
@@ -25,6 +25,7 @@ System.config({
     "casperin/nod": "github:casperin/nod@2.0.10",
     "core-js": "npm:core-js@0.9.18",
     "foundation": "github:bigcommerce-labs/foundation@5.5.3",
+    "ftlabs/fastclick": "github:ftlabs/fastclick@1.0.6",
     "hubspot/pace": "github:hubspot/pace@1.0.2",
     "jackmoore/zoom": "github:jackmoore/zoom@1.7.14",
     "jquery": "github:components/jquery@2.1.4",

--- a/assets/js/theme/global.js
+++ b/assets/js/theme/global.js
@@ -12,6 +12,7 @@ import maintenanceMode from './global/maintenanceMode';
 import carousel from './common/carousel';
 import loadingProgressBar from './global/loading-progress-bar';
 import {revealClose, revealReset} from './global/reveal-extension';
+import FastClick from 'ftlabs/fastclick';
 
 export default class Global extends PageManager {
     constructor() {
@@ -24,6 +25,7 @@ export default class Global extends PageManager {
      * @param next
      */
     loaded(next) {
+        new FastClick(document.body);
         quickSearch();
         currencySelector();
         foundation();

--- a/assets/js/theme/global/stencil-dropdown.js
+++ b/assets/js/theme/global/stencil-dropdown.js
@@ -5,7 +5,7 @@ export default {
         if (style) {
             $dropDown.attr('style', style);
         }
-
+        $('#search_query').blur();
         $dropDown.removeClass('is-open f-open-dropdown').attr('aria-hidden', 'true');
     },
     show($dropDown, event, style) {
@@ -21,6 +21,11 @@ export default {
         let modalOpened = false;
 
         $dropDownTrigger.on('click', (event) => {
+            let $cart = $('.is-open[data-cart-preview]');
+            if ($cart) {
+                $cart.click();
+            }
+            
             $container.hasClass('is-open') ? this.hide($container) : this.show($container, event, style);
         });
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -122,6 +122,7 @@
         "required": "Required",
         "email_address": "Email Address",
         "edit": "Edit",
+        "not_applicable": "N/A",
         "no": "No",
         "yes": "Yes",
         "from": "From",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
       "caolan/async": "github:caolan/async@^0.9.2",
       "casperin/nod": "github:casperin/nod@^2.0.10",
       "foundation": "github:bigcommerce-labs/foundation@^5.5.3",
+      "ftlabs/fastclick": "github:ftlabs/fastclick@^1.0.6",
       "hubspot/pace": "github:hubspot/pace@^1.0.2",
       "jackmoore/zoom": "github:jackmoore/zoom@^1.7.14",
       "jquery": "github:components/jquery@^2.1.3",


### PR DESCRIPTION
BIG-21304: Add Fast Click library

This fixes a lot of the mobile issues because most touch screen devices won't listen on click events unless the target is a "clickable" element such as an anchor. This library will polyfill in the use of click handling for mobile devices using their native "touchstart" and "touchend" events. The result is every custom click handler we have now works on mobile devices, and tapping elements on mobile devices is about 200-300ms faster to respond.
