### PR TITLE
MERC-251 update card-image to use product preset size

### DIFF
--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -1,7 +1,7 @@
 <article class="card {{#if alternate}}card--alternate{{/if}}">
     <figure class="card-figure">
         <a href="{{url}}">
-            <img class="card-image" src="{{getImage image 'gallery' (cdn theme_settings.default_image_product)}}" alt="{{image.alt}}">
+            <img class="card-image" src="{{getImage image 'product' (cdn theme_settings.default_image_product)}}" alt="{{image.alt}}">
         </a>
         <figcaption class="card-figcaption">
             <div class="card-figcaption-body">


### PR DESCRIPTION
The cause of this issue is from `card` css class which expands the image based on browser size, such as 265x456 px, but the current `gallery` preset is at 190x250 px, hence the blurry image. 

One way to fix this issue is by using `product` preset which is bigger than 265x456 px, at 500x659 px. 

@mcampa @mickr @bc-ejoe 
