### PR TITLE
BIG-21501 - EU Cookie warning

### DIFF
--- a/assets/js/theme/global/cookieNotification.js
+++ b/assets/js/theme/global/cookieNotification.js
@@ -22,6 +22,9 @@ export default function() {
         const $privacyDialog = $('.cookieMessage');
         $privacyDialog.show();
 
-        $('body').on('click', '[data-privacy-accept]', () => $privacyDialog.hide());
+        $('body').on('click', '[data-privacy-accept]', () => {
+            utils.hooks.emit('cookie-privacy-accepted');
+            $privacyDialog.hide();
+        });
     });
 }


### PR DESCRIPTION
BIG-21501 - EU Cookie warning

https://github.com/bigcommerce/stencil-utils/pull/49

Updating functionality so the cookie is not automatically set and will only be set once the warning has been accepted. The cookie warning will be shown until the terms are accpeted. Once they are accepted, an event will fire back to stencil-utils. This will then set the cookie and  the message will be dismissed.
- Implemented event emitter that will emit when the cookie is accepted.
