### PR TITLE
Add RDFa tags

### DIFF
--- a/templates/components/common/breadcrumbs.html
+++ b/templates/components/common/breadcrumbs.html
@@ -1,11 +1,12 @@
-<ul class="breadcrumbs">
+<ul class="breadcrumbs" vocab="http://schema.org/" typeof="BreadcrumbList">
     {{#each breadcrumbs}}
-        <li class="breadcrumb {{#if @last}}is-active{{/if}}">
+        <li property="itemListElement" typeof="ListItem" class="breadcrumb {{#if @last}}is-active{{/if}}">
             {{#if url}}
-                <a href="{{url}}" class="breadcrumb-label">{{name}}</a>
+                <a property="item" typeof="WebPage" href="{{url}}" class="breadcrumb-label"><span property="name">{{name}}</span></a>
             {{else}}
-                <span class="breadcrumb-label">{{name}}</span>
+                <span property="name" class="breadcrumb-label">{{name}}</span>
             {{/if}}
+            <meta property="position" content="{{add @index 1}}">
         </li>
     {{/each}}
 </ul>


### PR DESCRIPTION
**What?**

Add the RDFa BreadcrumbList markup to the generated breadcrumbs to help Google (and other web crawlers) understand the shop categories better.

**Documentation**

Follows the schema.org [breadcrumb markup guidelines](http://schema.org/BreadcrumbList), and passes Google's [structured data testing tool](https://search.google.com/structured-data/testing-tool). Both appear to suggest using OL instead of UL for the list element, but it validates as is and sticking with UL seems preferable to avoid potential css issues.

**Screenshots**
Google's testing tool before the markup - no breadcrumbs only product data detected:
<img width="1333" alt="screenshot 2017-07-14 14 01 10" src="https://user-images.githubusercontent.com/4799852/28309576-b0c5febc-6ba1-11e7-9ab7-9ce60f9ad964.png">
Same page after the markup - breadcrumbs now found:
<img width="1393" alt="screenshot 2017-07-14 14 01 24" src="https://user-images.githubusercontent.com/4799852/28309577-b120e25a-6ba1-11e7-96e8-7f86f87d0a3c.png">
