### PR TITLE
STENCIL-2599: Adds on/off toggle for Shop by Price.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Product Images were obscuring product details on smaller viewports [#1019](https://github.com/bigcommerce/cornerstone/pull/1019)
 - Add region tags to two template files to support payments team banner integration with content service [#1023](https://github.com/bigcommerce/cornerstone/pull/1023)
+- Add on/off toggle to the theme editor for the "Shop by Price" panel located on category pages [#1036](https://github.com/bigcommerce/cornerstone/pull/1036)
 - Fix H1-H6 font-sizing [#1034](https://github.com/bigcommerce/cornerstone/pull/1034)
 - Reduce theme bundle size by using specific minified libraries [#1037](https://github.com/bigcommerce/cornerstone/pull/1037)
 

--- a/config.json
+++ b/config.json
@@ -56,6 +56,7 @@
     "productpage_related_products_count": 10,
     "productpage_similar_by_views_count": 10,
     "categorypage_products_per_page": 12,
+    "shop_by_price_visible": true,
     "brandpage_products_per_page": 12,
     "searchpage_products_per_page": 12,
     "show_product_quick_view": true,

--- a/schema.json
+++ b/schema.json
@@ -1498,6 +1498,12 @@
         ]
       },
       {
+        "type": "checkbox",
+        "label": "Show &quot;Shop by Price&quot;",
+        "force_reload": true,
+        "id": "shop_by_price_visible"
+      },
+      {
         "type": "heading",
         "content": "Brand pages"
       },

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -24,12 +24,17 @@ category:
 {{{category.description}}}
 {{{snippet 'categories'}}}
 <div class="page">
-    {{#or category.subcategories category.faceted_search_enabled category.shop_by_price}}
+    {{#or category.subcategories category.faceted_search_enabled}}
         <aside class="page-sidebar" id="faceted-search-container">
             {{> components/category/sidebar}}
         </aside>
+    {{else}}
+        {{#if theme_settings.shop_by_price_visible}}
+            <aside class="page-sidebar" id="faceted-search-container">
+                {{> components/category/sidebar}}
+            </aside>
+        {{/if}}
     {{/or}}
-
     <main class="page-content" id="product-listing-container">
         {{#if category.products}}
             {{> components/category/product-listing}}


### PR DESCRIPTION
#### What?

Adds an on/off toggle to the theme editor for the "Shop by Price" panel located on category pages:

![2017-07-05_1807](https://user-images.githubusercontent.com/8430791/27888676-eecaa8ce-61ac-11e7-8250-f26ef3150156.png)

After adding the feature, I also tested it alongside faceted search and subcategories which live within the same sidebar. Everything works as expected. See video below.

#### Tickets / Documentation

- https://jira.bigcommerce.com/browse/STENCIL-2599

#### Screenshots (if appropriate)

https://www.screencast.com/t/Tk4mU7K5s


