### PR TITLE
BIG-21992

### DIFF
--- a/templates/pages/gift-certificate/balance.html
+++ b/templates/pages/gift-certificate/balance.html
@@ -23,7 +23,6 @@
         <input type="hidden" name="action" value="balance">
         <div class="form-field">
             <label class="form-label" for="giftcertificatecode">
-                <small>{{lang 'common.required' }}</small>
                 {{lang 'forms.gift_certificate.balance.code' }}
             </label>
             <div class="form-prefixPostfix nowrap">


### PR DESCRIPTION
Removing the required label as a simpler and better UX choice. It's 1 field, it is required by default.

@hegrec 
