### PR TITLE
STENCIL-3130: Fix img overlapping details on product page and Quick View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixes image overlapping details on product page and Quick View on small viewports [#1067](https://github.com/bigcommerce/cornerstone/pull/1067)
 
 ## 1.9.2 (2017-08-16)
 - Hide Info in footer if no address is provided in Store Profile. Hide Brands in footer if Merchant has no brands [#1053](https://github.com/bigcommerce/cornerstone/pull/1053)

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -26,7 +26,7 @@
 
     @include breakpoint("medium") {
         min-height: 366px;
-        min-width: 366px;
+        min-width: inherit;
     }
 
     img {


### PR DESCRIPTION
#### What?
Product images are overlapping product details on smaller viewports. This was fixed for product pages via this commit:

https://github.com/bigcommerce/cornerstone/commit/9fd0ea21c6eecdf1a616fc35412fbfd21414251d

However, the issue is still present for Quick View. This PR fixes both. Tested fix on Safari, Firefox, and Chrome. 

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/STENCIL-3130

#### Screenshots (if appropriate)
**BEFORE**
![before](https://user-images.githubusercontent.com/8430791/29470593-af09aebe-8412-11e7-8306-b26e68849d9d.png)

**AFTER**
![after](https://user-images.githubusercontent.com/8430791/29471345-4fcbca7e-8415-11e7-94fd-943313307005.png)

**VIDEO**
http://www.screencast.com/t/7LvuVqYXeGe




