### PR TITLE
Update product UPC when options are selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Style optimized checkout new checklist radio buttons [#1088](https://github.com/bigcommerce/cornerstone/pull/1088)
+- Update product UPC when options with different UPC are selected [#1089](https://github.com/bigcommerce/cornerstone/pull/1089)
 
 ## 1.9.3 (2017-09-19)
 - Fixes image overlapping details on product page and Quick View on small viewports [#1067](https://github.com/bigcommerce/cornerstone/pull/1067)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -70,6 +70,7 @@ export default class ProductDetails {
                 $input: $('[data-product-stock]', $scope),
             },
             $sku: $('[data-product-sku]'),
+            $upc: $('[data-product-upc]'),
             quantity: {
                 $text: $('.incrementTotal', $scope),
                 $input: $('[name=qty\\[\\]]', $scope),
@@ -368,6 +369,11 @@ export default class ProductDetails {
         // If SKU is available
         if (data.sku) {
             viewModel.$sku.text(data.sku);
+        }
+
+        // If UPC is available
+        if (data.upc) {
+            viewModel.$upc.text(data.upc);
         }
 
         // if stock view is on (CP settings)


### PR DESCRIPTION
#### What?
Selecting an option does not change the UPC to the UPC set on that option's SKU. The UPCs should change based on the option selected & should display the UPC of the option.

#### Tickets / Documentation
https://jira.bigcommerce.com/browse/STENCIL-3639

@bigcommerce/stencil-team 