### PR TITLE
CRO-172 Ability to see product illustrations in the storefront when t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Hide Info in footer if no address is provided in Store Profile. Hide Brands in footer if Merchant has no brands [#1053](https://github.com/bigcommerce/cornerstone/pull/1053)
+- Product illustrations in the storefront when the product catalog is empty [#1054](https://github.com/bigcommerce/cornerstone/pull/1054)
 
 ## 1.9.1 (2017-07-25)
 - Move some hard-coded validation messages to language file [#1040](https://github.com/bigcommerce/cornerstone/pull/1040)

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -16,14 +16,20 @@
                 </div>
             {{/if}}
         {{/or}}
-        <a href="{{url}}">
+        {{#if demo}}
             <img class="card-image lazyload" data-sizes="auto" src="{{cdn 'img/loading.svg'}}" data-src="{{getImage image 'productgallery_size' (cdn theme_settings.default_image_product)}}" alt="{{image.alt}}" title="{{image.alt}}">
-        </a>
+        {{else}}
+            <a href="{{url}}">
+                <img class="card-image lazyload" data-sizes="auto" src="{{cdn 'img/loading.svg'}}" data-src="{{getImage image 'productgallery_size' (cdn theme_settings.default_image_product)}}" alt="{{image.alt}}" title="{{image.alt}}">
+            </a>
+        {{/if}}
         <figcaption class="card-figcaption">
             <div class="card-figcaption-body">
                 {{#unless hide_product_quick_view}}
                     {{#if theme_settings.show_product_quick_view}}
-                        <a href="#" class="button button--small card-figcaption-button quickview" data-product-id="{{id}}">{{lang 'products.quick_view'}}</a>
+                        {{#unless demo}}
+                            <a href="#" class="button button--small card-figcaption-button quickview" data-product-id="{{id}}">{{lang 'products.quick_view'}}</a>
+                        {{/unless}}
                     {{/if}}
                 {{/unless}}
                 {{#if show_compare}}
@@ -62,7 +68,11 @@
             <p class="card-text" data-test-info-type="brandName">{{brand.name}}</p>
         {{/if}}
         <h4 class="card-title">
-            <a href="{{url}}">{{name}}</a>
+            {{#if demo}}
+                {{name}}
+            {{else}}
+                <a href="{{url}}">{{name}}</a>
+            {{/if}}
         </h4>
 
         <div class="card-text" data-test-info-type="price">


### PR DESCRIPTION
…he product catalog is empty

#### What?
Part of CRO-9. show demo products on product on Cornerstone theme home page when inventory is empty

When there is not inventory data in DB. we inject a data array in resource with negative product ids. 
At Cornerstone side, when id is negative, we hide the URL and Quick View.

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/CRO-172

https://launchbay.bigcommerce.net/projects/1/releases/36743

#### Screenshots (if appropriate)
![screen shot 2017-07-27 at 2 01 39 pm](https://user-images.githubusercontent.com/24903136/28692303-d6fb2bae-72d4-11e7-8a13-fa908dac719b.png)


@bigcommerce/cp-dt @mcampa @junedkazi 
