### PR TITLE
Add global Sass variables to easily toggle exposure of Foundation styles from Citadel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Restore product image carousel [#1028](https://github.com/bigcommerce/cornerstone/pull/1028)
 - Reduce theme bundle size by using minified libraries where applicable [#1039](https://github.com/bigcommerce/cornerstone/pull/1039)
 - Replace JavaScript alert/confirmations with sweetalert2 library [#1035](https://github.com/bigcommerce/cornerstone/pull/1035)
+- Add global Sass variables to easily toggle exposure of Foundation styles from Citadel [#1047](https://github.com/bigcommerce/cornerstone/pull/1047)
 
 ## 1.9.0 (2017-07-18)
 - Product Images were obscuring product details on smaller viewports [#1019](https://github.com/bigcommerce/cornerstone/pull/1019)

--- a/assets/scss/settings/global/_global.scss
+++ b/assets/scss/settings/global/_global.scss
@@ -29,3 +29,16 @@
 
 // Overlays
 @import "overlay/overlay";
+
+// Set these to true so that Foundation styles are exposed from Citadel
+$include-html-classes: false !default;
+$include-print-styles: false !default;
+$include-html-global-classes: $include-html-classes !default;
+
+// These are needed when setting $include-html-classes to true, so that rems don't conflict with pixels.
+$h1-font-reduction: rem-calc(10) !default;
+$h2-font-reduction: rem-calc(10) !default;
+$h3-font-reduction: rem-calc(5) !default;
+$h4-font-reduction: rem-calc(5) !default;
+$h5-font-reduction: 0 !default;
+$h6-font-reduction: 0 !default;


### PR DESCRIPTION
#### What?

* Adds global sass $include-html-classes variable for easy exposure of Foundation styles from Citadel.  Simply set `$include-html-classes` to `true`.

#### Screenshots (if appropriate)

* before scenario:  i try to include some basic Foundation 5 styles such as grid and panel:
```html
<div class="body">
    {{#block "hero"}} {{/block}}
    <div class="container">
        {{#block "page"}} {{/block}}
    </div>
    {{> components/common/modal}}

    <div class="row">
        <div class="small-2 columns">2 columns</div>
        <div class="small-10 columns">10 columns</div>
    </div>
    <div class="row">
        <div class="small-3 columns">3 columns</div>
        <div class="small-9 columns">9 columns</div>
    </div>

    <div class="panel callout radius">
        <h5>This is a callout panel.</h5>
        <p>It's a little ostentatious, but useful for important content.</p>
    </div>
</div>
```
and they don't show up:

-- i can't add screenshots right now --

* after setting `$include-html-classes` to `true`, they show up:

-- i can't add screenshots right now --

cc @bigcommerce/stencil-team 