### PR TITLE
Print a readable error  instead of dumping the whole error object to the console.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Update package.json to disambiguate Stencil and Cornerstone [#943] (https://github.com/bigcommerce/stencil/pull/943)
 - Added support up to 8 levels for category menu depth [#939] (https://github.com/bigcommerce/stencil/pull/939)
 - Implement lazyloading for product card images to improve above-the-fold rendering [#944] (https://github.com/bigcommerce/stencil/pull/944)
+- Print a readable error instead of dumping the whole error object to the console [#950](https://github.com/bigcommerce/cornerstone/pull/950)
 
 ## 1.5.3 (2017-02-23)
 - Show 'Write a Review' link for mobile [#922] (https://github.com/bigcommerce/stencil/pull/922)

--- a/stencil.conf.js
+++ b/stencil.conf.js
@@ -40,7 +40,7 @@ function development(Bs) {
     // Rebuild the bundle once at bootup
     compiler.watch({}, function(err, stats) {
         if (err) {
-            console.error(err)
+            console.error(err.message, err.details);
         }
 
         Bs.reload();


### PR DESCRIPTION
#### What?

Print a readable error when a npm module is missing, or any other webpack error, instead of dumping the whole error object to the console.


Example:
```
Module not found: Error: Cannot resolve module 'lazysizes' in /Users/mario.campa/stencil/assets/js/theme resolve module lazysizes in /Users/mario.campa/stencil/assets/js/theme
  looking for modules in /Users/mario.campa/stencil/node_modules
    /Users/mario.campa/stencil/node_modules/lazysizes doesn't exist (module as directory)
    resolve 'file' lazysizes in /Users/mario.campa/stencil/node_modules
      resolve file
        /Users/mario.campa/stencil/node_modules/lazysizes doesn't exist
        /Users/mario.campa/stencil/node_modules/lazysizes.webpack.js doesn't exist
        /Users/mario.campa/stencil/node_modules/lazysizes.web.js doesn't exist
        /Users/mario.campa/stencil/node_modules/lazysizes.js doesn't exist
        /Users/mario.campa/stencil/node_modules/lazysizes.json doesn't exist
```

@bigcommerce/stencil-team 