### PR TITLE
Fix latest node-sass issues with Citadel upgrade and conditional impo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fix latest node-sass issues with Citadel upgrade and conditional import swap with mixin [#999](https://github.com/bigcommerce/cornerstone/pull/999)
 - Repopulate review form fields after error [#996](https://github.com/bigcommerce/cornerstone/pull/996)
 - Fix product quick view 'Write a Review' link [#995](https://github.com/bigcommerce/cornerstone/pull/995)
 - Update bigcommerce.com footer link [#990](https://github.com/bigcommerce/cornerstone/pull/990)

--- a/assets/scss/fonts/_clear-sans.scss
+++ b/assets/scss/fonts/_clear-sans.scss
@@ -1,15 +1,17 @@
-@font-face {
-    font-family: "Clear Sans";
-    font-style: normal;
-    font-weight: 400;
-    src: url("../fonts/clearsans-regular-webfont.woff2") format("woff2"),
-         url("../fonts/clearsans-regular-webfont.woff") format("woff");
-}
+@mixin clear-sans {
+    @font-face {
+        font-family: "Clear Sans";
+        font-style: normal;
+        font-weight: 400;
+        src: url("../fonts/clearsans-regular-webfont.woff2") format("woff2"),
+            url("../fonts/clearsans-regular-webfont.woff") format("woff");
+    }
 
-@font-face {
-    font-family: "Clear Sans";
-    font-style: normal;
-    font-weight: 700;
-    src: url("../fonts/clearsans-bold-webfont.woff2") format("woff2"),
-         url("../fonts/clearsans-bold-webfont.woff") format("woff");
+    @font-face {
+        font-family: "Clear Sans";
+        font-style: normal;
+        font-weight: 700;
+        src: url("../fonts/clearsans-bold-webfont.woff2") format("woff2"),
+            url("../fonts/clearsans-bold-webfont.woff") format("woff");
+    }
 }

--- a/assets/scss/fonts/_fonts.scss
+++ b/assets/scss/fonts/_fonts.scss
@@ -1,5 +1,7 @@
+@import "clear-sans";
+
 $fonts: $fontFamily-sans $fontFamily-serif $fontFamily-mono $fontFamily-headings $fontFamily-hero;
 
 @if contains($fonts, "'Clear Sans', sans-serif") {
-    @import "clear-sans";
+    @include clear-sans;
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "BigCommerce",
   "license": "MIT",
   "devDependencies": {
-    "@bigcommerce/citadel": "^2.11.5",
+    "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/stencil-utils": "1.0.5",
     "async": "^1.5.2",
     "babel-core": "6.7.4",


### PR DESCRIPTION
…rt swap with mixin

#### What?

* Fixes the two node-sass issues that were preventing upgrading node-sass:
  * Points to the latest version of Citadel which includes a [fix](https://github.com/bigcommerce/citadel/commit/0e4cc29c9bcb3781cdcc109d6f62598556f2ca5a) to `_tabs.scss`.
  * Moves the conditional import of _clear-sans.scss to a conditional mixin inclusion instead

cc @bigcommerce/stencil-team 
