### PR TITLE
Category sidebar display & copyright year in footer

### DIFF
--- a/templates/components/common/footer.html
+++ b/templates/components/common/footer.html
@@ -83,11 +83,8 @@
         {{/if}}
         {{#if theme_settings.show_copyright_footer}}
             <div class="footer-copyright">
-                <p class="powered-by">&copy; <span id="copyright_year"></span> {{settings.store_name}} </p>
+                <p class="powered-by">&copy; {{moment format="YYYY"}} {{settings.store_name}} </p>
             </div>
-            <script type="text/javascript">
-                document.getElementById("copyright_year").innerHTML = new Date().getFullYear();
-            </script>
         {{/if}}
     </div>
 </footer>

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -24,9 +24,11 @@ category:
 {{{category.description}}}
 {{{snippet 'categories'}}}
 <div class="page">
-    <aside class="page-sidebar" id="faceted-search-container">
-        {{> components/category/sidebar}}
-    </aside>
+    {{#or category.subcategories category.faceted_search_enabled}}
+        <aside class="page-sidebar" id="faceted-search-container">
+            {{> components/category/sidebar}}
+        </aside>
+    {{/or}}
 
     <main class="page-content" id="product-listing-container">
         {{#if category.products}}


### PR DESCRIPTION
When neither faceted search is enabled, or a subcategory is not present, the main content area remains at 75% width. This is due to the styling of .page-sidebar + .page-content. Another issue is three products display display in a row.

Using the {{or}} operator, verify if child category exists or faceted
search is enabled. If neither is true, page content will stretch 100%
and display four products by default.

Instead of using an extra JavaScript call on the client side, let's use {{moment}} to display the copyright year.

[https://github.com/bigcommerce/cornerstone/issues/1000](https://github.com/bigcommerce/cornerstone/issues/1000)
[https://stencil.bigcommerce.com/docs/handlebars-helpers-reference](https://stencil.bigcommerce.com/docs/handlebars-helpers-reference)