### PR TITLE
Remove orphan backtick

### DIFF
--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -52,4 +52,3 @@
 </div>
 {{/partial}}
 {{> layout/base}}
-`


### PR DESCRIPTION
#### What?

While editing our cart page we discovered an orphan backtick hanging out in the cart template. This PR removes it.

#### Tickets / Documentation

N/A

#### Screenshots (if appropriate)

N/A
