### PR TITLE
STENCIL-3289: Allows 'none' to be default selection on pick lists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Fixes image overlapping details on product page and Quick View on small viewports [#1067](https://github.com/bigcommerce/cornerstone/pull/1067)
+- Allow 'none' to be a default selection on product option pick lists [#1068](https://github.com/bigcommerce/cornerstone/pull/1068)
 
 ## 1.9.2 (2017-08-16)
 - Hide Info in footer if no address is provided in Store Profile. Hide Brands in footer if Merchant has no brands [#1053](https://github.com/bigcommerce/cornerstone/pull/1053)

--- a/templates/components/products/options/product-list.html
+++ b/templates/components/products/options/product-list.html
@@ -17,7 +17,7 @@
                            name="attribute[{{id}}]"
                            value="0"
                            id="attribute_0_{{id}}"
-                           {{#if defaultValue '==' 0}}checked{{/if}} required>
+                           checked="{{#if defaultValue '==' 0}}checked{{/if}}" required>
                     <label class="form-label" for="attribute_0_{{id}}">{{lang 'products.none'}}</label>
                 </li>
             {{/unless}}


### PR DESCRIPTION
#### What?

Selects product pick list option 'none' by default if that is what a merchant has specified in his or her control panel settings. See video below.

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/STENCIL-3289

#### Screenshots (if appropriate)

Can download before and after video here:

http://www.screencast.com/t/TxxboMdlz7
