### PR TITLE
STENCIL-3190 : Adding `customized_checkout` theme feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 1.6.2 (2017-03-15)
 - Fix a bug that was not updating price and weight when an option is selected [#963](https://github.com/bigcommerce/cornerstone/pull/963)
+- Add `customized_checkout` feature to features list [#974] (https://github.com/bigcommerce/stencil/pull/974)
 
 ## 1.6.1 (2017-03-14)
 - Fix a bug that was preventing opening the cart preview modal [#960](https://github.com/bigcommerce/cornerstone/pull/960)

--- a/config.json
+++ b/config.json
@@ -29,7 +29,8 @@
       "persistent_cart",
       "one_page_check_out",
       "product_videos",
-      "google_amp"
+      "google_amp",
+      "customized_checkout"
     ]
   },
   "css_compiler": "scss",


### PR DESCRIPTION
#### Why?
To serve checkout and order-confirmation pages in Stencil

#### Tickets / Documentation
https://github.com/bigcommerce/bigcommerce/pull/17826

Ping: @jordanwink201 @mcampa 

#### Testing
Tested manually that checkout/order confirmation renders in Stencil properly.