### PR TITLE
STENCIL-3106: Lazy load zoomed images on image gallery

### DIFF
--- a/assets/js/theme/product/image-gallery.js
+++ b/assets/js/theme/product/image-gallery.js
@@ -71,7 +71,7 @@ export default class ImageGallery {
     }
 
     setImageZoom() {
-        this.$mainImage.zoom({ url: this.$mainImage.attr('data-zoom-image'), touch: false });
+        this.$mainImage.zoom({ url: this.$mainImage.attr('data-zoom-image'), deferLoading: true, touch: false });
     }
 
     destroyImageZoom() {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "html5-history-api": "^4.2.7",
     "jasmine-core": "^2.2.0",
     "jquery": "^2.2.1",
-    "jquery-zoom": "^1.7.15",
+    "jquery-zoom": "BC-EChristensen/zoom#64651ce299804923b1f06184d368e9e22e79e4ec",
     "jstree": "vakata/jstree",
     "karma": "^0.13.22",
     "karma-babel-preprocessor": "6.0.1",


### PR DESCRIPTION
#### What?

Switch to a modified jquery-zoom library (see changes [here](https://github.com/BC-EChristensen/zoom/commit/64651ce299804923b1f06184d368e9e22e79e4ec)) that adds a `deferLoading` flag when setting up a zoom element. This will defer loading of the zoomed image until it is actually required.

In this particular instance, since we have the `touch` flag disabled, this also means the unnecessary zoomed image is no longer loaded on mobile.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [STENCIL-3106](https://jira.bigcommerce.com/browse/STENCIL-3106)
