### PR TITLE
No html5 validation on reset password

### DIFF
--- a/templates/pages/auth/forgot-password.html
+++ b/templates/pages/auth/forgot-password.html
@@ -9,7 +9,7 @@
         <form action="{{urls.auth.send_password_email}}" class="form forgot-password-form" method="post">
             <label class="form-label" for="email">{{lang 'common.email_address'}}</label>
             <div class="form-prefixPostfix nowrap">
-                <input class="form-input" name="email" id="email" type="email">
+                <input class="form-input" name="email" id="email" type="email" formnovalidate>
                 <input type="submit" class="button button--primary form-prefixPostfix-button--postfix" value="{{lang 'reset_password.heading' }}">
             </div>
         </form>


### PR DESCRIPTION
Allow nod to be the sole validator
