### PR TITLE
PAYMENTS-1160: Ensure Apple Pay button is hidden for incompatible browsers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixes image overlapping details on product page and Quick View on small viewports [#1067](https://github.com/bigcommerce/cornerstone/pull/1067)
 - Allow 'none' to be a default selection on product option pick lists [#1068](https://github.com/bigcommerce/cornerstone/pull/1068)
 - Fixes a bug where product options and add to cart do not work when opened in Quick View modals [#1070](https://github.com/bigcommerce/cornerstone/pull/1070)
+- Fixes a bug where the Apple Pay button is displayed in incompatible browsers in the Preview Cart modal [#1084](https://github.com/bigcommerce/cornerstone/pull/1084)
 
 ## 1.9.2 (2017-08-16)
 - Hide Info in footer if no address is provided in Store Profile. Hide Brands in footer if Merchant has no brands [#1053](https://github.com/bigcommerce/cornerstone/pull/1053)

--- a/assets/scss/components/stencil/applePay/_applePay.scss
+++ b/assets/scss/components/stencil/applePay/_applePay.scss
@@ -43,7 +43,6 @@
 
 .previewCartCheckout {
     .apple-pay-checkout-button {
-        display: block;
         float: none;
         margin-top: spacing("half");
     }


### PR DESCRIPTION
#### What?
Remove an unnecessary `display: block` rule that was causing the Apple Pay button to appear in the Cart Modal even for browsers that do not support Apple Pay.

#### Why?
Shopper confusion. The rule in question is ignoring the `apple-pay-supported` class that gets attached to the `body` element, forcing the button to appear in all browsers. My first solution was to fix this by changing the nesting of the rules to respect this class, but then I realised that the `display: block` rule itself is unnecessary, because it will be inherited from the rule defined on L33. 

#### Screenshots (if appropriate)
Since I can't enable Apple Pay for local development, I have screenshots showing the HTML structure in Chrome and Safari respectively to prove that this should work.
<img width="1370" alt="screen shot 2017-09-04 at 3 53 42 pm" src="https://user-images.githubusercontent.com/813373/30038434-1b8b3862-918a-11e7-83b8-02e83441d6ca.png">
<img width="1279" alt="screen shot 2017-09-04 at 3 53 21 pm" src="https://user-images.githubusercontent.com/813373/30038404-c199f15e-9189-11e7-9c19-630c1f06c464.png">

Ping @bigcommerce/stencil-team @bigcommerce/payments 