### PR TITLE
STENCIL-3374 add higher z-index to display text over burst image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add pointer-event for color and pattern swatches so title tags appear upon hover [#1055](https://github.com/bigcommerce/cornerstone/pull/1055)
 - Change the 403 page message to be more friendly [#1057](https://github.com/bigcommerce/cornerstone/pull/1057) & [#1059](https://github.com/bigcommerce/cornerstone/pull/1059)
 - Add bulk discount rates to product cards [#1058](https://github.com/bigcommerce/cornerstone/pull/1058)
+- Add higher z-index to display text over burst image [#1066](https://github.com/bigcommerce/cornerstone/pull/1066)
 
 ## 1.9.1 (2017-07-25)
 - Move some hard-coded validation messages to language file [#1040](https://github.com/bigcommerce/cornerstone/pull/1040)

--- a/assets/scss/layouts/products/_productSaleBadges.scss
+++ b/assets/scss/layouts/products/_productSaleBadges.scss
@@ -44,7 +44,7 @@
     text-align: center;
     top: 20%;
     width: rem-calc(50px);
-    z-index: zIndex("lower");
+    z-index: zIndex("high");
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION

#### What?
Cornerstone - 'Burst' Sale Badge Does Not Display Text

Adding a higher z-index to the text div.

#### Tickets / Documentation
https://jira.bigcommerce.com/browse/STENCIL-3374

#### Screenshots (if appropriate)
## Before
![screen shot 2017-08-11 at 4 30 24 pm](https://user-images.githubusercontent.com/319659/29235277-7273a8e8-7eb2-11e7-9862-224cbc064fe1.png)

## After
![screen shot 2017-08-11 at 4 27 27 pm](https://user-images.githubusercontent.com/319659/29235235-03094d96-7eb2-11e7-8303-07da78377f49.png)