### PR TITLE
BIG-23188 - Reorder items should not be added to hidden fields for re-order

### DIFF
--- a/assets/js/theme/common/form-utils.js
+++ b/assets/js/theme/common/form-utils.js
@@ -259,10 +259,6 @@ const Validators = {
         });
     },
 
-    phoneNumberValidation: (validator, selectors) => {
-
-    },
-
     /**
      * Sets up a new validation when the form is dirty
      * @param validator


### PR DESCRIPTION
BIG-23188 - Reorder items should not be added to hidden fields for re-order
- Added logic that will not allow a hidden field used for re-ordering to be injected into the dom during compilation.
- Could not reproduce initial bug on VM, even after altering the dom and forcing a product that should not be able to be ordered into a valid order state.

@hegrec 
