### PR TITLE
Use {{template_file}} as parameter in window.stencilBootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Reduce theme bundle size by using minified libraries where applicable [#1039](https://github.com/bigcommerce/cornerstone/pull/1039)
 - Replace JavaScript alert/confirmations with sweetalert2 library [#1035](https://github.com/bigcommerce/cornerstone/pull/1035)
 - Add global Sass variables to easily toggle exposure of Foundation styles from Citadel [#1047](https://github.com/bigcommerce/cornerstone/pull/1047)
+- Use {{template_file}} as parameter in window.stencilBootstrap [#1049](https://github.com/bigcommerce/cornerstone/pull/1049)
 
 ## 1.9.0 (2017-07-18)
 - Product Images were obscuring product details on smaller viewports [#1019](https://github.com/bigcommerce/cornerstone/pull/1019)

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -37,7 +37,7 @@
 
         <script>
             // Exported in app.js
-            window.stencilBootstrap("{{template}}", {{jsContext}}).load();
+            window.stencilBootstrap("{{template_file}}", {{jsContext}}).load();
         </script>
 
         {{{footer.scripts}}}


### PR DESCRIPTION
#### What?

`{{template}}` comes up as undefined in `window.stencilBootstrap()`  [#1032] , preventing product options from loading on custom templates, so restoring the use of `{{template_file}}` for the time being.

#### Tickets / Documentation

https://github.com/bigcommerce/cornerstone/commit/547b511d366c0fed046fb5c0fcfd59b30d271abf#commitcomment-23057333

#### Screenshots

`{{template_file}}`
<img width="600" alt="1-options" src="https://user-images.githubusercontent.com/5056945/28486470-ee2229d8-6e36-11e7-8a21-76d5a4325343.png">

`{{template}}`
<img width="647" alt="2-no-options" src="https://user-images.githubusercontent.com/5056945/28486471-ee2e8a0c-6e36-11e7-8de2-e30218a66d96.png">