### PR TITLE
Fix AMP Carousel on Product Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Load amp social share JS only when we have share icons enabled. [#968](https://github.com/bigcommerce/cornerstone/pull/968)
 - Escape html for product summaries in product list view [#980](https://github.com/bigcommerce/cornerstone/pull/980)
 - Add `customized_checkout` feature to features list [#974](https://github.com/bigcommerce/stencil/pull/974)
+- Fixed AMP Carousel alignment on product view [#982](https://github.com/bigcommerce/cornerstone/pull/982)
 
 ## 1.6.2 (2017-03-15)
 - Fix a bug that was not updating price and weight when an option is selected [#963](https://github.com/bigcommerce/cornerstone/pull/963)

--- a/templates/components/amp/css/base.html
+++ b/templates/components/amp/css/base.html
@@ -127,10 +127,6 @@ ol {
 }
 dl dt {
     font-weight: 700;
-    margin-bottom: .35714rem
-}
-dl dd {
-    margin-bottom: 1.5rem
 }
 abbr,
 acronym {

--- a/templates/components/amp/css/product.html
+++ b/templates/components/amp/css/product.html
@@ -117,7 +117,7 @@
     width: 1px
 }
 .productView-details {
-    margin-bottom: 2rem
+    margin-bottom: 1rem
 }
 .productView-product >:last-child {
     margin-bottom: 0
@@ -152,24 +152,18 @@
 .productView-info {
     margin-top: .78571rem
 }
-.productView-info:before,
-.productView-info:after {
-    content: " ";
-    display: table
-}
 .productView-info >:last-child {
     margin-bottom: 0
 }
 .productView-info-name,
 .productView-info-value {
-    float: left
+    display: inline;
+    margin: 0;
 }
 .productView-info-name {
-    clear: both;
-    margin-bottom: .21429rem;
-    margin-right: .35714rem
+    margin-right: 5px;
 }
-.productView-info-value {
-    margin-bottom: .35714rem;
-    margin-left: 0;
+.productView-info-value::after {
+    content: "\A";
+    white-space: pre;
 }


### PR DESCRIPTION
### What?
Restyled how product details are implemented on the product page.

### Why?
When there are additional details on the product page, the amp carousel
shrinks because of the way that the product details are styled.

### Proof/Testing

![image](https://cloud.githubusercontent.com/assets/21048202/24336842/561b3f5a-124a-11e7-8f11-381c767a5ad1.png)

ping: @junedkazi @bookernath 
