### PR TITLE
BIG-22656: Forgot password spacing on mobile

### DIFF
--- a/assets/scss/components/citadel/forms/_forms.scss
+++ b/assets/scss/components/citadel/forms/_forms.scss
@@ -181,10 +181,38 @@
     }
 }
 
-//TODO This probably needs to be changed in Citadel BIG-20499
-.form-prefixPostfix.nowrap {
-    flex-wrap: wrap;
+.form-prefixPostfix {
+    display: block;
+
+    @include breakpoint("small") {
+        display: flex;
+    }
+
+    //TODO This probably needs to be changed in Citadel BIG-20499
+    &.nowrap {
+        flex-wrap: wrap;
+    }
+
+    // scss-lint:disable NestingDepth, SelectorDepth
+    .form-input,
+    .button {
+        display: block;
+        width: 100%;
+
+        @include breakpoint("small") {
+            width: auto;
+        }
+    }
+
+    .button {
+        margin: spacing("half") 0 0;
+
+        @include breakpoint("small") {
+            margin: 0 0 0 spacing("half");
+        }
+    }
 }
+
 
 // Increment field
 // -----------------------------------------------------------------------------

--- a/assets/scss/layouts/footer/_footer.scss
+++ b/assets/scss/layouts/footer/_footer.scss
@@ -49,33 +49,6 @@
     > :last-child {
         margin-bottom: 0;
     }
-
-    .form-prefixPostfix {
-        display: block;
-
-        @include breakpoint("small") {
-            display: flex;
-        }
-
-        // scss-lint:disable NestingDepth, SelectorDepth
-        .form-input,
-        .button {
-            display: block;
-            width: 100%;
-
-            @include breakpoint("small") {
-                width: auto;
-            }
-        }
-
-        .button {
-            margin: spacing("half") 0 0;
-
-            @include breakpoint("small") {
-                margin: 0 0 0 spacing("half");
-            }
-        }
-    }
 }
 
 .footer-info-col--small {


### PR DESCRIPTION
Updating the prefixPostfix styling to have global `display: block` items for mobile screens, which were currently tied to the footer class only, causing Forgot Password's form/use of the class to not be treated for mobile.

Moved code from footer to forms styling.

@davidchin @bc-miko-ademagic 
