### PR TITLE
STENCIL-3592 - Fix H1-H6 font-sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Product Images were obscuring product details on smaller viewports [#1019](https://github.com/bigcommerce/cornerstone/pull/1019)
 - Add region tags to two template files to support payments team banner integration with content service [#1023](https://github.com/bigcommerce/cornerstone/pull/1023)
+- Fix H1-H6 font-sizing [#1034](https://github.com/bigcommerce/cornerstone/pull/1034)
 
 ## 1.8.2 (2017-06-23)
 - Swaps `writeReview` for `write_review` to fix email link issue [#1017](https://github.com/bigcommerce/cornerstone/pull/1017)

--- a/assets/scss/components/foundation/type/_type.scss
+++ b/assets/scss/components/foundation/type/_type.scss
@@ -36,11 +36,33 @@ cite {
 }
 
 .page-heading {
-    font-size: $h1-font-size;
     margin: 0 0 spacing("double");
     text-align: center;
 }
 
+h1 {
+    font-size: $h1-font-size;
+}
+
+h2 {
+    font-size: $h2-font-size;
+}
+
+h3 {
+    font-size: $h3-font-size;
+}
+
+h4 {
+    font-size: $h4-font-size;
+}
+
+h5 {
+    font-size: $h5-font-size;
+}
+
+h6 {
+    font-size: $h6-font-size;
+}
 
 .definitionList {
     @include clearfix;


### PR DESCRIPTION
#### What?

Fixes a bug that showed up in Theme Editor where changing the H1 font size affected H2's because the same style (using the H1 font size) was being applied to both types of heading.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [STENCIL-3592](https://jira.bigcommerce.com/browse/STENCIL-3592)

cc @bigcommerce/stencil-team @shanth100 
