### PR TITLE
CHECKOUT-1671 Use different id for gift cert in cart page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Move some hard-coded validation messages to language file [#1040](https://github.com/bigcommerce/cornerstone/pull/1040)
+- Use different id for gift cert in cart page [#1044](https://github.com/bigcommerce/cornerstone/pull/1044)
 
 ## 1.9.0 (2017-07-18)
 - Product Images were obscuring product details on smaller viewports [#1019](https://github.com/bigcommerce/cornerstone/pull/1019)

--- a/templates/components/cart/gift-certificate-input.html
+++ b/templates/components/cart/gift-certificate-input.html
@@ -7,8 +7,8 @@
 
 <div class="cart-form gift-certificate-code" style="display: none;">
     <form class="form form--hiddenLabels cart-gift-certificate-form" method="post" action="{{urls.cart}}">
-        <label class="form-label" for="couponcode">{{lang 'cart.gift_certificates.cert_code'}}</label>
-        <input class="form-input" data-error="{{lang 'cart.gift_certificates.empty_error'}}"  id="couponcode" type="text" name="certcode" value="" placeholder="{{lang 'cart.gift_certificates.add_cert_code'}}">
+        <label class="form-label" for="certcode">{{lang 'cart.gift_certificates.cert_code'}}</label>
+        <input class="form-input" data-error="{{lang 'cart.gift_certificates.empty_error'}}"  id="certcode" type="text" name="certcode" value="" placeholder="{{lang 'cart.gift_certificates.add_cert_code'}}">
         <input class="button button--primary button--small" type="submit" value="{{lang 'cart.coupons.button'}}">
         <input type="hidden" name="action" value="applycoupon">
     </form>


### PR DESCRIPTION
#### What?
IDs not unique in Shopping Cart for Coupon Code & Gift Certificate (they both use id=”couponcode”)

#### Why?
Make IDs to be unique for accessibility 

#### Tickets / Documentation
https://jira.bigcommerce.com/browse/CHECKOUT-1671

#### Screenshots (if appropriate)
Before:
- Coupon code:
<img width="379" alt="screen shot 2017-07-18 at 4 57 31 pm" src="https://user-images.githubusercontent.com/22089936/28304278-3aa47f68-6bda-11e7-982d-521e085693cb.png">

- Gift certificate:
<img width="381" alt="screen shot 2017-07-18 at 4 56 33 pm" src="https://user-images.githubusercontent.com/22089936/28304264-275d5c5e-6bda-11e7-932b-8c816816a883.png">


After:
- Gift certificate:
<img width="380" alt="screen shot 2017-07-18 at 4 51 21 pm" src="https://user-images.githubusercontent.com/22089936/28304058-673b0070-6bd9-11e7-8639-1f72430acb48.png">

