### PR TITLE
Webkit fix: Blurry elements in modal windows

### DIFF
--- a/assets/scss/components/foundation/modal/_modal.scss
+++ b/assets/scss/components/foundation/modal/_modal.scss
@@ -15,7 +15,7 @@
     padding: 0;
     right: 0;
     top: 50% !important;
-    transform: translate(-50%, calc(-50% - .5px));
+    transform: translate(-50%, calc(-50% - 0.5px));
 }
 
 .modal--large {

--- a/assets/scss/components/foundation/modal/_modal.scss
+++ b/assets/scss/components/foundation/modal/_modal.scss
@@ -15,7 +15,7 @@
     padding: 0;
     right: 0;
     top: 50% !important;
-    transform: translate(-50%, -50%);
+    transform: translate(-50%, calc(-50% - .5px));
 }
 
 .modal--large {


### PR DESCRIPTION
See issue #993.

translate(-50%, -50%) is calculating a pixel value on both axes with a
decimal place, causing subpixel rendering on elements in quick view
modal windows. Removing half a pixel off the Y-axis seems to solve this.