### PR TITLE
BIG-25339 - Add explicit base_url to urls that should not be relative.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -464,7 +464,7 @@
             "captcha_desc": "Please copy the characters from the image into the text field below. Doing this helps us prevent automated submissions.",
             "question": "Comments/Questions",
             "submit": "Submit Form",
-            "successful": "We've received your feedback and will respond shortly if required. <a href=\"{shopPath}\">Continue</a>."
+            "successful": "We've received your feedback and will respond shortly if required. <a href=\"{basePath}{shopPath}\">Continue</a>."
         },
         "create_account": {
             "submit_value": "Create Account"

--- a/templates/components/common/navigation.html
+++ b/templates/components/common/navigation.html
@@ -16,14 +16,14 @@
             </li>
         {{/if}}
         <li class="navUser-item">
-            <a class="navUser-action navUser-item--compare" href="{{urls.compare}}" data-compare-nav>{{lang 'common.compare'}} <span class="countPill countPill--positive countPill--alt"></span></a>
+            <a class="navUser-action navUser-item--compare" href="{{settings.base_url}}{{urls.compare}}" data-compare-nav>{{lang 'common.compare'}} <span class="countPill countPill--positive countPill--alt"></span></a>
         </li>
         <li class="navUser-item">
             <a class="navUser-action navUser-action--quickSearch" href="#" data-search="quickSearch" aria-controls="quickSearch" aria-expanded="false">{{lang 'common.search'}}</a>
         </li>
         {{#if settings.gift_certificates_enabled}}
             <li class="navUser-item">
-                <a class="navUser-action" href="{{urls.gift_certificate.purchase}}">{{lang 'common.gift_cert'}}</a>
+                <a class="navUser-action" href="{{settings.base_url}}{{urls.gift_certificate.purchase}}">{{lang 'common.gift_cert'}}</a>
             </li>
         {{/if}}
         {{#if settings.account_creation_enabled}}

--- a/templates/components/common/store-logo.html
+++ b/templates/components/common/store-logo.html
@@ -1,4 +1,4 @@
-<a href="{{urls.home}}">
+<a href="{{settings.base_url}}{{urls.home}}">
     {{#if settings.store_logo.image}}
         <img class="header-logo-image" src="{{getImage settings.store_logo.image 'logo'}}" alt="{{settings.store_logo.title}}">
     {{else}}

--- a/templates/pages/auth/account-created.html
+++ b/templates/pages/auth/account-created.html
@@ -3,7 +3,7 @@
         <main class="page-content page-content--textCenter">
             <h1 class="page-heading">{{lang 'create_account.created.heading'}}</h1>
             <p>{{{lang 'create_account.created.intro' store_name=settings.store_name email=customer.email}}}</p>
-            <a class="button button--primary" href="{{urls.home}}">{{lang 'create_account.created.continue'}}</a>
+            <a class="button button--primary" href="{{settings.base_url}}{{urls.home}}">{{lang 'create_account.created.continue'}}</a>
         </main>
     </section>
 {{/partial}}

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -27,7 +27,7 @@
                 </div>
             {{else}}
                 <div class="cart-actions">
-                    <a class="button" href="{{urls.home}}" title="{{lang 'cart.continue_shopping'}}">{{lang 'cart.continue_shopping'}}</a>
+                    <a class="button" href="{{settings.base_url}}{{urls.home}}" title="{{lang 'cart.continue_shopping'}}">{{lang 'cart.continue_shopping'}}</a>
                 </div>
             {{/if}}
 

--- a/templates/pages/contact-us.html
+++ b/templates/pages/contact-us.html
@@ -18,7 +18,7 @@
 
     <div class="page-content page-content--centered">
         {{#if forms.contact.success}}
-            {{{lang 'forms.contact_us.successful' shopPath=urls.home}}}
+            {{{lang 'forms.contact_us.successful' shopPath=urls.home basePath=settings.base_url}}}
         {{else}}
             <p>{{{page.content}}}</p>
             {{> components/page/contact-us-form}}


### PR DESCRIPTION
BIG-25339 - Add explicit base_url to urls that should not be relative.
@hegrec @bc-ravijayaramappa 
### Why

When using relative URLs for links, depending on the page that they were displayed on, would use the secure non-vanity URL and this would cause the correct domain to become "lost".

This is hard to identify using locally because the URL's are all converted to relative paths by Stencil-CLI. So please test the bundle ensure it is fixed.
