### PR TITLE
BIG-22439: Fix quick search error message

### DIFF
--- a/assets/scss/components/stencil/search/_search.scss
+++ b/assets/scss/components/stencil/search/_search.scss
@@ -67,3 +67,9 @@
 .search-refine {
     margin-left: spacing("single");
 }
+
+.quickSearchMessage {
+    font-size: fontSize("largest");
+    margin: spacing("single") 0 0;
+    text-align: center;
+}

--- a/templates/components/search/quick-results.html
+++ b/templates/components/search/quick-results.html
@@ -8,7 +8,7 @@
         {{/each}}
     </ul>
 {{else}}
-    <h1 class="page-heading">
-        {{lang 'search.results.count' num_products=pagination.product_results.total search_query=forms.search.query}}
-    </h1>
+    <p class="quickSearchMessage">
+        {{lang 'search.results.count' count=pagination.product_results.total search_query=forms.search.query}}
+    </p>
 {{/if}}


### PR DESCRIPTION
Previously, when there's no search result, the server returns 500 because the template references a missing variable. This means the error message isn't shown and previously search results aren't getting cleared. It is now fixed.

<img width="533" alt="screen shot 2015-12-04 at 9 13 18 am" src="https://cloud.githubusercontent.com/assets/667603/11575853/5ee592f4-9a67-11e5-9faa-c0d54b959727.png">

@bc-chris-roper
