### PR TITLE
STENCIL-3383 Do not show add to cart on disabled products.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Change the 403 page message to be more friendly [#1057](https://github.com/bigcommerce/cornerstone/pull/1057) & [#1059](https://github.com/bigcommerce/cornerstone/pull/1059)
 - Add bulk discount rates to product cards [#1058](https://github.com/bigcommerce/cornerstone/pull/1058)
 - Add higher z-index to display text over burst image [#1066](https://github.com/bigcommerce/cornerstone/pull/1066)
+- Do not show add to cart on disabled products, add pre-order button, update pre-order url to add product to cart & fix login for pricing on product cards. [#1063](https://github.com/bigcommerce/cornerstone/pull/1063)
 
 ## 1.9.1 (2017-07-25)
 - Move some hard-coded validation messages to language file [#1040](https://github.com/bigcommerce/cornerstone/pull/1040)

--- a/assets/scss/layouts/products/_productList.scss
+++ b/assets/scss/layouts/products/_productList.scss
@@ -8,6 +8,7 @@
 
 .productList {
     @include u-listBullets("none");
+    margin: spacing("half");
 
     .product {
         // scss-lint:disable NestingDepth

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -43,7 +43,7 @@
                             <a href="{{url}}" class="button button--small card-figcaption-button" data-product-id="{{id}}">{{lang 'products.choose_options'}}</a>
                         {{/if}}
                         {{#if pre_order}}
-                            <a href="{{url}}" class="button button--small card-figcaption-button">{{lang 'products.pre_order'}}</a>
+                            <a href="{{pre_order_add_to_cart_url}}" class="button button--small card-figcaption-button">{{lang 'products.pre_order'}}</a>
                         {{/if}}
                         {{#if add_to_cart_url }}
                             <a href="{{add_to_cart_url}}" class="button button--small card-figcaption-button">{{lang 'products.add_to_cart'}}</a>

--- a/templates/components/products/list-item.html
+++ b/templates/components/products/list-item.html
@@ -26,23 +26,27 @@
                 {{/if}}
             </div>
             <div class="listItem-actions">
-                {{#if price}}
-                    <div class="listItem-price">{{> components/products/price price=price}}</div>
-                {{/if}}
-                {{#if show_cart_action}}
-                    {{#if has_options}}
-                        <a href="{{url}}" class="button button--small" data-product-id="{{id}}">{{lang 'products.choose_options'}}</a>
+                {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
+                    {{#if price}}
+                        <div class="listItem-price">{{> components/products/price price=price}}</div>
                     {{/if}}
-                    {{#if pre_order}}
-                        <a href="{{url}}" class="button button--primary">{{lang 'products.pre_order'}}</a>
+                    {{#if show_cart_action}}
+                        {{#if has_options}}
+                            <a href="{{url}}" class="button button--small" data-product-id="{{id}}">{{lang 'products.choose_options'}}</a>
+                        {{/if}}
+                        {{#if pre_order}}
+                            <a href="{{pre_order_add_to_cart_url}}" class="button button--primary">{{lang 'products.pre_order'}}</a>
+                        {{/if}}
+                        {{#if add_to_cart_url }}
+                            <a href="{{add_to_cart_url}}" class="button button--primary">{{lang 'products.add_to_cart'}}</a>
+                        {{/if}}
+                        {{#if out_of_stock_message }}
+                            <a href="{{url}}" class="button button--small" data-product-id="{{id}}">{{out_of_stock_message}}</a>
+                        {{/if}}
                     {{/if}}
-                    {{#if add_to_cart_url }}
-                        <a href="{{add_to_cart_url}}" class="button button--primary">{{lang 'products.add_to_cart'}}</a>
-                    {{/if}}
-                    {{#if out_of_stock_message }}
-                        <a href="{{url}}" class="button button--small" data-product-id="{{id}}">{{out_of_stock_message}}</a>
-                    {{/if}}
-                {{/if}}
+                {{else}}
+                    {{> components/common/login-for-pricing}}
+                {{/or}}
                 {{#if show_compare}}
                     <label class="button button--small" for="compare-{{id}}">
                         {{lang "products.compare"}} <input type="checkbox" name="products[]" value="{{id}}" id="compare-{{id}}" data-compare-id="{{id}}">

--- a/templates/components/products/list-item.html
+++ b/templates/components/products/list-item.html
@@ -29,17 +29,20 @@
                 {{#if price}}
                     <div class="listItem-price">{{> components/products/price price=price}}</div>
                 {{/if}}
-                {{#unless hide_add_to_cart}}
+                {{#if show_cart_action}}
                     {{#if has_options}}
-                        <a href="{{url}}" class="button button--primary" data-product-id="{{id}}">{{lang "products.choose_options"}}</a>
-                    {{else}}
-                        {{#if out_of_stock_message }}
-                        <span href="{{url}}" class="button button--primary">{{out_of_stock_message}}</span>
-                        {{else}}
-                        <a href="{{add_to_cart_url}}" class="button button--primary">{{lang "products.add_to_cart"}}</a>
-                        {{/if}}
+                        <a href="{{url}}" class="button button--small" data-product-id="{{id}}">{{lang 'products.choose_options'}}</a>
                     {{/if}}
-                {{/unless}}
+                    {{#if pre_order}}
+                        <a href="{{url}}" class="button button--primary">{{lang 'products.pre_order'}}</a>
+                    {{/if}}
+                    {{#if add_to_cart_url }}
+                        <a href="{{add_to_cart_url}}" class="button button--primary">{{lang 'products.add_to_cart'}}</a>
+                    {{/if}}
+                    {{#if out_of_stock_message }}
+                        <a href="{{url}}" class="button button--small" data-product-id="{{id}}">{{out_of_stock_message}}</a>
+                    {{/if}}
+                {{/if}}
                 {{#if show_compare}}
                     <label class="button button--small" for="compare-{{id}}">
                         {{lang "products.compare"}} <input type="checkbox" name="products[]" value="{{id}}" id="compare-{{id}}" data-compare-id="{{id}}">

--- a/templates/components/products/list.html
+++ b/templates/components/products/list.html
@@ -1,7 +1,7 @@
 <ul class="productList">
     {{#each products}}
     <li class="product">
-        {{>components/products/list-item show_compare=../show_compare show_rating=../settings.show_product_rating theme_settings=../theme_settings}}
+        {{>components/products/list-item show_compare=../show_compare show_rating=../settings.show_product_rating theme_settings=../theme_settings customer=../customer}}
     </li>
     {{/each}}
 </ul>


### PR DESCRIPTION
#### What?
This PR fixes a couple of things;
- In list view do not show "Add to Cart" on Storefront when Products are Disabled for Purchase.
- Added the "Pre order" cart action as it was missing.
- Fix the bug where the buttons were getting slightly cut off
- Updated "choose options" to not be a primary option to match grid view
- Login for pricing in list view
- Add to cart url for pre-order products since it was just redirecting to product detail page

#### Tickets / Documentation
https://jira.bigcommerce.com/browse/STENCIL-3383
https://jira.bigcommerce.com/browse/STENCIL-3353

#### Screenshots (if appropriate)
#### Before
![screen shot 2017-08-11 at 9 49 37 am](https://user-images.githubusercontent.com/319659/29223180-80192366-7e7a-11e7-9096-b054b48ea9ef.png)


#### After
##### Pre order
![screen shot 2017-08-11 at 9 47 16 am](https://user-images.githubusercontent.com/319659/29223094-23a1a252-7e7a-11e7-8589-e418fc1a3f9a.png)
##### options
![screen shot 2017-08-11 at 9 47 05 am](https://user-images.githubusercontent.com/319659/29223092-239c2cc8-7e7a-11e7-89f0-7750a64726c7.png)
##### disabled online ordering
![screen shot 2017-08-11 at 9 46 57 am](https://user-images.githubusercontent.com/319659/29223095-23a2a94a-7e7a-11e7-9175-7db4518263ef.png)
##### Add to cart
![screen shot 2017-08-11 at 9 46 51 am](https://user-images.githubusercontent.com/319659/29223093-239cbf26-7e7a-11e7-97e9-e4376684e23e.png)
##### Login for pricing in list view
![screen shot 2017-08-11 at 10 34 42 am](https://user-images.githubusercontent.com/319659/29224827-c144b994-7e80-11e7-92ce-e4758a1eed00.png)


@bigcommerce/stencil-team @bc-ranji @cristycarpenter 