### PR TITLE
PAYMENTS-1945 - Add spacing between checkout buttons

### DIFF
--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -520,6 +520,18 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
             float: right;
         }
     }
+
+    .CheckoutButton {
+        margin-bottom: spacing("base");
+
+        &:first-child {
+            margin-top: spacing("single");
+        }
+
+        &:last-child {
+            margin-bottom: spacing("single");
+        }
+    }
 }
 
 

--- a/assets/scss/components/stencil/previewCart/_previewCart.scss
+++ b/assets/scss/components/stencil/previewCart/_previewCart.scss
@@ -82,6 +82,18 @@
         float: none !important; // 1
         margin: spacing("third") 0;
     }
+
+    .CheckoutButton {
+        margin-bottom: spacing("base");
+
+        &:first-child {
+            margin-top: spacing("single");
+        }
+
+        &:last-child {
+            margin-bottom: spacing("single");
+        }
+    }
 }
 
 .suggestiveCart {


### PR DESCRIPTION
#### What?

Adds spacing between "Additional Checkout Buttons" such as PayPal, PayPal Credit and VisaCheckout on the Cart and Cart Preview pages.

#### Tickets / Documentation
- [PAYMENTS-1945](https://jira.bigcommerce.com/browse/PAYMENTS-1945)

#### Screenshots

**Cart Page**
<img width="459" alt="screen shot 2017-10-20 at 11 59 09 am" src="https://user-images.githubusercontent.com/3030010/31800655-1b6c6a22-b58e-11e7-8711-63a46df8a6e2.png">
<img width="478" alt="screen shot 2017-10-20 at 11 56 55 am" src="https://user-images.githubusercontent.com/3030010/31800645-068e4116-b58e-11e7-92a0-da2aaebbdf51.png">
<img width="473" alt="screen shot 2017-10-20 at 11 57 06 am" src="https://user-images.githubusercontent.com/3030010/31800646-06b91be8-b58e-11e7-847f-60085deb062f.png">

**Cart Preview Modal**
<img width="400" alt="screen shot 2017-10-20 at 11 57 43 am" src="https://user-images.githubusercontent.com/3030010/31800664-2b239f1c-b58e-11e7-9965-d022e1a2537e.png">
<img width="406" alt="screen shot 2017-10-20 at 11 57 50 am" src="https://user-images.githubusercontent.com/3030010/31800665-2b4ca880-b58e-11e7-9e34-f9f0841d9c9e.png">
<img width="409" alt="screen shot 2017-10-20 at 11 57 56 am" src="https://user-images.githubusercontent.com/3030010/31800666-2b74cc48-b58e-11e7-9f63-d0e34ccbf09a.png">

@bigcommerce/payments @davidchin @icatalina @supercrabtree 
