### PR TITLE
Revert "Releasing 1.6.3"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 
 ## Draft
-
-## 1.6.3 (2017-03-27)
 - `stencil.conf.js` was refactored to support webpack2 builds [961](https://github.com/bigcommerce/cornerstone/pull/961)
 - Load amp social share JS only when we have share icons enabled. [#968](https://github.com/bigcommerce/cornerstone/pull/968)
 - Escape html for product summaries in product list view [#980](https://github.com/bigcommerce/cornerstone/pull/980)

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Cornerstone",
-  "version": "1.6.3",
+  "version": "1.6.2",
   "meta": {
     "price": 0,
     "documentation_url": "https://support.bigcommerce.com/articles/Public/Cornerstone-Theme-Manual",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bigcommerce-cornerstone",
   "description": "The BigCommerce reference theme for the Stencil platform",
-  "version": "1.6.3",
+  "version": "1.6.2",
   "private": true,
   "author": "BigCommerce",
   "license": "MIT",


### PR DESCRIPTION
This reverts commit 3d5332a9fe7baaa0c43207a529f2f92d2f51b24e.

#### What?
Revert 1.6.3 since it was built using 1.5.1 of stencil-cli. Will need to create new release using 1.6.0 of stencil-cli 

@mjschock 