### PR TITLE
STENCIL-3153 - Fix google plus social icon position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Reduce theme bundle size by using minified libraries where applicable [#1039](https://github.com/bigcommerce/cornerstone/pull/1039)
 - Replace JavaScript alert/confirmations with sweetalert2 library [#1035](https://github.com/bigcommerce/cornerstone/pull/1035)
 - Add global Sass variables to easily toggle exposure of Foundation styles from Citadel [#1047](https://github.com/bigcommerce/cornerstone/pull/1047)
+- Fix google plus social icon position [#1048](https://github.com/bigcommerce/cornerstone/pull/1048)
 
 ## 1.9.0 (2017-07-18)
 - Product Images were obscuring product details on smaller viewports [#1019](https://github.com/bigcommerce/cornerstone/pull/1019)

--- a/assets/scss/components/stencil/socialLinks/_socialLinks.scss
+++ b/assets/scss/components/stencil/socialLinks/_socialLinks.scss
@@ -33,19 +33,23 @@
 }
 
 // scss-lint:disable SelectorFormat
-.socialLinks-item--google_plusone {
-    width: 35px;
+.google_plusone_iframe_widget {
+    // scss-lint:disable ImportantRule
+    width: inherit !important;
 }
+// scss-lint:enable SelectorFormat
 
 // scss-lint:disable SelectorFormat
 .socialLinks-item--pinterest {
     width: 25px;
 }
+// scss-lint:enable SelectorFormat
 
 // scss-lint:disable SelectorFormat
 .pin_it_iframe_widget {
     display: none;
 }
+// scss-lint:enable SelectorFormat
 
 .socialLinks-item {
     display: inline-block;


### PR DESCRIPTION
#### What?

* fixes width of google plus social icon position

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [STENCIL-3153](https://jira.bigcommerce.com/browse/STENCIL-3153)

#### Screenshots (if appropriate)

![screen shot 2017-07-21 at 1 55 17 pm](https://user-images.githubusercontent.com/1357197/28482349-cc9b5970-6e1c-11e7-8345-987522ada502.png)

