### PR TITLE
Always show shop by price widget

### DIFF
--- a/templates/components/category/sidebar.html
+++ b/templates/components/category/sidebar.html
@@ -15,8 +15,6 @@
     {{#if category.faceted_search_enabled}}
         {{> components/faceted-search/index category}}
     {{else}}
-        {{#if category.products.length '>' 0}}
-            {{> components/category/shop-by-price shop_by_price=category.shop_by_price category_url=category.url}}
-        {{/if}}
+        {{> components/category/shop-by-price shop_by_price=category.shop_by_price category_url=category.url}}
     {{/if}}
 </nav>


### PR DESCRIPTION
Not quite sure why I added that check around the widget in the first place..Removing it now so that navigation is possible when there are no results for a selected price range.
