### PR TITLE
Improve colour contrast by slighly darken border colour

### DIFF
--- a/config.json
+++ b/config.json
@@ -52,11 +52,11 @@
     "color-primaryLight": "#a5a5a5",
 
     "color-secondary": "#ffffff",
-    "color-secondaryDark": "#f2f2f2",
-    "color-secondaryDarker": "#f2f2f2",
+    "color-secondaryDark": "#e8e8e8",
+    "color-secondaryDarker": "#e8e8e8",
 
     "color-highlight": "#00abc9",
-    "color-highlightDark": "#f2f2f2",
+    "color-highlightDark": "#e8e8e8",
     "color-highlightDarker": "#dfdfdf",
 
     "color-error": "#ff7d7d",
@@ -90,7 +90,7 @@
     "color-greyMedium": "#989898",
     "color-greyLight": "#a5a5a5",
     "color-greyLighter": "#dfdfdf",
-    "color-greyLightest": "#f2f2f2",
+    "color-greyLightest": "#e8e8e8",
 
     "alert-color": "#4f4f4f",
     "alert-color-alt": "#ffffff",
@@ -134,7 +134,7 @@
     "button--primary-borderColorHover": "#666666",
     "button--primary-borderColorActive": "#989898",
 
-    "container-border-global-color-base": "#f2f2f2",
+    "container-border-global-color-base": "#e8e8e8",
     "container-border-global-color-dark": "#454545",
     "container-fill-base": "#ffffff",
     "container-fill-dark": "#f2f2f2",
@@ -153,13 +153,13 @@
     "navList-action-color": "#4f4f4f",
 
     "navUser-dropdown-backgroundColor": "#ffffff",
-    "navUser-dropdown-borderColor": "f2f2f2",
+    "navUser-dropdown-borderColor": "#e8e8e8",
     "navUser-indicator-backgroundColor": "#4f4f4f",
 
-    "dropdown--quickSearch-backgroundColor": "#f2f2f2",
+    "dropdown--quickSearch-backgroundColor": "#e8e8e8",
 
     "input-font-color": "#454545",
-    "input-border-color": "#f2f2f2",
+    "input-border-color": "#dfdfdf",
     "input-border-color-active": "#989898",
     "input-bg-color": "#ffffff",
     "input-disabled-bg": "#ffffff",


### PR DESCRIPTION
Darken the border colour of input fields and containers slightly (look closer to the Sketch file).

<img width="861" alt="screen shot 2015-12-15 at 12 24 38 pm" src="https://cloud.githubusercontent.com/assets/667603/11799424/0d7b1cb2-a328-11e5-9eaa-7eff70352beb.png">

@bc-chris-roper 
