### PR TITLE
Disable accordions on desktop

### DIFF
--- a/assets/scss/components/foundation/accordion/_accordion.scss
+++ b/assets/scss/components/foundation/accordion/_accordion.scss
@@ -84,6 +84,10 @@
 
     .accordion-indicator {
         fill: color("greys", "light");
+
+        @include breakpoint("medium") {
+            visibility: hidden;
+        }
     }
 
     .accordion-navigation-actions {


### PR DESCRIPTION
Must refire the open method because the toggle code doesn't allow intercepting and preventing default actions.
