### PR TITLE
BIG-24974 Fix checkout button not showing up when payment is not setup

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -30,6 +30,7 @@
         "no_products": "There are no products listed under this category."
     },
     "cart": {
+        "continue_shopping": "Click here to continue shopping",
         "items": "{NUM, plural, =0{(0 items)} one {(# item)} other {(# items)}}",
         "checkout": {
             "address": {

--- a/templates/components/cart/preview.html
+++ b/templates/components/cart/preview.html
@@ -7,9 +7,11 @@
 <div class="modal-body">
     <div class="previewCart">
         <section class="previewCartCheckout">
-            <a href="{{urls.checkout.single_address}}" class="button button--primary">
-                {{lang 'cart.added_to_cart.proceed_to_checkout'}}
-            </a>
+            {{#if cart.show_primary_checkout_button}}
+                <a href="{{urls.checkout.single_address}}" class="button button--primary">
+                    {{lang 'cart.added_to_cart.proceed_to_checkout'}}
+                </a>
+            {{/if}}
 
             <div class="previewCartCheckout-additionalCheckoutButtons">
                 {{#each cart.additional_checkout_buttons}}

--- a/templates/components/common/cart-preview.html
+++ b/templates/components/common/cart-preview.html
@@ -31,11 +31,13 @@
             {{/each}}
         </ul>
         <div class="previewCartAction">
-            <div class="previewCartAction-checkout">
-                <a href="{{urls.checkout.single_address}}" class="button button--small button--primary">
-                    {{lang 'cart.preview.checkout_now'}}
-                </a>
-            </div>
+            {{#if cart.show_primary_checkout_button}}
+                <div class="previewCartAction-checkout">
+                    <a href="{{urls.checkout.single_address}}" class="button button--small button--primary">
+                        {{lang 'cart.preview.checkout_now'}}
+                    </a>
+                </div>
+            {{/if}}
 
             <div class="previewCartAction-viewCart">
                 <a href="{{urls.cart}}" class="button button--small button--action">

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -21,11 +21,15 @@
                 {{> components/cart/totals}}
             </div>
 
-
-
-            <div class="cart-actions">
-                <a class="button button--primary" href="{{urls.checkout.single_address}}" title="{{lang 'cart.checkout.title'}}">{{lang 'cart.checkout.button'}}</a>
-            </div>
+            {{#if cart.show_primary_checkout_button}}
+                <div class="cart-actions">
+                    <a class="button button--primary" href="{{urls.checkout.single_address}}" title="{{lang 'cart.checkout.title'}}">{{lang 'cart.checkout.button'}}</a>
+                </div>
+            {{else}}
+                <div class="cart-actions">
+                    <a class="button" href="{{urls.home}}" title="{{lang 'cart.continue_shopping'}}">{{lang 'cart.continue_shopping'}}</a>
+                </div>
+            {{/if}}
 
             {{#if cart.additional_checkout_buttons}}
                 <div class="cart-additionalCheckoutButtons">


### PR DESCRIPTION
Fixed three places that has checkout buttons:
- Quickview after adding item to cart
- Cart preview dropdown (top of page)
- Cart page
