### PR TITLE
Reduce theme bundle size by using minified libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Move some hard-coded validation messages to language file [#1040](https://github.com/bigcommerce/cornerstone/pull/1040)
 - Use different id for gift cert in cart page [#1044](https://github.com/bigcommerce/cornerstone/pull/1044)
 - Restore product image carousel [#1028](https://github.com/bigcommerce/cornerstone/pull/1028)
+- Reduce theme bundle size by using minified libraries where applicable [#1039](https://github.com/bigcommerce/cornerstone/pull/1039)
 
 ## 1.9.0 (2017-07-18)
 - Product Images were obscuring product details on smaller viewports [#1019](https://github.com/bigcommerce/cornerstone/pull/1019)

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -65,9 +65,12 @@ module.exports = {
     ],
     resolve: {
         alias: {
+            'async': path.resolve(__dirname, 'node_modules/async/dist/async.min.js'),
             'html5-history-api': path.resolve(__dirname, 'node_modules/html5-history-api/history.min.js'),
             jquery: path.resolve(__dirname, 'node_modules/jquery/dist/jquery.min.js'),
+            'jquery-zoom': path.resolve(__dirname, 'node_modules/jquery-zoom/jquery.zoom.min.js'),
             jstree: path.resolve(__dirname, 'node_modules/jstree/dist/jstree.min.js'),
+            'pace': path.resolve(__dirname, 'node_modules/pace/pace.min.js'),
             'slick-carousel': path.resolve(__dirname, 'node_modules/slick-carousel/slick/slick.min.js'),
         },
     },


### PR DESCRIPTION
#### What?

In additional effort to #1037/#1038 and reduce the size of the theme bundle, I've pointed `async`, `jquery-zoom`, and `pace` to their minified versions.

#### Screenshots

**before**
![1_before](https://user-images.githubusercontent.com/5056945/27941952-4a6a38f8-6288-11e7-9d84-16969a0adeee.png)

**after**
![2_after](https://user-images.githubusercontent.com/5056945/27941953-4a6e75e4-6288-11e7-975d-85814c318785.png)
