### PR TITLE
Bind events once and scope them accordingly

### DIFF
--- a/assets/js/theme/global/quick-view.js
+++ b/assets/js/theme/global/quick-view.js
@@ -20,7 +20,7 @@ export default function(context) {
 
             modal.$content.find('.productView').addClass('productView--quickView');
 
-            return new ProductDetails(modal.$content, context);
+            return new ProductDetails(modal.$content.find('.quickView'), context);
         });
     });
 }


### PR DESCRIPTION
Stencil Utils Events need to be bound once and be rescoped to the single active product details instance. 

Also rescoping the DOM selector passed into the ProductDetails for the Quick View to ensure that the stencil theme based quantity event is scoped to the removable modal content and will only associate with a given ProductDetails instance.
