### PR TITLE
STENCIL-3384: Makes title tag appear on hover for swatch options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Hide Info in footer if no address is provided in Store Profile. Hide Brands in footer if Merchant has no brands [#1053](https://github.com/bigcommerce/cornerstone/pull/1053)
 - Product illustrations in the storefront when the product catalog is empty [#1054](https://github.com/bigcommerce/cornerstone/pull/1054)
+- Add pointer-event for color and pattern swatches so title tags appear upon hover [#1055](https://github.com/bigcommerce/cornerstone/pull/1055)
 
 ## 1.9.1 (2017-07-25)
 - Move some hard-coded validation messages to language file [#1040](https://github.com/bigcommerce/cornerstone/pull/1040)

--- a/assets/scss/components/citadel/forms/_forms.scss
+++ b/assets/scss/components/citadel/forms/_forms.scss
@@ -259,6 +259,7 @@
 //
 // 1. Issue with FastClick JS library workaround: https://github.com/ftlabs/fastclick/issues/351
 // 2. Resetting font due to inline-block whitespace issue.
+// 3. Added for STENCIL-3384. Did not change directly on .form-option-variant to avoid 1.
 //
 
 .form-option {
@@ -296,6 +297,7 @@
     @include square(22);
     min-width: initial;
     padding: 0;
+    pointer-events: inherit;  // 3
 }
 
 .form-option-variant--pattern {


### PR DESCRIPTION
#### What?

This change allows the title tag to appear when shoppers hover over product swatches.

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/STENCIL-3384

#### Screenshots (if appropriate)

**Color Swatches Before/After:**
![before-color-swatch](https://user-images.githubusercontent.com/8430791/28676879-80f0da06-72b1-11e7-8cf9-1182fc8c09c6.jpg)

![after-color-swatch](https://user-images.githubusercontent.com/8430791/28676883-850fa3d8-72b1-11e7-8a4f-576983de4b89.jpg)

**Pattern Swatches Before/After:**
![before-pattern-swatch](https://user-images.githubusercontent.com/8430791/28676895-8eb61674-72b1-11e7-9327-1a5236071b7b.jpg)

![after-pattern-swatch](https://user-images.githubusercontent.com/8430791/28676899-92265c88-72b1-11e7-9154-da1dacb673c4.jpg)

