### PR TITLE
BIG-25249: Down for maintenance notices

### DIFF
--- a/assets/scss/components/stencil/maintenanceNotice/_maintenanceNotice.scss
+++ b/assets/scss/components/stencil/maintenanceNotice/_maintenanceNotice.scss
@@ -5,6 +5,7 @@
 .maintenanceNotice {
     background-color: $maintenanceNotice-backgroundColor;
     box-shadow: $maintenanceNotice-box-shadow;
+    color: $maintenanceNotice-color;
     left: $maintenanceNotice-left;
     padding: $maintenanceNotice-padding;
     position: fixed;
@@ -14,6 +15,10 @@
 
     > :last-child {
         margin-bottom: 0;
+    }
+
+    a {
+        color: $maintenanceNotice-color;
     }
 }
 

--- a/assets/scss/settings/stencil/maintenanceNotice/_settings.scss
+++ b/assets/scss/settings/stencil/maintenanceNotice/_settings.scss
@@ -5,6 +5,7 @@
 
 $maintenanceNotice-backgroundColor:     color("warning", "light");
 $maintenanceNotice-box-shadow:          0 0 5px color("greys", "light");
+$maintenanceNotice-color:               color("greys", "darker");
 $maintenanceNotice-left:                spacing("half") + spacing("quarter");
 $maintenanceNotice-padding:             spacing("base") (spacing("base") + spacing("fifth"));
 $maintenanceNotice-top:                 spacing("half") + spacing("quarter");


### PR DESCRIPTION
Adding a text and link color to the down for maintenance notices. Basically to ensure they're visible and legible. Not something that needs to be added to schema or config.

@bc-miko-ademagic 
