### PR TITLE
Reduce theme bundle size by using specific minified libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Product Images were obscuring product details on smaller viewports [#1019](https://github.com/bigcommerce/cornerstone/pull/1019)
 - Add region tags to two template files to support payments team banner integration with content service [#1023](https://github.com/bigcommerce/cornerstone/pull/1023)
 - Fix H1-H6 font-sizing [#1034](https://github.com/bigcommerce/cornerstone/pull/1034)
+- Reduce theme bundle size by using specific minified libraries [#1037](https://github.com/bigcommerce/cornerstone/pull/1037)
 
 ## 1.8.2 (2017-06-23)
 - Swaps `writeReview` for `write_review` to fix email link issue [#1017](https://github.com/bigcommerce/cornerstone/pull/1017)

--- a/assets/js/theme/common/carousel.js
+++ b/assets/js/theme/common/carousel.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import 'slick-carousel/slick/slick';
+import 'slick-carousel/slick/slick.min';
 
 export default function () {
     const $carousel = $('[data-slick]');

--- a/assets/js/theme/global.js
+++ b/assets/js/theme/global.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import './common/select-option-plugin';
-import 'html5-history-api';
+import 'html5-history-api/history.min';
 import PageManager from './page-manager';
 import quickSearch from './global/quick-search';
 import currencySelector from './global/currency-selector';


### PR DESCRIPTION
#### What?

In an effort to reduce the size of the theme bundle, I've pointed two libraries to their minified versions.

#### Screenshots (if appropriate)

**Bundle, before history.min.js**
![1_sourcemap-visualizer-history-before](https://user-images.githubusercontent.com/5056945/27917717-b0f412fe-6221-11e7-95f8-8248ae065d2d.png)

**Bundle, after history.min.js**
![2_sourcemap-visualizer-history-after](https://user-images.githubusercontent.com/5056945/27917719-b0f7c02a-6221-11e7-8bcf-5a80ba63bdd6.png)

**Bundle, before slick.min.js**
![3_sourcemap-visualizer-slick-before](https://user-images.githubusercontent.com/5056945/27917720-b0f9dfa4-6221-11e7-851c-c216d2bf77e4.png)

**Bundle, after slick.min.js**
![4_sourcemap-visualizer-slick-after](https://user-images.githubusercontent.com/5056945/27917716-b0f39946-6221-11e7-86df-bbd27c1bca15.png)

**Bundle, after both history.min.js and slick.min.js**
![5_sourcemap-visualizer-both-after](https://user-images.githubusercontent.com/5056945/27917718-b0f72804-6221-11e7-816d-1852c9f29bf9.png)

