### PR TITLE
STENCIL-3254 - Fixes disappearing sub category menus issue

### DIFF
--- a/assets/scss/components/stencil/navPages/_navPages.scss
+++ b/assets/scss/components/stencil/navPages/_navPages.scss
@@ -262,6 +262,7 @@
 
     @include breakpoint("medium") {
         border: 0;
+        display: block;
     }
 
     &.is-open {


### PR DESCRIPTION
#### What?

This fixes the issue where the sub category menus would disappear after clicking away from them, as the stencil-dropdown `hide` method removes the 'is-open' class.

#### Ticket

[STENCIL-3254](https://jira.bigcommerce.com/browse/STENCIL-3254)

#### GIF

![GIF Showing Fix](http://g.recordit.co/V2FHL3NGda.gif)

@bigcommerce/stencil-team 
