### PR TITLE
STENCIL-3305 - Fix invalid html (tag not closed)

### DIFF
--- a/templates/components/products/options/product-list.html
+++ b/templates/components/products/options/product-list.html
@@ -49,7 +49,7 @@
                name="attribute[{{id}}]"
                value="0"
                id="attribute_0_{{id}}"
-               {{#if defaultValue '==' 0}}checked{{/if}}
+               {{#if defaultValue '==' 0}}checked{{/if}}>
         <label class="form-label" for="attribute_0_{{id}}">{{lang 'products.none'}}</label>
         {{/unless}}
         {{#each values}}


### PR DESCRIPTION
#### What?

In a previous PR an HTML tag was accidentally left unclosed, leading to broken PDPs when non-required Product List Options were used. 

#### Tickets / Documentation

- [STENCIL-3305](https://jira.bigcommerce.com/browse/STENCIL-3305)

#### Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/8922457/24223328/d8d16522-0f12-11e7-84c0-57c981665501.png)

