### PR TITLE
STENCIL-3961 Switch slick library to 'anticipated' lazy load

### DIFF
--- a/assets/scss/components/vendor/slick/_slick.scss
+++ b/assets/scss/components/vendor/slick/_slick.scss
@@ -19,6 +19,7 @@
 .slick-next,
 .slick-prev {
     @include carouselOpaqueBackgrounds($slick-arrow-bgColor);
+    z-index: 1;
     border: 1px solid $slick-arrow-borderColor;
     height: remCalc(61px);
     margin-top: -(remCalc(30px));

--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -6,7 +6,7 @@
         "slidesToScroll": 1,
         "autoplay": true,
         "autoplaySpeed": {{carousel.swap_frequency}},
-        "lazyLoad": "ondemand"
+        "lazyLoad": "anticipated"
     }'>
     {{#each carousel.slides}}
     <div class="heroCarousel-slide {{#if ../theme_settings.homepage_stretch_carousel_images}}heroCarousel-slide--stretch{{/if}}"


### PR DESCRIPTION
#### What?

Use `anticipated` option rather than `ondemand` for slick carousel lazy loading. The `ondemand` option has a bug that causes the first slide not to appear while sliding in when wrapping back around from the last slide.

Also, set `z-index` of the slick arrows to 1. Prior to this the left arrow was not appearing.

#### Tickets / Documentation

- [STENCIL-3961](https://jira.bigcommerce.com/browse/STENCIL-3961)
