### PR TITLE
STENCIL-3328 - Remove footer scripts from amp-iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Escape html for product summaries in product list view [#980](https://github.com/bigcommerce/cornerstone/pull/980)
 - Add `customized_checkout` feature to features list [#974](https://github.com/bigcommerce/stencil/pull/974)
 - Fixed AMP Carousel alignment on product view [#982](https://github.com/bigcommerce/cornerstone/pull/982)
+- Remove footer scripts from the amp-iframe used to render product options for stores using AMP [#983](https://github.com/bigcommerce/cornerstone/pull/983/
 
 ## 1.6.2 (2017-03-15)
 - Fix a bug that was not updating price and weight when an option is selected [#963](https://github.com/bigcommerce/cornerstone/pull/963)

--- a/templates/layout/amp-iframe.html
+++ b/templates/layout/amp-iframe.html
@@ -44,6 +44,5 @@
             }, false);
         </script>
 
-        {{{ footer.scripts }}}
     </body>
 </html>


### PR DESCRIPTION
Removing the footer.scripts helper from the amp-iframe so footer
scripts will NOT render in the amp product options iframe. This was
causing weird display of product options on some stores.

Ping @junedkazi 