### PR TITLE
STENCIL-3527: Adding toggle for weight and dimensions on product pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Lazy load carousel images [#1090](https://github.com/bigcommerce/cornerstone/pull/1090)
 - Theme Editor menu item updates for ease of use [#1091](https://github.com/bigcommerce/cornerstone/pull/1091)
 - Upgrades all dependencies except for Foundation and jQuery [#1069](https://github.com/bigcommerce/cornerstone/pull/1069)
+- Adds a theme editor display toggle for weight and dimensions on product pages [#1092](https://github.com/bigcommerce/cornerstone/pull/1092)
 
 ## 1.9.3 (2017-09-19)
 - Fixes image overlapping details on product page and Quick View on small viewports [#1067](https://github.com/bigcommerce/cornerstone/pull/1067)

--- a/config.json
+++ b/config.json
@@ -69,6 +69,8 @@
     "show_accept_paypal": false,
     "show_accept_visa": false,
     "show_product_details_tabs": true,
+    "show_product_weight": true,
+    "show_product_dimensions": false,
     "product_list_display_mode": "grid",
     "logo-position": "center",
     "logo_size": "250x100",

--- a/lang/en.json
+++ b/lang/en.json
@@ -678,6 +678,13 @@
         "including_tax": "Including Tax",
         "excluding_tax": "Excluding Tax",
         "weight": "Weight:",
+        "width": "Width:",
+        "height": "Height:",
+        "depth": "Depth:",
+        "measurement": {
+            "metric": "cm",
+            "imperial": "in"
+        },
         "you_save": "(You save {amount})",
         "gift_wrapping": "Gift wrapping:",
         "gift_wrapping_available": "Options available",

--- a/schema.json
+++ b/schema.json
@@ -1144,6 +1144,18 @@
         "id": "show_product_details_tabs"
       },
       {
+        "type": "checkbox",
+        "label": "Show product weight",
+        "force_reload": true,
+        "id": "show_product_weight"
+      },
+      {
+        "type": "checkbox",
+        "label": "Show product dimensions",
+        "force_reload": true,
+        "id": "show_product_dimensions"
+      },
+      {
         "type": "select",
         "label": "Number of Related Products",
         "id": "productpage_related_products_count",

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -76,10 +76,39 @@
                     <dt class="productView-info-name">{{lang 'products.availability'}}</dt>
                     <dd class="productView-info-value">{{product.availability}}</dd>
                 {{/if}}
-                {{#if product.weight}}
+                {{#all product.weight theme_settings.show_product_weight}}
                     <dt class="productView-info-name">{{lang 'products.weight'}}</dt>
                     <dd class="productView-info-value" data-product-weight>{{product.weight}}</dd>
-                {{/if}}
+                {{/all}}
+                {{#all product.width product.height product.depth theme_settings.show_product_dimensions}}
+                    <dt class="productView-info-name">{{lang 'products.width'}}</dt>
+                    <dd class="productView-info-value" data-product-width>
+                        {{product.width}}
+                        {{#if settings.measurements.length '==' 'Centimeters'}}
+                        ({{lang 'products.measurement.metric'}})
+                        {{else}}
+                        ({{lang 'products.measurement.imperial'}})
+                        {{/if}}
+                    </dd>
+                    <dt class="productView-info-name">{{lang 'products.height'}}</dt>
+                    <dd class="productView-info-value" data-product-height>
+                        {{product.height}}
+                        {{#if settings.measurements.length '==' 'Centimeters'}}
+                        ({{lang 'products.measurement.metric'}})
+                        {{else}}
+                        ({{lang 'products.measurement.imperial'}})
+                        {{/if}}
+                    </dd>
+                    <dt class="productView-info-name">{{lang 'products.depth'}}</dt>
+                    <dd class="productView-info-value" data-product-depth>
+                        {{product.depth}}
+                        {{#if settings.measurements.length '==' 'Centimeters'}}
+                        ({{lang 'products.measurement.metric'}})
+                        {{else}}
+                        ({{lang 'products.measurement.imperial'}})
+                        {{/if}}
+                    </dd>
+                {{/all}}
                 {{#if product.min_purchase_quantity}}
                     <dt class="productView-info-name">{{lang 'products.min_purchase_quantity'}}</dt>
                     <dd class="productView-info-value">{{lang 'products.purchase_units' quantity=product.min_purchase_quantity}}</dd>


### PR DESCRIPTION
#### What?

Adds toggle settings to the theme editor for displaying (or not displaying) weight and dimensions on product pages.

#### Tickets / Documentation

This is a feature request from customers as documented here:

- https://jira.bigcommerce.com/browse/STENCIL-3527

#### Screenshots (if appropriate)

![screenshot](https://user-images.githubusercontent.com/8430791/31150505-71b85888-a859-11e7-8521-a71fe660881b.png)

Video of working changes: https://www.screencast.com/t/juQ8DUTeG3F8

