### PR TITLE
STENCIL-3352 - Fix product quick view 'Write a Review' link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fix product quick view 'Write a Review' link [#995](https://github.com/bigcommerce/cornerstone/pull/995)
 - Update bigcommerce.com footer link [#990](https://github.com/bigcommerce/cornerstone/pull/990)
 - Fix invalid icon HTML in AMP templates [#989](https://github.com/bigcommerce/cornerstone/pull/989)
 

--- a/assets/js/theme/product.js
+++ b/assets/js/theme/product.js
@@ -63,7 +63,7 @@ export default class Product extends PageManager {
     }
 
     productReviewHandler() {
-        if (this.url.indexOf('#write_review') !== -1) {
+        if (this.url.indexOf('#writeReview') !== -1) {
             this.$reviewLink.click();
         }
     }


### PR DESCRIPTION
#### What?

Fixes a bug pointed out by @ocvninfo where clicking the 'Write a Review' link in the quick view would take you to the product page but would not open the modal.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [STENCIL-3352](https://jira.bigcommerce.com/browse/STENCIL-3352)
- #984 

#### GIF with Fix

http://recordit.co/CS8jVePxfd/gif/notify

@bigcommerce/stencil-team 