### PR TITLE
CHECKOUT-2461 Style optimized checkout checklist radios buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Style optimized checkout new checklist radio buttons [#1088](https://github.com/bigcommerce/cornerstone/pull/1088)
 
 ## 1.9.3 (2017-09-19)
 - Fixes image overlapping details on product page and Quick View on small viewports [#1067](https://github.com/bigcommerce/cornerstone/pull/1067)

--- a/assets/scss/optimized-checkout.scss
+++ b/assets/scss/optimized-checkout.scss
@@ -349,6 +349,26 @@ $optimizedCheckout-input--error-boxShadow: 0 0 3px transparentize(stencilColor("
     border-color: stencilColor("optimizedCheckout-formChecklist-borderColor");
 }
 
+.optimizedCheckout-form-checklist-checkbox {
+    ~ .form-label::after,
+    ~ .form-label::before {
+        background-color: stencilColor("optimizedCheckout-formField-backgroundColor");
+        border-color: stencilColor("optimizedCheckout-formField-borderColor");
+    }
+
+    &:focus ~ .form-label {
+        box-shadow: inset 0 0 0 1px stencilColor("optimizedCheckout-colorFocus");
+    }
+
+    &:checked ~ .form-label::before {
+        border-color: stencilColor("optimizedCheckout-formField-inputControlColor");
+    }
+
+    &:checked ~ .form-label::after {
+        background: stencilColor("optimizedCheckout-formField-inputControlColor");
+    }
+}
+
 //
 // Loading Toaster
 // Background & Text Color


### PR DESCRIPTION
#### What?
Styling of the new checklist radio buttons in optimized checkout.

#### Context:
We changed the checklist from:
![image](https://user-images.githubusercontent.com/4542735/30732787-8fd7894c-9fb7-11e7-957c-a659885335e0.png)

to: 
![light-before](https://user-images.githubusercontent.com/4542735/30732448-f813743c-9fb5-11e7-937e-9c21c2f7fe17.png)

To make it more obvious that it is a `radio buttons list`.

Because of that, we need to include some `(s)CSS` in cornerstone to match the different theme designs. 

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/CHECKOUT-2461

#### Screenshots (if appropriate)
||Before|After
|---|---|---|
|Light|![light-before](https://user-images.githubusercontent.com/4542735/30732448-f813743c-9fb5-11e7-937e-9c21c2f7fe17.png)|![light-after](https://user-images.githubusercontent.com/4542735/30732604-b2375f40-9fb6-11e7-98e6-26c11110002a.png)|
|Bold|![bold-before](https://user-images.githubusercontent.com/4542735/30732552-7699011e-9fb6-11e7-899b-8af0a3dfc4ce.png)|![bold-after](https://user-images.githubusercontent.com/4542735/30732616-bf7e2b5c-9fb6-11e7-9f59-2e3b1cc3cc5d.png)|
|Warm|![warm-before](https://user-images.githubusercontent.com/4542735/30732572-8ff89750-9fb6-11e7-8a93-2c42c9975fdb.png)|![warm-after](https://user-images.githubusercontent.com/4542735/30732666-f9156fc4-9fb6-11e7-8694-70933779d1db.png)|

@bigcommerce/checkout @bigcommerce/stencil-team 