### PR TITLE
BIG-24060: Set the price of the stencil master theme to 0.

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,8 +1,8 @@
 {
   "name": "Stencil",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "meta": {
-    "price": 15000,
+    "price": 0,
     "documentation_url": "https://docs.bigcommerce.com/stencil.html",
     "composed_image": "composed_image.png",
     "features": [


### PR DESCRIPTION
In order for the stencil master theme to be set on newly created stores,
a "purchase" will need to be initiated. When the price of a theme is
greater than 0, we will require a valid stripe token.

This change will also allow existing merchants to "purchase" the master
theme without requiring a credit card.

ping @junedkazi @mattolson @hegrec @mickr
