### PR TITLE
BIG-22796: Star ratings config

### DIFF
--- a/assets/scss/components/citadel/icons/_icons.scss
+++ b/assets/scss/components/citadel/icons/_icons.scss
@@ -8,14 +8,14 @@
     display: none; // 1
 }
 
-.icon--starEmpty {
+.icon--ratingEmpty {
     svg {
-        fill: $icon--starEmpty;
+        fill: stencilColor("icon-ratingEmpty");
     }
 }
 
-.icon--starFull {
+.icon--ratingFull {
     svg {
-        fill: $icon--starFull;
+        fill: stencilColor("icon-ratingFull");
     }
 }

--- a/assets/scss/settings/citadel/icons/_settings.scss
+++ b/assets/scss/settings/citadel/icons/_settings.scss
@@ -7,6 +7,3 @@ $exportCSS--icons:              true;
 
 $icon-color:                    color("greys", "darker");
 $icon-size:                     16px;
-
-$icon--starEmpty:               stencilColor("starRating-empty");
-$icon--starFull:                stencilColor("starRating-full");

--- a/config.json
+++ b/config.json
@@ -156,8 +156,8 @@
     "carousel-arrow-color": "#989898",
     "carousel-arrow-bgColor": "#ffffff",
 
-    "starRating-empty": "#dfdfdf",
-    "starRating-full": "#454545",
+    "icon-ratingEmpty": "#dfdfdf",
+    "icon-ratingFull": "#454545",
 
     "fontFamily-sans": "Karla, sans-serif",
     "fontFamily-serif": "Georgia, serif",
@@ -321,8 +321,8 @@
         "fontFamily-sans": "'Source Sans Pro', sans-serif",
         "fontFamily-headings": "'Roboto', sans-serif",
 
-        "starRating-empty": "#696969",
-        "starRating-full": "#7fc0c2"
+        "icon-ratingEmpty": "#696969",
+        "icon-ratingFull": "#7fc0c2"
       }
     },
     {

--- a/templates/components/products/ratings.html
+++ b/templates/components/products/ratings.html
@@ -1,12 +1,12 @@
 {{#for 1 5}}
     {{#if ../this.rating '>=' $index}}
-        <span class="icon icon--starFull">
+        <span class="icon icon--ratingFull">
             <svg>
                 <use xlink:href="#icon-star" />
             </svg>
         </span>
     {{else}}
-        <span class="icon icon--starEmpty">
+        <span class="icon icon--ratingEmpty">
             <svg>
                 <use xlink:href="#icon-star" />
             </svg>


### PR DESCRIPTION
Adding config for star rating colours. This fixes and allows variants to customise the star ratings background colors per variant. More granular control to theme better.

@SiTaggart @bc-miko-ademagic 

If you guys have any better naming than empty/full stars let me know. I don't like them very much but have no clue what else I could call them
