### PR TITLE
Display product reviews in tabbed content region of product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Fixes functionality of carousel links in IE and Edge. [#1093](https://github.com/bigcommerce/cornerstone/pull/1093)
 - Add image width & height for carousel images. [#1126](https://github.com/bigcommerce/cornerstone/pull/1126)
+- Display product reviews in tabbed content region of product page [#1043](https://github.com/bigcommerce/cornerstone/pull/1043)
 
 ## 1.10.0 (2017-11-15)
 - Fix spaces in faceted search option names [#1113](https://github.com/bigcommerce/cornerstone/pull/1113)

--- a/assets/js/theme/product/reviews.js
+++ b/assets/js/theme/product/reviews.js
@@ -23,10 +23,13 @@ export default class {
      */
     initLinkBind() {
         const $content = $('#productReviews-content', this.$reviewsContent);
+        const $tabLink = $('a[href="#tab-reviews"]');
 
         $('.productView-reviewLink').click(() => {
             if (!$content.hasClass('is-open')) {
                 this.$collapsible.trigger(CollapsibleEvents.click);
+            } else if ($tabLink.length) {
+                $tabLink.click();
             }
         });
     }

--- a/assets/scss/components/foundation/tabs/_tabs.scss
+++ b/assets/scss/components/foundation/tabs/_tabs.scss
@@ -46,26 +46,52 @@
     }
 }
 
+.tab-content {
+    //
+    // State for when tab-content has js generated of calculated content, like carousel
+    //
+    // Purpose: The content being display: none, means any js calculated dimensions
+    // are incorrect as the elements inside the tab-content have no dimensions to grab.
+    // Carousel is a prime example. It needs widths to calculate the layout and slides
+    // -----------------------------------------------------------------------------
+    &.has-jsContent {
+        display: block;
+        height: 0;
+        overflow: hidden;
+        padding: 0;
+        visibility: hidden;
 
-//
-// State for when tab-content has js generated of calculated content, like carousel
-//
-// Purpose: The content being display: none, means any js calculated dimensions
-// are incorrect as the elements inside the tab-content have no dimensions to grab.
-// Carousel is a prime example. It needs widths to calculate the layout and slides
-// -----------------------------------------------------------------------------
+        // scss-lint:disable NestingDepth
+        &.is-active {
+            height: auto;
+            overflow: visible;
+            padding: $tabs-content-padding;
+            visibility: visible;
+        }
+        // scss-lint:enable NestingDepth
+    }
 
-.tab-content.has-jsContent {
-    display: block;
-    height: 0;
-    overflow: hidden;
-    padding: 0;
-    visibility: hidden;
 
-    &.is-active {
-        height: auto;
-        overflow: visible;
-        padding: $tabs-content-padding;
-        visibility: visible;
+    //
+    // Product review displays in tabs
+    //
+    // Purpose: Display product reviews within tabbed content on product pages.
+    // -----------------------------------------------------------------------------
+    .productReview {
+        @include breakpoint("small") {
+            width: grid-calc(6, $total-columns);
+        }
+
+        @include breakpoint("medium") {
+            width: grid-calc(4, $total-columns);
+        }
+
+        @include breakpoint("large") {
+            width: grid-calc(6, $total-columns);
+        }
+    }
+
+    .productReviews {
+        border-top: 0;
     }
 }

--- a/config.json
+++ b/config.json
@@ -69,6 +69,7 @@
     "show_accept_paypal": false,
     "show_accept_visa": false,
     "show_product_details_tabs": true,
+    "show_product_reviews_tabs": true,
     "show_product_weight": true,
     "show_product_dimensions": false,
     "product_list_display_mode": "grid",

--- a/schema.json
+++ b/schema.json
@@ -1144,6 +1144,12 @@
         "id": "show_product_details_tabs"
       },
       {
+         "type": "checkbox",
+         "label": "Product reviews in tabs",
+         "force_reload": true,
+         "id": "show_product_reviews_tabs"
+      },
+      {
         "type": "checkbox",
         "label": "Show product weight",
         "force_reload": true,

--- a/templates/components/products/description-tabs.html
+++ b/templates/components/products/description-tabs.html
@@ -7,6 +7,11 @@
             <a class="tab-title" href="#tab-warranty">{{lang 'products.warranty'}}</a>
         </li>
     {{/if}}
+    {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs}}
+        <li class="tab">
+            <a class="tab-title productView-reviewTabLink" href="#tab-reviews">{{lang 'products.reviews.header' total=product.reviews.total}}</a>
+        </li>
+    {{/all}}
 </ul>
 <div class="tabs-contents">
     <div class="tab-content is-active" id="tab-description">
@@ -18,4 +23,9 @@
            {{{product.warranty}}}
        </div>
    {{/if}}
+   {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs}}
+       <div class="tab-content" id="tab-reviews">
+           {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
+       </div>
+   {{/all}}
 </div>

--- a/templates/components/products/reviews.html
+++ b/templates/components/products/reviews.html
@@ -2,14 +2,16 @@
 <section class="toggle productReviews" id="product-reviews" data-product-reviews>
     <h4 class="toggle-title">
         {{lang 'products.reviews.header' total=reviews.total}}
-        <a class="toggleLink is-open" data-collapsible href="#productReviews-content">
-            <span class="toggleLink-text toggleLink-text--on">
-                {{lang 'products.reviews.hide'}}
-            </span>
-            <span class="toggleLink-text toggleLink-text--off">
-                {{lang 'products.reviews.show'}}
-            </span>
-        </a>
+        {{#all settings.show_product_reviews (if theme_settings.show_product_reviews_tabs '!==' true)}}
+            <a class="toggleLink is-open" data-collapsible href="#productReviews-content">
+                <span class="toggleLink-text toggleLink-text--on">
+                    {{lang 'products.reviews.hide'}}
+                </span>
+                <span class="toggleLink-text toggleLink-text--off">
+                    {{lang 'products.reviews.show'}}
+                </span>
+            </a>
+        {{/all}}
     </h4>
     <div class="toggle-content is-open" id="productReviews-content" aria-hidden="false">
         <ul class="productReviews-list" id="productReviews-list">

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -23,9 +23,9 @@ product:
             {{> components/products/videos product.videos}}
         {{/if}}
 
-        {{#if settings.show_product_reviews}}
+        {{#all settings.show_product_reviews (if theme_settings.show_product_reviews_tabs '!==' true)}}
             {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
-        {{/if}}
+        {{/all}}
 
         {{> components/products/tabs}}
 


### PR DESCRIPTION
#### What?

Adds an option to display customer reviews in the details tabs area on product pages.

#### Screenshots

**full width**
![1-full-width](https://user-images.githubusercontent.com/5056945/28300405-25a0f886-6b34-11e7-9db0-81f5cb318867.png)

**resized, desktop**
![2-desktop](https://user-images.githubusercontent.com/5056945/28300406-25a1547a-6b34-11e7-8dbe-9697cbd41613.png)

**tablet**
![3-tablet](https://user-images.githubusercontent.com/5056945/28300407-25aba1dc-6b34-11e7-9bfe-c954a63ecfb0.png)

**mobile**
![4-mobile](https://user-images.githubusercontent.com/5056945/28300409-25c040c4-6b34-11e7-9c94-cfa6d91c4ee5.png)

**theme editor**
<img width="373" alt="5-theme editor" src="https://user-images.githubusercontent.com/5056945/28300408-25ac0c4e-6b34-11e7-88c5-e9748aee3eb0.png">
