### PR TITLE
BIG-25097 - Set relevance as an option

### DIFF
--- a/templates/components/category/sort-box.html
+++ b/templates/components/category/sort-box.html
@@ -10,7 +10,7 @@
             <option value="avgcustomerreview" {{#if sort '==' 'avgcustomerreview'}}selected{{/if}}>{{lang 'common.sorter.reviews'}}</option>
             <option value="priceasc" {{#if sort '==' 'priceasc'}}selected{{/if}}>{{lang 'common.sorter.price_asc'}}</option>
             <option value="pricedesc" {{#if sort '==' 'pricedesc'}}selected{{/if}}>{{lang 'common.sorter.price_desc'}}</option>
-            {{#if template_file '==' 'pages/search'}}
+            {{#if result_count}}
                 <option value="relevance" {{#if sort '==' 'relevance'}}selected{{/if}}>{{lang 'common.sorter.relevance'}}</option>
             {{/if}}
         </select>


### PR DESCRIPTION
BIG-25097 - Set relevance as an option
- Comparing agains page type for relevance breaks down in faceted search. The will only display relevance as an option if there is a result_count.
