### PR TITLE
STENCIL-3380: Adds auto height to alternative nav menu and submenus.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add bulk discount rates to product cards [#1058](https://github.com/bigcommerce/cornerstone/pull/1058)
 - Add higher z-index to display text over burst image [#1066](https://github.com/bigcommerce/cornerstone/pull/1066)
 - Do not show add to cart on disabled products, add pre-order button, update pre-order url to add product to cart & fix login for pricing on product cards. [#1063](https://github.com/bigcommerce/cornerstone/pull/1063)
+- Add auto height to the alternative navigation menu and its submenus. [#1056](https://github.com/bigcommerce/cornerstone/pull/1056)
 
 ## 1.9.1 (2017-07-25)
 - Move some hard-coded validation messages to language file [#1040](https://github.com/bigcommerce/cornerstone/pull/1040)

--- a/assets/scss/components/stencil/navPages/_navPages.scss
+++ b/assets/scss/components/stencil/navPages/_navPages.scss
@@ -308,6 +308,7 @@
 .has-subMenu.is-root + .navPage-subMenu-horizontal {
     @include breakpoint("medium") {
         border-left: 0;
+        height: $navPage-subMenu-horizontal-height;
         left: inherit;
         margin: auto;
         top: inherit;

--- a/assets/scss/settings/stencil/navPages/_settings.scss
+++ b/assets/scss/settings/stencil/navPages/_settings.scss
@@ -4,7 +4,7 @@
 $navPage-borderColor:                               stencilColor("navPages-subMenu-separatorColor");
 $navPage-childList-borderColor:                     $navPage-borderColor;
 $navPage-subMenu-horizontal-backgroundColor:        stencilColor("navPages-subMenu-backgroundColor");
-$navPage-subMenu-horizontal-height:                 rem-calc(242px);
+$navPage-subMenu-horizontal-height:                 auto;
 $navPage-subMenu-horizontal-width:                  rem-calc(215px);
 $navPage-subMenu-item--is-highlighted-background:   #c8bdb2;
 $navPage-subMenu-item--is-highlighted-color:        #000;


### PR DESCRIPTION
#### What?

This change ensures the alternative navigation menu and its submenus always have the proper background length no matter how many categories a merchant has. 

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/STENCIL-3380

#### Screenshots (if appropriate)

Before/After for Main Menu:
https://www.screencast.com/t/Dueilwqbp

Before/After for Submenus:
https://www.screencast.com/t/qOgJbQnM

