### PR TITLE
BIG-25097 - Add Relevance as a sort option

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -162,6 +162,7 @@
         "previous": "Previous",
         "next": "Next",
         "sorter": {
+            "relevance": "Relevance",
             "sort_by": "Sort By:",
             "featured": "Featured Items",
             "top_sellers": "Best Selling",

--- a/templates/components/category/sort-box.html
+++ b/templates/components/category/sort-box.html
@@ -10,6 +10,9 @@
             <option value="avgcustomerreview" {{#if sort '==' 'avgcustomerreview'}}selected{{/if}}>{{lang 'common.sorter.reviews'}}</option>
             <option value="priceasc" {{#if sort '==' 'priceasc'}}selected{{/if}}>{{lang 'common.sorter.price_asc'}}</option>
             <option value="pricedesc" {{#if sort '==' 'pricedesc'}}selected{{/if}}>{{lang 'common.sorter.price_desc'}}</option>
+            {{#if template_file '==' 'pages/search'}}
+                <option value="relevance" {{#if sort '==' 'relevance'}}selected{{/if}}>{{lang 'common.sorter.relevance'}}</option>
+            {{/if}}
         </select>
     </div>
 </fieldset>


### PR DESCRIPTION
BIG-25097 - Add Relevance as a sort option
### What

Added `Relevance` as a sort option that will only appear on the search page.
### Why

`Relevance` is the default sort option on the search results page and it was missing.
