### PR TITLE
Product Images obscure product details on smaller viewports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Product Images were obscuring product details on smaller viewports [#1019](https://github.com/bigcommerce/cornerstone/pull/1019)
 
 ## 1.8.2 (2017-06-23)
 - Swaps `writeReview` for `write_review` to fix email link issue [#1017](https://github.com/bigcommerce/cornerstone/pull/1017)

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -25,8 +25,8 @@
     margin: 0;
 
     @include breakpoint("medium") {
-        min-height: 500px;
-        min-width: 500px;
+        min-height: 366px;
+        min-width: 366px;
     }
 
     img {


### PR DESCRIPTION
Product image obscures product details when scaling down the viewport.

#### What?

A minimum width and height of 366px solves the overlap issue. Setting
display to initial as an alternative solution breaks product zoom.

#### Tickets / Documentation

See [issue #966](https://github.com/bigcommerce/cornerstone/issues/966)

#### Screenshots

The red border is just for demonstration purposes.

**`display: initial` breaking out of container**
![Initial](http://i.imgur.com/wKW1jDm.jpg)

**Before**
![Before](http://i.imgur.com/rROzVUs.png)

**After**
![After](http://i.imgur.com/D59P4si.png)