### PR TITLE
STENCIL-3533 Remove gift certificate format validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Swaps `writeReview` for `write_review` to fix email link issue [#1017](https://github.com/bigcommerce/cornerstone/pull/1017)
 - Maintenance page stylesheet fix [#1016](https://github.com/bigcommerce/cornerstone/pull/1016)
 - Restore four products per row on category pages when sidebar is empty. [#1018](https://github.com/bigcommerce/cornerstone/pull/1018)
+- Remove gift certificate format validation [#1026](https://github.com/bigcommerce/cornerstone/pull/1026)
 
 ## 1.8.1 (2017-05-05)
 - Bug fix for category sidebar [#1006](https://github.com/bigcommerce/cornerstone/pull/1006)

--- a/assets/js/theme/common/gift-certificate-validator.js
+++ b/assets/js/theme/common/gift-certificate-validator.js
@@ -3,5 +3,6 @@ export default function (cert) {
         return false;
     }
 
-    return /^[A-Z0-9]{3}\-[A-Z0-9]{3}\-[A-Z0-9]{3}\-[A-Z0-9]{3}$/.exec(cert);
+    // Add any custom gift certificate validation logic here
+    return true;
 }


### PR DESCRIPTION
#### What?

Before we had a Gift Certificates API for the creation or import of gift certificates from another system, gift certificates in BC were all of a single format, alphanumeric with hyphens like this:

AAA-AAA-AAA-AAA

However, now we have the API and 3rd parties are welcome to import certificates of an arbitrary format.

However, Cornerstone still validates the old format, which will cause these imported certificates to fail. Making this change to fix that and allow any format.

#### Tickets / Documentation

- [STENCIL-3533](STENCIL-3533)

#### Screenshots (if appropriate)

![screen shot 2017-06-19 at 10 24 56 am](https://user-images.githubusercontent.com/8922457/27292664-b6ddd5ec-54d9-11e7-9cfa-317c5f8da60e.png)
![screen shot 2017-06-19 at 10 25 09 am](https://user-images.githubusercontent.com/8922457/27292663-b6d6c914-54d9-11e7-8205-60e4998464f9.png)

