### PR TITLE
Add clearfix to product view details for AMP

### DIFF
--- a/templates/components/amp/css/product.html
+++ b/templates/components/amp/css/product.html
@@ -119,6 +119,11 @@
 .productView-details {
     margin-bottom: 2rem
 }
+.productView-details:after {
+    content: "";
+    display: table;
+    clear: both;
+}
 .productView-product >:last-child {
     margin-bottom: 0
 }


### PR DESCRIPTION
#### What?
There is a bug where the image carousel in AMP will be tiny when there are additional product info added to the product information causes the carousel to resize itself aligned right caused by the floats not being cleared inside the above frame.

![image](https://cloud.githubusercontent.com/assets/21048202/23977737/2f1ba372-09ad-11e7-9f08-e3f79a4532ec.png)


@mcampa @junedkazi 