### PR TITLE
STENCIL-3010 - Repopulate review form fields after error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Repopulate review form fields after error [#996](https://github.com/bigcommerce/cornerstone/pull/996)
 - Fix product quick view 'Write a Review' link [#995](https://github.com/bigcommerce/cornerstone/pull/995)
 - Update bigcommerce.com footer link [#990](https://github.com/bigcommerce/cornerstone/pull/990)
 - Fix invalid icon HTML in AMP templates [#989](https://github.com/bigcommerce/cornerstone/pull/989)

--- a/templates/components/products/modals/writeReview.html
+++ b/templates/components/products/modals/writeReview.html
@@ -22,24 +22,36 @@
                     <select id="rating-rate" class="form-select" name="revrating">
                         <option value="">{{lang 'products.reviews.select_rating'}}</option>
                         {{#for 1 5}}
-                            <option value="{{$index}}">{{lang (concat 'products.reviews.rating.' $index) }}</option>
+                            {{#if ../product.reviews.selected_rating '===' $index}}
+                                <option selected value="{{$index}}">{{lang (concat 'products.reviews.rating.' $index) }}</option>
+                            {{else}}
+                                <option value="{{$index}}">{{lang (concat 'products.reviews.rating.' $index) }}</option>
+                            {{/if}}
                         {{/for}}
                     </select>
                 </div>
 
                 <!-- Name -->
-                {{> components/common/forms/text name="revfromname" label=(lang 'products.reviews.form_write.name') value=customer.name}}
+                {{#if product.reviews.author}}
+                    {{> components/common/forms/text name="revfromname" label=(lang 'products.reviews.form_write.name') value=product.reviews.author}}
+                {{else}}
+                    {{> components/common/forms/text name="revfromname" label=(lang 'products.reviews.form_write.name') value=customer.name}}
+                {{/if}}
 
                 {{#if product.reviews.show_review_email}}
                     <!-- Email -->
-                    {{> components/common/forms/text name="email" required="false" label=(lang 'products.reviews.form_write.email') value=customer.email}}
+                    {{#if product.reviews.email}}
+                        {{> components/common/forms/text name="email" required="false" label=(lang 'products.reviews.form_write.email') value=product.reviews.email}}
+                    {{else}}
+                        {{> components/common/forms/text name="email" required="false" label=(lang 'products.reviews.form_write.email') value=customer.email}}
+                    {{/if}}
                 {{/if}}
 
                 <!-- Review Subject -->
-                {{> components/common/forms/text name="revtitle" required="true" label=(lang 'products.reviews.form_write.subject')}}
+                {{> components/common/forms/text name="revtitle" required="true" label=(lang 'products.reviews.form_write.subject') value=product.reviews.title}}
 
                 <!-- Comments -->
-                {{> components/common/forms/multiline name="revtext" required="true" label=(lang 'products.reviews.form_write.comments')}}
+                {{> components/common/forms/multiline name="revtext" required="true" label=(lang 'products.reviews.form_write.comments') value=product.reviews.text}}
 
                 {{{product.reviews.recaptcha.markup}}}
 


### PR DESCRIPTION
#### What?

Fixes an issue where submitting an invalid form (usually because of the captcha) would result in the loss of the form data.  For example, the comments might need to be re-entered.

#### Tickets / Documentation

- [STENCIL-3010](https://jira.bigcommerce.com/browse/STENCIL-3010)

#### GIF showing Fix

http://g.recordit.co/MhD8igg03S.gif

@bigcommerce/stencil-team 

P.S. i opted for `if/else`'s here for the sake of readability - i'm open to using an `if` subexpression in-line if people prefer that