### PR TITLE
WIP: BIG-22605

### DIFF
--- a/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
+++ b/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
@@ -29,6 +29,10 @@
         opacity: 1;
     }
 
+    .slick-track {
+        perspective: 1000;
+    }
+
     .slick-next,
     .slick-prev {
         top: 20%;
@@ -76,6 +80,7 @@
 .heroCarousel-image {
     @include breakpoint("medium") { // 1
         visibility: hidden;
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
Don't merge this yet. Waiting to hear if we truly want to apply this or not from the J-man.

A solution to the cropped images is to show the full image at max-width. Also includes a fix to tall slides in chrome "perspective: 1000" removes bizarre translate3d flash of white.
