### PR TITLE
Revert "Category sidebar display & copyright year in footer"

### DIFF
--- a/templates/components/common/footer.html
+++ b/templates/components/common/footer.html
@@ -83,8 +83,11 @@
         {{/if}}
         {{#if theme_settings.show_copyright_footer}}
             <div class="footer-copyright">
-                <p class="powered-by">&copy; {{moment format="YYYY"}} {{settings.store_name}} </p>
+                <p class="powered-by">&copy; <span id="copyright_year"></span> {{settings.store_name}} </p>
             </div>
+            <script type="text/javascript">
+                document.getElementById("copyright_year").innerHTML = new Date().getFullYear();
+            </script>
         {{/if}}
     </div>
 </footer>

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -24,11 +24,9 @@ category:
 {{{category.description}}}
 {{{snippet 'categories'}}}
 <div class="page">
-    {{#or category.subcategories category.faceted_search_enabled}}
-        <aside class="page-sidebar" id="faceted-search-container">
-            {{> components/category/sidebar}}
-        </aside>
-    {{/or}}
+    <aside class="page-sidebar" id="faceted-search-container">
+        {{> components/category/sidebar}}
+    </aside>
 
     <main class="page-content" id="product-listing-container">
         {{#if category.products}}


### PR DESCRIPTION
Reverts bigcommerce/cornerstone#1001

This has caused a side effect in which "shop by price" filter which was showing without faceted search no longer shows up.

https://jira.bigcommerce.com/browse/STENCIL-3438

@bigcommerce/stencil-team @shanth100 @bc-jason @lord2800 