### PR TITLE
BIG-30266: Add klarna checkout template.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Swaps `writeReview` for `write_review` to fix email link issue [#1017](https://github.com/bigcommerce/cornerstone/pull/1017)
+- Add Klarna Checkout template [#1022](https://github.com/bigcommerce/cornerstone/pull/1022)
 
 ## 1.8.1 (2017-05-05)
 - Bug fix for category sidebar [#1006](https://github.com/bigcommerce/cornerstone/pull/1006)

--- a/templates/pages/klarna-checkout.html
+++ b/templates/pages/klarna-checkout.html
@@ -1,0 +1,4 @@
+{{#partial "page"}}
+<div class="Content" id="klarnaContainer"></div>
+{{/partial}}
+{{> layout/base}}

--- a/templates/pages/klarna-checkout.html
+++ b/templates/pages/klarna-checkout.html
@@ -1,4 +1,4 @@
 {{#partial "page"}}
-<div class="Content" id="klarnaContainer"></div>
+  <div class="Content" id="klarnaContainer"></div>
 {{/partial}}
 {{> layout/base}}


### PR DESCRIPTION
#### What?
This pull request adds a template for Klarna Checkout on Stencil. Javascript hooks into the div tag on the template and populates the checkout and cart elements. 

#### Screenshots
The end result:
<img width="1128" alt="screen shot 2017-06-14 at 10 17 33 am" src="https://user-images.githubusercontent.com/9664217/27145530-06eb33b0-50eb-11e7-83ca-6bc842333a84.png">

