### PR TITLE
STENCIL-3253 allow merchants to specify Geotrust cert Common Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Update bigcommerce.com footer link [#990](https://github.com/bigcommerce/cornerstone/pull/990)
 - Fix invalid icon HTML in AMP templates [#989](https://github.com/bigcommerce/cornerstone/pull/989)
+- Add new theme editor setting for SSL common name to enable GeoTrust badge to work properly [#994](https://github.com/bigcommerce/cornerstone/pull/994)
 
 ## 1.6.3 (2017-03-28)
 - `stencil.conf.js` was refactored to support webpack2 builds [961](https://github.com/bigcommerce/cornerstone/pull/961)

--- a/config.json
+++ b/config.json
@@ -252,7 +252,7 @@
     "swatch_option_size": "22x22",
     "social_icon_placement_top": false,
     "social_icon_placement_bottom": "bottom_none",
-    "show_geotrust_ssl_seal": false,
+    "geotrust_ssl_common_name": "",
     "geotrust_ssl_seal_size": "M",
     "navigation_design": "simple"
   },

--- a/schema.json
+++ b/schema.json
@@ -2273,10 +2273,14 @@
         "content": "GeoTrust SSL"
       },
       {
-        "type": "checkbox",
-        "label": "Show Seal",
+        "type": "paragraph",
+        "content": "If you've purchased a GeoTrust SSL from BigCommerce, check your BigCommerce Account Dashboard for the correct Common Name to use here."
+      },
+      {
+        "type": "text",
+        "label": "SSL Common Name",
         "force_reload": true,
-        "id": "show_geotrust_ssl_seal"
+        "id": "geotrust_ssl_common_name"
       },
       {
         "type": "select",

--- a/templates/components/common/footer.html
+++ b/templates/components/common/footer.html
@@ -71,7 +71,7 @@
                 {{> components/common/payment-icons}}
             </article>
         </section>
-        {{#if theme_settings.show_geotrust_ssl_seal}}
+        {{#if theme_settings.geotrust_ssl_common_name}}
             <div class="footer-geotrust-ssl-seal">
                 {{> components/common/geotrust-ssl-seal}}
             </div>

--- a/templates/components/common/geotrust-ssl-seal.html
+++ b/templates/components/common/geotrust-ssl-seal.html
@@ -1,7 +1,7 @@
 <table width="135" border="0" cellpadding="2" cellspacing="0" title="Click to Verify - This site chose GeoTrust SSL for secure e-commerce and confidential communications.">
     <tr>
         <td width="135" align="center" valign="top">
-            <script type="text/javascript" src="https://seal.geotrust.com/getgeotrustsslseal?host_name={{settings.secure_host}}&amp;size={{theme_settings.geotrust_ssl_seal_size}}&amp;lang={{locale_name}}"></script><br />
+            <script type="text/javascript" src="https://seal.geotrust.com/getgeotrustsslseal?host_name={{theme_settings.geotrust_ssl_common_name}}&amp;size={{theme_settings.geotrust_ssl_seal_size}}&amp;lang={{locale_name}}"></script><br />
             <a href="http://www.geotrust.com/ssl/" target="_blank"  style="color:#000000; text-decoration:none; font:bold 7px verdana,sans-serif; letter-spacing:.5px; text-align:center; margin:0px; padding:0px;"></a>
         </td>
     </tr>


### PR DESCRIPTION
Allowing the theme user to specify the correct Common Name for the
certificate will allow it to render correctly. This information can be
referenced from the billing system for certs purchased through BC.

The SSL common name value is known only by the billing system and/or the merchant, so we'll need to create a KB article detailing how to use this setting.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [STENCIL-3253](https://jira.bigcommerce.com/browse/STENCIL-3253)

#### Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/8922457/24883712/f885ece8-1dfa-11e7-8380-883c30fc4400.png)
