### PR TITLE
Load amp social share only when we have icons to share.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Draft
 - `stencil.conf.js` was refactored to support webpack2 builds [961](https://github.com/bigcommerce/cornerstone/pull/961)
+- Load amp social share JS only when we have share icons enabled. [#968](https://github.com/bigcommerce/cornerstone/pull/968)
+
 ## 1.6.2 (2017-03-15)
 - Fix a bug that was not updating price and weight when an option is selected [#963](https://github.com/bigcommerce/cornerstone/pull/963)
 

--- a/templates/components/amp/products/product-view.html
+++ b/templates/components/amp/products/product-view.html
@@ -65,11 +65,13 @@
         {{#if settings.show_product_reviews}}
             {{> components/amp/products/reviews reviews=product.reviews product=product urls=urls}}
         {{/if}}
-        <section expanded class="productAccordion">
-            <h4 class="productAccordion-title">Share</h4>
-            <div class="productAccordion-content social-share">
-                {{> components/amp/common/share }}
-            </div>
-        </section>
+        {{#if settings.add_this.buttons}}
+            <section expanded class="productAccordion">
+                <h4 class="productAccordion-title">Share</h4>
+                <div class="productAccordion-content social-share">
+                    {{> components/amp/common/share }}
+                </div>
+            </section>
+        {{/if}}
     </amp-accordion>
 </div>

--- a/templates/pages/amp/product.html
+++ b/templates/pages/amp/product.html
@@ -13,9 +13,11 @@ product:
 {{#partial "amp-scripts"}}
     <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
     <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
-    <script async custom-element="amp-social-share" src="https://cdn.ampproject.org/v0/amp-social-share-0.1.js"></script>
+    {{#if settings.add_this.buttons}}
+        <script async custom-element="amp-social-share" src="https://cdn.ampproject.org/v0/amp-social-share-0.1.js"></script>
+    {{/if}}
     {{#if product.options}}
-    <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
+        <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
     {{/if}}
     {{#if product.videos}}
         <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>


### PR DESCRIPTION
#### What?
Load amp social share only when we have social icons.

#### Screenshots (if appropriate)
##### Before
![share_before](https://cloud.githubusercontent.com/assets/319659/24016322/ef0514ac-0a48-11e7-8989-4e986907d16b.png)
##### After
![after](https://cloud.githubusercontent.com/assets/319659/24016326/f12c6028-0a48-11e7-96fc-61f85ea7bb46.png)
