### PR TITLE
QuickFix - Custom fields can contain HTML that shouldn't be escaped.

### DIFF
--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -131,7 +131,7 @@
 
                 {{#each product.custom_fields}}
                     <dt class="productView-info-name">{{name}}:</dt>
-                    <dd class="productView-info-value">{{value}}</dd>
+                    <dd class="productView-info-value">{{{value}}}</dd>
                 {{/each}}
             </dl>
         </div>


### PR DESCRIPTION
QuickFix - Custom fields can contain HTML that shouldn't be escaped.
