### PR TITLE
STENCIL-2497: Makes carousel links functional in IE and Edge.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixes functionality of carousel links in IE and Edge. [#1093](https://github.com/bigcommerce/cornerstone/pull/1093)
 
 ## 1.10.0 (2017-11-15)
 - Fix spaces in faceted search option names [#1113](https://github.com/bigcommerce/cornerstone/pull/1113)

--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -9,9 +9,9 @@
         "lazyLoad": "anticipated"
     }'>
     {{#each carousel.slides}}
-    <div class="heroCarousel-slide {{#if ../theme_settings.homepage_stretch_carousel_images}}heroCarousel-slide--stretch{{/if}}"
-        style="background-image: url({{image}})">
-        <a href="{{url}}">
+    <a href="{{url}}">
+        <div class="heroCarousel-slide {{#if ../theme_settings.homepage_stretch_carousel_images}}heroCarousel-slide--stretch{{/if}}"
+            style="background-image: url({{image}})">
             <img class="heroCarousel-image" data-lazy="{{image}}" alt="{{alt_text}}" title="{{alt_text}}"/>
             {{#if heading}}
                 {{> components/carousel-content show_background=true}}
@@ -24,7 +24,7 @@
                     {{/if}}
                 {{/if}}
             {{/if}}
-        </a>
-    </div>
+        </div>
+    </a>
     {{/each}}
 </section>


### PR DESCRIPTION
#### What?
Allows carousel slide links to work in IE and Edge. 

#### Tickets / Documentation

- https://jira.bigcommerce.com/browse/STENCIL-2497

#### Screenshots (if appropriate)

Before and after video: https://www.screencast.com/t/mlb6Nd3h

Links still work in Chrome, Firefox, and Safari too. Button links also still functional. 