### PR TITLE
STENCIL-2418 - Fix BC link in footer to HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Update bigcommerce.com footer link [#990](https://github.com/bigcommerce/cornerstone/pull/990)
 
 ## 1.6.3 (2017-03-28)
 - `stencil.conf.js` was refactored to support webpack2 builds [961](https://github.com/bigcommerce/cornerstone/pull/961)

--- a/templates/components/common/footer.html
+++ b/templates/components/common/footer.html
@@ -78,7 +78,7 @@
         {{/if}}
         {{#if theme_settings.show_powered_by}}
             <div class="footer-copyright">
-                <p class="powered-by">Powered by <a href="http://bigcommerce.com" rel="nofollow">BigCommerce</a></p>
+                <p class="powered-by">Powered by <a href="https://www.bigcommerce.com/" rel="nofollow">BigCommerce</a></p>
             </div>
         {{/if}}
         {{#if theme_settings.show_copyright_footer}}


### PR DESCRIPTION
This HTTP link to bigcommerce.com was causing problems in theme editor
due to mixed content. Updating to a correct HTTPS link (which also
saves a redirect, incidentally.