### PR TITLE
Restore four products per row on category pages when sidebar is empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Swaps `writeReview` for `write_review` to fix email link issue [#1017](https://github.com/bigcommerce/cornerstone/pull/1017)
 - Maintenance page stylesheet fix [#1016](https://github.com/bigcommerce/cornerstone/pull/1016)
+- Restore four products per row on category pages when sidebar is empty. [#1018](https://github.com/bigcommerce/cornerstone/pull/1018)
 
 ## 1.8.1 (2017-05-05)
 - Bug fix for category sidebar [#1006](https://github.com/bigcommerce/cornerstone/pull/1006)

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -24,9 +24,11 @@ category:
 {{{category.description}}}
 {{{snippet 'categories'}}}
 <div class="page">
-    <aside class="page-sidebar" id="faceted-search-container">
-        {{> components/category/sidebar}}
-    </aside>
+    {{#or category.subcategories category.faceted_search_enabled category.shop_by_price}}
+        <aside class="page-sidebar" id="faceted-search-container">
+            {{> components/category/sidebar}}
+        </aside>
+    {{/or}}
 
     <main class="page-content" id="product-listing-container">
         {{#if category.products}}


### PR DESCRIPTION
#### What?

Three products are displayed per row on category pages if one or more of these three conditions are met.

A) Faceted search is enabled.
B) Category contains subcategories.
C) Shop by price is enabled

If none are met, the main content area remains at 75% width, leaving a quarter of the content area empty. This is due to the styling of .page-sidebar + .page-content.

Using the {{or}} operator, verify if either of the three conditions are met. If neither are true, page content will stretch 100% and display four products by default.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [#1000](https://github.com/bigcommerce/cornerstone/issues/1000)