### PR TITLE
BIG-24642: Fix flicker in carousel when switching to new slide

### DIFF
--- a/assets/scss/components/vendor/slick/_slick.scss
+++ b/assets/scss/components/vendor/slick/_slick.scss
@@ -12,6 +12,8 @@
 // Purpose: Override the plugin to give some Stencil styling to the js generated mark-up
 //
 // 1. Set the background again because the plugin sets the full background property on hover
+// 2. Prevent screen flicker when CSS transition is applied
+//
 // -----------------------------------------------------------------------------
 
 .slick-next,
@@ -143,4 +145,13 @@
 .slick-disabled {
     cursor: $cursor-default-value;
     opacity: 0.1;
+}
+
+
+//
+// Slick track
+// -----------------------------------------------------------------------------
+.slick-track {
+    backface-visibility: hidden; // 2
+    perspective: 1000px; // 2
 }


### PR DESCRIPTION
I remember it was fixed previously by roper. But I couldn't find the fix anymore. Anyway, `slick-track` is the element that has `translated3d` applied by slick.js.

@bc-chris-roper @bc-miko-ademagic 
