### PR TITLE
Toggle displaying product description/warranty in tab format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Restore four products per row on category pages when sidebar is empty. [#1018](https://github.com/bigcommerce/cornerstone/pull/1018)
 - Remove gift certificate format validation [#1026](https://github.com/bigcommerce/cornerstone/pull/1026)
 - Remove usage of deprecated {{template_file}} property [#1032](https://github.com/bigcommerce/cornerstone/pull/1032)
+- Toggle displaying product description in tabs [#1030](https://github.com/bigcommerce/cornerstone/pull/1030)
 
 ## 1.8.1 (2017-05-05)
 - Bug fix for category sidebar [#1006](https://github.com/bigcommerce/cornerstone/pull/1006)

--- a/assets/scss/layouts/products/_productView.scss
+++ b/assets/scss/layouts/products/_productView.scss
@@ -55,4 +55,19 @@
         float: right;
         width: grid-calc(6, $total-columns);
     }
+
+    .productView-title {
+        border-bottom: container("border");
+        margin-bottom: spacing("base");
+        padding-left: spacing("base");
+        padding-right: spacing("base");
+    }
+
+    .productView-description {
+        @include breakpoint("medium") {
+            clear: both;
+            float: none;
+            width: 100%;
+        }
+    }
 }

--- a/config.json
+++ b/config.json
@@ -67,6 +67,7 @@
     "show_accept_mastercard": false,
     "show_accept_paypal": false,
     "show_accept_visa": false,
+    "show_product_details_tabs": true,
     "product_list_display_mode": "grid",
     "logo-position": "center",
     "logo_size": "250x100",

--- a/schema.json
+++ b/schema.json
@@ -1248,6 +1248,12 @@
         "content": "Product page"
       },
       {
+         "type": "checkbox",
+         "label": "Product description tabs",
+         "force_reload": true,
+         "id": "show_product_details_tabs"
+      },
+      {
         "type": "select",
         "label": "Number of Product Reviews",
         "id": "productpage_reviews_count",

--- a/templates/components/products/description-tabs.html
+++ b/templates/components/products/description-tabs.html
@@ -1,0 +1,21 @@
+<ul class="tabs" data-tab>
+    <li class="tab is-active">
+        <a class="tab-title" href="#tab-description">{{lang 'products.description'}}</a>
+    </li>
+    {{#if product.warranty}}
+        <li class="tab">
+            <a class="tab-title" href="#tab-warranty">{{lang 'products.warranty'}}</a>
+        </li>
+    {{/if}}
+</ul>
+<div class="tabs-contents">
+    <div class="tab-content is-active" id="tab-description">
+        {{{product.description}}}
+        {{{snippet 'product_description'}}}
+    </div>
+   {{#if product.warranty}}
+       <div class="tab-content" id="tab-warranty">
+           {{{product.warranty}}}
+       </div>
+   {{/if}}
+</div>

--- a/templates/components/products/description.html
+++ b/templates/components/products/description.html
@@ -1,0 +1,12 @@
+<p class="productView-title">{{lang 'products.description'}}</p>
+<div class="productView-description">
+    {{{product.description}}}
+    {{{snippet 'product_description'}}}
+</div>
+
+{{#if product.warranty}}
+    <p class="productView-title">{{lang 'products.warranty'}}</p>
+    <div class="productView-description">
+        {{{product.warranty}}}
+    </div>
+{{/if}}

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -227,27 +227,11 @@
     </section>
 
     <article class="productView-description"{{#if schema}} itemprop="description"{{/if}}>
-        <ul class="tabs" data-tab>
-            <li class="tab is-active">
-                <a class="tab-title" href="#tab-description">{{lang 'products.description'}}</a>
-            </li>
-            {{#if product.warranty}}
-                <li class="tab">
-                    <a class="tab-title" href="#tab-warranty">{{lang 'products.warranty'}}</a>
-                </li>
-            {{/if}}
-        </ul>
-        <div class="tabs-contents">
-            <div class="tab-content is-active" id="tab-description">
-                {{{product.description}}}
-                {{{snippet 'product_description'}}}
-            </div>
-           {{#if product.warranty}}
-               <div class="tab-content" id="tab-warranty">
-                   {{{product.warranty}}}
-               </div>
-           {{/if}}
-        </div>
+        {{#if theme_settings.show_product_details_tabs}}
+            {{> components/products/description-tabs}}
+        {{else}}
+            {{> components/products/description}}
+        {{/if}}
     </article>
 </div>
 


### PR DESCRIPTION
Apologies for the multiple PR. Struggling to figure out what I broke when merging branches/squashing commits.

#### What?

Allow the ability to disable displaying product descriptions in tabbed containers.

#### Screenshots (if appropriate)

![enabled](http://i.imgur.com/Wq1Wgc7.png)
![disabled](http://i.imgur.com/U1OdDUa.png)
![editor](http://i.imgur.com/xi1l22f.png)

