### PR TITLE
STENCIL-3262 - only load AMP-analytics if there's an ID

### DIFF
--- a/templates/layout/amp.html
+++ b/templates/layout/amp.html
@@ -20,7 +20,9 @@
         {{{snippet 'htmlhead'}}}
         <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
         <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
-        <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+        {{#if theme_settings.amp_analytics_id}}
+            <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+        {{/if}}
         {{#block "amp-scripts"}}{{/block}}
     </head>
     <body>

--- a/templates/pages/amp/category.html
+++ b/templates/pages/amp/category.html
@@ -42,41 +42,43 @@ category:
     </main>
     {{> components/amp/category/subcategories}}
     {{> components/amp/common/footer }}
-    <amp-analytics type="googleanalytics">
-        <script type="application/json">
-        {
-            "vars": {
-                "account": "{{theme_settings.amp_analytics_id}}"
-            },
-            "extraUrlParams": {
-                "cd1": "{{page_type}}",
-                "cd2": "{{category.id}}",
-                "cd3": "{{category.url}}",
-                "cd4": "{{category.name}}"
-            },
-            "triggers": {
-                "trackPageview": {
-                    "on": "visible",
-                    "request": "pageview"
+    {{#if theme_settings.amp_analytics_id}}
+        <amp-analytics type="googleanalytics">
+            <script type="application/json">
+            {
+                "vars": {
+                    "account": "{{theme_settings.amp_analytics_id}}"
                 },
-                "trackClickOnProductCard" : {
-                    "on": "click",
-                    "selector": ".card-figure a, .card-title a",
-                    "request": "event",
-                    "vars": {
-                        "eventCategory": "Category",
-                        "eventAction": "Product Card"
+                "extraUrlParams": {
+                    "cd1": "{{page_type}}",
+                    "cd2": "{{category.id}}",
+                    "cd3": "{{category.url}}",
+                    "cd4": "{{category.name}}"
+                },
+                "triggers": {
+                    "trackPageview": {
+                        "on": "visible",
+                        "request": "pageview"
                     },
-                    "extraUrlParams": {
-                        "cd6": "${productLink}",
-                        "cd7": "${productId}",
-                        "cd8": "${productName}"
+                    "trackClickOnProductCard" : {
+                        "on": "click",
+                        "selector": ".card-figure a, .card-title a",
+                        "request": "event",
+                        "vars": {
+                            "eventCategory": "Category",
+                            "eventAction": "Product Card"
+                        },
+                        "extraUrlParams": {
+                            "cd6": "${productLink}",
+                            "cd7": "${productId}",
+                            "cd8": "${productName}"
+                        }
                     }
                 }
             }
-        }
-        </script>
-    </amp-analytics>
+            </script>
+        </amp-analytics>
+    {{/if}}
 {{/partial}}
 {{> layout/amp}}
 

--- a/templates/pages/amp/product.html
+++ b/templates/pages/amp/product.html
@@ -24,47 +24,49 @@ product:
     <div itemscope itemtype="http://schema.org/Product">
         {{> components/amp/products/product-view schema=true}}
     </div>
-    <amp-analytics type="googleanalytics">
-        <script type="application/json">
-        {
-            "vars": {
-                "account": "{{theme_settings.amp_analytics_id}}"
-            },
-            "extraUrlParams": {
-                "cd1": "{{page_type}}",
-                "cd2": "{{product.id}}",
-                "cd3": "{{product.url}}",
-                "cd4": "{{product.title}}",
-                "cd5": "{{product.sku}}"
-            },
-            "triggers": {
-                "trackPageview": {
-                    "on": "visible",
-                    "request": "pageview"
+    {{#if theme_settings.amp_analytics_id}}
+        <amp-analytics type="googleanalytics">
+            <script type="application/json">
+            {
+                "vars": {
+                    "account": "{{theme_settings.amp_analytics_id}}"
                 },
-                "trackClickOnAddToCart" : {
-                    "on": "click",
-                    "selector": ".productView-action a, .card-title a",
-                    "request": "event",
-                    "vars": {
-                        "eventCategory": "Product",
-                        "eventAction": "Add to Cart"
-                    }
+                "extraUrlParams": {
+                    "cd1": "{{page_type}}",
+                    "cd2": "{{product.id}}",
+                    "cd3": "{{product.url}}",
+                    "cd4": "{{product.title}}",
+                    "cd5": "{{product.sku}}"
                 },
-                "trackClickOnSocialLink" : {
-                    "on": "click",
-                    "selector": ".amp-social-share",
-                    "request": "social",
-                    "vars": {
-                        "socialNetwork": "${socialType}",
-                        "socialAction": "Share",
-                        "socialTarget": "${productLink}"
+                "triggers": {
+                    "trackPageview": {
+                        "on": "visible",
+                        "request": "pageview"
+                    },
+                    "trackClickOnAddToCart" : {
+                        "on": "click",
+                        "selector": ".productView-action a, .card-title a",
+                        "request": "event",
+                        "vars": {
+                            "eventCategory": "Product",
+                            "eventAction": "Add to Cart"
+                        }
+                    },
+                    "trackClickOnSocialLink" : {
+                        "on": "click",
+                        "selector": ".amp-social-share",
+                        "request": "social",
+                        "vars": {
+                            "socialNetwork": "${socialType}",
+                            "socialAction": "Share",
+                            "socialTarget": "${productLink}"
+                        }
                     }
                 }
             }
-        }
-        </script>
-    </amp-analytics>
+            </script>
+        </amp-analytics>
+    {{/if}}
     {{> components/amp/common/footer }}
 {{/partial}}
 {{> layout/amp }}


### PR DESCRIPTION
Currently we load the AMP-analytics module even if no ID is specified.

Although we want everyone to have an ID, I don't want there to be
errors on the storefront, so let's fix that.

https://jira.bigcommerce.com/browse/STENCIL-3262