### PR TITLE
STENCIL-3499 Do not scale product thumbnail images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Style optimized checkout new checklist radio buttons [#1088](https://github.com/bigcommerce/cornerstone/pull/1088)
 - Update product UPC when options with different UPC are selected [#1089](https://github.com/bigcommerce/cornerstone/pull/1089)
+- Do not scale product thumbnail images [#1094](https://github.com/bigcommerce/cornerstone/pull/1094)
 
 ## 1.9.3 (2017-09-19)
 - Fixes image overlapping details on product page and Quick View on small viewports [#1067](https://github.com/bigcommerce/cornerstone/pull/1067)

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -71,7 +71,7 @@
         position: absolute;
         right: 0;
         top: 0;
-        width: 100%;
+        width: auto;
     }
 }
 


### PR DESCRIPTION
#### What?
When we try to update product thumbnail image dimension in theme editor to a dimension smaller than 50x50 which is the max limit for the thumbnail it tries to scale & stretch the image

#### Tickets / Documentation

Add links to any relevant tickets and documentation.
- https://jira.bigcommerce.com/browse/STENCIL-3499

#### Screenshots (if appropriate)
##### Before
<img width="1263" alt="screen shot 2017-10-05 at 8 49 18 pm" src="https://user-images.githubusercontent.com/319659/31262268-be779b5a-aa0e-11e7-9eb7-ce3506f8cb2e.png">
##### After
<img width="1229" alt="screen shot 2017-10-05 at 8 46 57 pm" src="https://user-images.githubusercontent.com/319659/31262269-be7887d6-aa0e-11e7-8d32-d02760b21bfa.png">
