### PR TITLE
STENCIL-3962 Use _.includes rather than _.contains

### DIFF
--- a/assets/js/theme/common/faceted-search.js
+++ b/assets/js/theme/common/faceted-search.js
@@ -266,7 +266,7 @@ class FacetedSearch {
         $navLists.each((index, navList) => {
             const $navList = $(navList);
             const id = $navList.attr('id');
-            const shouldCollapse = _.contains(this.collapsedFacetItems, id);
+            const shouldCollapse = _.includes(this.collapsedFacetItems, id);
 
             if (shouldCollapse) {
                 this.collapseFacetItems($navList);
@@ -283,7 +283,7 @@ class FacetedSearch {
             const $accordionToggle = $(accordionToggle);
             const collapsible = $accordionToggle.data('collapsible-instance');
             const id = collapsible.targetId;
-            const shouldCollapse = _.contains(this.collapsedFacets, id);
+            const shouldCollapse = _.includes(this.collapsedFacets, id);
 
             if (shouldCollapse) {
                 this.collapseFacet($accordionToggle);

--- a/assets/js/theme/common/form-utils.js
+++ b/assets/js/theme/common/form-utils.js
@@ -27,7 +27,7 @@ function classifyInput(input, formFieldClass) {
     if (tagName === 'input') {
         const inputType = $input.prop('type');
 
-        if (_.contains(['radio', 'checkbox', 'submit'], inputType)) {
+        if (_.includes(['radio', 'checkbox', 'submit'], inputType)) {
             // ie: .form-field--checkbox, .form-field--radio
             className = `${formFieldClass}--${_.camelCase(inputType)}`;
         } else {


### PR DESCRIPTION
#### What?

Lodash 4.0 and above removed the deprecated alias `_.contains` for the function `_.includes`. We were using the deprecated version in a few places, causing these functions to fail after updating lodash. This manifested in the State field in the new account form failing to change properly from a dropdown to a text field (and vice versa) as different Countries were selected.

It's quite possible this had other detrimental effects as well, as this function was also being used in faceted search.

#### Tickets / Documentation

- [STENCIL-3962](https://jira.bigcommerce.com/browse/STENCIL-3962)
