### PR TITLE
BIG-25186: ActionBar form-field bg color and accordion bg color

### DIFF
--- a/assets/scss/components/citadel/actionBar/_actionBar.scss
+++ b/assets/scss/components/citadel/actionBar/_actionBar.scss
@@ -6,6 +6,7 @@
 .actionBar-section {
 
     .form-field {
+        background-color: $input-bg-color;
         border: $actionBar-form-field-border;
         border-radius: $actionBar-form-field-radius;
         overflow: hidden;

--- a/assets/scss/settings/foundation/accordion/_settings.scss
+++ b/assets/scss/settings/foundation/accordion/_settings.scss
@@ -58,7 +58,7 @@ $accordion-navigation-font-size:                fontSize("base");
 $accordion-navigation-font-family:              fontFamily("sans");
 
 $accordion-content-padding:                     container("padding", "large");
-$accordion-content-active-bg-color:             container("fill");
+$accordion-content-active-bg-color:             null;
 
 
 // Stencil Variables


### PR DESCRIPTION
1) Remove the background on accordion backgrounds for the themes.
2) Adding the background color to the actionbar's form-field class so the selects look correct.

@SiTaggart 
