### PR TITLE
BIG-25580: Add city field support to shipping estimator

### DIFF
--- a/assets/js/theme/cart/shipping-estimator.js
+++ b/assets/js/theme/cart/shipping-estimator.js
@@ -114,6 +114,7 @@ export default class ShippingEstimator {
             const params = {
                 country_id: $('[name="shipping-country"]', $estimatorForm).val(),
                 state_id: $('[name="shipping-state"]', $estimatorForm).val(),
+                city: $('[name="shipping-city"]', $estimatorForm).val(),
                 zip_code: $('[name="shipping-zip"]', $estimatorForm).val(),
             };
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -90,6 +90,7 @@
             "select_a_country": "Country",
             "select_a_state": "State/province",
             "estimate_shipping": "Estimate Shipping",
+            "suburb_city": "Suburb/city",
             "zip_postal_code": "Zip/postcode",
             "free_shipping": "Free shipping",
             "hide_ups_rates": "Hide UPS Rates",

--- a/templates/components/cart/shipping-estimator.html
+++ b/templates/components/cart/shipping-estimator.html
@@ -45,6 +45,13 @@
             </dd>
 
             <dt class="estimator-form-label">
+                <label class="form-label" for="shipping-city">{{lang 'cart.shipping_estimator.suburb_city'}}</label>
+            </dt>
+            <dd class="estimator-form-input">
+                <input class="form-input" type="text" id="shipping-city" name="shipping-city" value="{{selected_city}}" placeholder="{{lang 'cart.shipping_estimator.suburb_city'}}">
+            </dd>
+
+            <dt class="estimator-form-label">
                 <label class="form-label" for="shipping-zip">{{lang 'cart.shipping_estimator.zip_postal_code'}}</label>
             </dt>
             <dd class="estimator-form-input">


### PR DESCRIPTION
Required Stencil theme updates to handle the shipping estimator's city field.

Has a matching Bigcommerce PR: https://github.com/bigcommerce/bigcommerce/pull/12183

Ping @bc-chris-roper, @hegrec, @mickr, @bc-mkatz, @bc-ranji.
