### PR TITLE
STENCIL-3210: Fixed homepage featured products floating left and unec…

### DIFF
--- a/assets/scss/layouts/products/_productGrid.scss
+++ b/assets/scss/layouts/products/_productGrid.scss
@@ -147,7 +147,7 @@
 
             // scss-lint:disable SelectorDepth, NestingDepth
             .product {
-                @include grid-column(4);
+                @include grid-column(4, $float: none);
             }
         }
     }


### PR DESCRIPTION
…essarily wrapping to next row.

#### What?

Changed the SCSS for the featured products grid so that the <li> elements with the class 'products' would not float left, but rather float none.

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/STENCIL-3210

#### Screenshots (if appropriate)

Products with float:left
<img width="360" alt="screen_shot" src="https://cloud.githubusercontent.com/assets/23507446/23592662/08879332-01ca-11e7-8299-390aecbaa982.png">


Products with float:none
<img width="1169" alt="screen shot 2017-03-05 at 5 27 15 pm" src="https://cloud.githubusercontent.com/assets/23507446/23592641/b2084b64-01c9-11e7-8f57-04b6a780353c.png">


@bigcommerce/stencil-team @bookernath 