### PR TITLE
Restore product image carousel

### DIFF
--- a/assets/js/theme/global/quick-view.js
+++ b/assets/js/theme/global/quick-view.js
@@ -4,6 +4,7 @@ import 'foundation-sites/js/foundation/foundation.dropdown';
 import utils from '@bigcommerce/stencil-utils';
 import ProductDetails from '../common/product-details';
 import { defaultModal } from './modal';
+import 'slick-carousel/slick/slick';
 
 export default function (context) {
     const modal = defaultModal();
@@ -19,6 +20,8 @@ export default function (context) {
             modal.updateContent(response);
 
             modal.$content.find('.productView').addClass('productView--quickView');
+
+            modal.$content.find('[data-slick]').slick();
 
             return new ProductDetails(modal.$content.find('.quickView'), context);
         });

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -62,10 +62,8 @@
         left: 0;
     }
 
-    .slick-slide {
-        img {
-            margin: 0 auto;
-        }
+    .slick-slide img {
+        margin: 0 auto;
     }
 }
 

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -48,6 +48,25 @@
 
     margin-left: -(spacing("quarter"));
     margin-right: -(spacing("quarter"));
+
+    .slick-list {
+        margin-left: remCalc(40px);
+        margin-right: remCalc(40px);
+    }
+
+    .slick-next {
+        right: 0;
+    }
+
+    .slick-prev {
+        left: 0;
+    }
+
+    .slick-slide {
+        img {
+            margin: 0 auto;
+        }
+    }
 }
 
 .productView-thumbnail {

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -160,7 +160,12 @@
                      alt="{{product.main_image.alt}}" title="{{product.main_image.alt}}" data-main-image>
             </a>
         </figure>
-        <ul class="productView-thumbnails">
+        <ul class="productView-thumbnails" data-slick='{
+                "infinite": false,
+                "mobileFirst": true,
+                "slidesToShow": 4,
+                "slidesToScroll": 1
+            }'>
             {{#each product.images}}
                 <li class="productView-thumbnail">
                     <a


### PR DESCRIPTION
#### What?

Cornerstone lacks an image carousel for product images. This restores that functionality. Slick needs to be triggered on opening modal window for QuickView.

#### Screenshots (if appropriate)

![Gallery](http://i.imgur.com/snKhj3d.png)
