### PR TITLE
BIG-24685 Render HTML for down for maintenance page

### DIFF
--- a/templates/pages/unavailable/maintenance.html
+++ b/templates/pages/unavailable/maintenance.html
@@ -7,7 +7,7 @@
         <header>
             <h1>{{lang 'maintenance.down'}}</h1>
         </header>
-        <section><p>{{settings.maintenance.message}}</p></section>
+        <section><p>{{{settings.maintenance.message}}}</p></section>
         <section></section>
         <footer><small></small></footer>
     </main>


### PR DESCRIPTION
@hegrec 

renders all html, even unsafe strings, but that's up to the merchant's input.
# before

![screen shot 2015-12-14 at 2 02 47 pm](https://cloud.githubusercontent.com/assets/8482478/11795548/19bd8daa-a26c-11e5-9038-82a1fc98942c.png)
# after

![screen shot 2015-12-14 at 2 07 13 pm](https://cloud.githubusercontent.com/assets/8482478/11795549/1d7fa2d4-a26c-11e5-9353-d2c1d06d4640.png)
