### PR TITLE
Remove usage of deprecated {{template_file}} property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Maintenance page stylesheet fix [#1016](https://github.com/bigcommerce/cornerstone/pull/1016)
 - Restore four products per row on category pages when sidebar is empty. [#1018](https://github.com/bigcommerce/cornerstone/pull/1018)
 - Remove gift certificate format validation [#1026](https://github.com/bigcommerce/cornerstone/pull/1026)
+- Remove usage of deprecated {{template_file}} property [#1032](https://github.com/bigcommerce/cornerstone/pull/1032)
 
 ## 1.8.1 (2017-05-05)
 - Bug fix for category sidebar [#1006](https://github.com/bigcommerce/cornerstone/pull/1006)

--- a/templates/components/common/header.html
+++ b/templates/components/common/header.html
@@ -12,7 +12,7 @@
 
     {{> components/common/navigation}}
 
-    {{#if template_file '===' 'pages/home'}}
+    {{#if template '===' 'pages/home'}}
         <h1 class="header-logo header-logo--{{theme_settings.logo-position}}">
             {{> components/common/store-logo}}
         </h1>

--- a/templates/layout/amp-iframe.html
+++ b/templates/layout/amp-iframe.html
@@ -29,7 +29,7 @@
 
         <script>
             // Exported in app.js
-            window.stencilBootstrap("{{template_file}}", {{ jsContext }}, false).load();
+            window.stencilBootstrap("{{template}}", {{ jsContext }}, false).load();
         </script>
         <script type="text/javascript" charset="utf-8">
             function postHeight() {

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -31,13 +31,13 @@
         {{> components/common/header }}
         {{> components/common/body }}
         {{> components/common/footer }}
-        
+
         <script>window.__webpack_public_path__ = "{{cdn 'assets/dist/'}}";</script>
         <script src="{{cdn 'assets/dist/theme-bundle.main.js'}}"></script>
 
         <script>
             // Exported in app.js
-            window.stencilBootstrap("{{template_file}}", {{jsContext}}).load();
+            window.stencilBootstrap("{{template}}", {{jsContext}}).load();
         </script>
 
         {{{footer.scripts}}}


### PR DESCRIPTION
#### What?

`{{template_file}}` is deprecated, so better to use the `{{template}}` property.