### PR TITLE
STENCIL-3194: Adds theme editor setting for product display mode (grid vs list).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed homepage featured products floating left and unecessarily wrapping to next row [#948](https://github.com/bigcommerce/cornerstone/pull/948)
 - Add google recaptcha v2 support to cornerstone. [#951](https://github.com/bigcommerce/cornerstone/pull/951)
 - Added order confirmation template page [#949](https://github.com/bigcommerce/cornerstone/pull/949)
+- Added theme editor setting for product display mode (grid vs list view) [#941](https://github.com/bigcommerce/stencil/pull/941)
 
 ## 1.5.3 (2017-02-23)
 - Show 'Write a Review' link for mobile [#922](https://github.com/bigcommerce/stencil/pull/922)

--- a/schema.json
+++ b/schema.json
@@ -1091,6 +1091,25 @@
       },
       {
         "type": "heading",
+        "content": "Product display mode"
+      },
+      {
+        "type": "select",
+        "id": "product_list_display_mode",
+        "force_reload": true,
+        "options": [
+          {
+            "value": "grid",
+            "label": "Show products in a grid"
+          },
+          {
+            "value": "list",
+            "label": "Show products in a list"
+          }
+        ]
+      },
+      {
+        "type": "heading",
         "content": "Product page"
       },
       {


### PR DESCRIPTION
#### What?
Adds a "Product display mode" setting to the theme editor so merchants can choose between a grid or list view for their products on category, brand, and search results pages.  Product list view functionality already exists in the theme. This change allows merchants to actually use it :)

#### Tickets / Documentation
https://jira.bigcommerce.com/browse/STENCIL-3194

#### Screenshots (if appropriate)

Grid Mode (Default):
<img width="1438" alt="grid-view" src="https://cloud.githubusercontent.com/assets/8430791/23243034/e7de472e-f941-11e6-9ce6-6004d99301de.png">

List Mode:
<img width="1429" alt="list-view" src="https://cloud.githubusercontent.com/assets/8430791/23243038/ee78bdc6-f941-11e6-9a4b-0b5a884c83b6.png">

