### PR TITLE
fix(storefront): STENCIL-3567 Fix spaces in faceted search option names

### DIFF
--- a/templates/components/faceted-search/facets/hierarchy.html
+++ b/templates/components/faceted-search/facets/hierarchy.html
@@ -3,7 +3,7 @@
     <div
         class="accordion-navigation toggleLink {{#unless ../start_collapsed }} is-open {{/unless}}"
         role="button"
-        data-collapsible="#facetedSearch-content--{{ facet }}">
+        data-collapsible="#facetedSearch-content--{{hyphenate facet }}">
         <h5 class="accordion-title">
             {{ title }}
         </h5>
@@ -21,12 +21,12 @@
         </div>
     </div>
 
-    <div id="facetedSearch-content--{{ facet }}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
-        <ul id="facetedSearch-navList--{{ facet }}" class="navList" data-facet="{{facet}}" data-has-more-results="{{ has_more_results }}">
+    <div id="facetedSearch-content--{{hyphenate facet }}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
+        <ul id="facetedSearch-navList--{{hyphenate facet }}" class="navList" data-facet="{{facet}}" data-has-more-results="{{ has_more_results }}">
             {{#each items}}
                 <li class="navList-item">
                     <a
-                        href="{{url}}"
+                        href="{{ url }}"
                         class="navList-action navList-action--checkbox {{#if selected }} is-selected {{/if}} {{#if has_sub_categories }} has-children {{/if}}"
                         rel="nofollow"
                         data-id="{{ id }}"
@@ -46,7 +46,7 @@
         </ul>
 
         {{#if show_more_toggle}}
-            <a href="#facetedSearch-navList--{{ facet }}" role="button" class="toggleLink">
+            <a href="#facetedSearch-navList--{{hyphenate facet }}" role="button" class="toggleLink">
                 <span class="toggleLink-text toggleLink-text--off">{{lang 'search.faceted.show-more'}}</span>
             </a>
         {{/if}}

--- a/templates/components/faceted-search/facets/multi.html
+++ b/templates/components/faceted-search/facets/multi.html
@@ -3,7 +3,7 @@
     <div
         class="accordion-navigation toggleLink {{#unless ../start_collapsed }} is-open {{/unless}}"
         role="button"
-        data-collapsible="#facetedSearch-content--{{ facet }}">
+        data-collapsible="#facetedSearch-content--{{hyphenate facet }}">
         <h5 class="accordion-title">
             {{ title }}
         </h5>
@@ -21,8 +21,8 @@
         </div>
     </div>
 
-    <div id="facetedSearch-content--{{ facet }}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
-        <ul id="facetedSearch-navList--{{ facet }}" data-facet="{{facet}}" class="navList" data-has-more-results="{{ has_more_results }}">
+    <div id="facetedSearch-content--{{hyphenate facet }}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
+        <ul id="facetedSearch-navList--{{hyphenate facet }}" data-facet="{{facet}}" class="navList" data-has-more-results="{{ has_more_results }}">
             {{#each items}}
                 <li class="navList-item">
                     <a
@@ -46,7 +46,7 @@
         </ul>
 
         {{#if show_more_toggle}}
-            <a href="#facetedSearch-navList--{{ facet }}" role="button" class="toggleLink">
+            <a href="#facetedSearch-navList--{{hyphenate facet }}" role="button" class="toggleLink">
                 <span class="toggleLink-text toggleLink-text--off">{{lang 'search.faceted.show-more'}}</span>
             </a>
         {{/if}}

--- a/templates/components/faceted-search/facets/range.html
+++ b/templates/components/faceted-search/facets/range.html
@@ -2,7 +2,7 @@
     <div
         class="accordion-navigation toggleLink {{#unless ../start_collapsed }} is-open {{/unless}}"
         role="button"
-        data-collapsible="#facetedSearch-content--{{ facet }}">
+        data-collapsible="#facetedSearch-content--{{hyphenate facet }}">
         <h5 class="accordion-title">
             {{ title }}
         </h5>
@@ -20,7 +20,7 @@
         </div>
     </div>
 
-    <div id="facetedSearch-content--{{ facet }}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
+    <div id="facetedSearch-content--{{hyphenate facet }}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
         <form id="facet-range-form" class="form" method="get" data-faceted-search-range novalidate>
             {{#each current_selected_items}}
                 <input type="hidden" name="{{ param_name }}[]" value="{{ param_value }}"/>

--- a/templates/components/faceted-search/facets/rating.html
+++ b/templates/components/faceted-search/facets/rating.html
@@ -3,7 +3,7 @@
     <div
         class="accordion-navigation toggleLink {{#unless ../start_collapsed }} is-open {{/unless}}"
         role="button"
-        data-collapsible="#facetedSearch-content--{{ facet }}">
+        data-collapsible="#facetedSearch-content--{{hyphenate facet }}">
         <h5 class="accordion-title">
             {{ title }}
         </h5>
@@ -21,7 +21,7 @@
         </div>
     </div>
 
-    <div id="facetedSearch-content--{{ facet }}" class="accordion-content facetedSearch-content--{{ facet }} {{#unless ../start_collapsed }} is-open {{/unless}}">
+    <div id="facetedSearch-content--{{hyphenate facet }}" class="accordion-content facetedSearch-content--{{hyphenate facet}} {{#unless ../start_collapsed }} is-open {{/unless}}">
         <ul class="navList">
             {{#each items}}
                 <li class="navList-item">


### PR DESCRIPTION
#### What?
For stores that implement faceted search on category and search pages, the list of filters can be limited to a specific number with the rest revealed after a 'show more' link is clicked. When the name of the filter or facet contains a space, the `show more` link does not work.

This fix uses the `hypenate` Handlebars filter to remove spaces before the facet name is applied as a DOM selector.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.
- [STENCIL-3567](https://jira.bigcommerce.com/browse/STENCIL-3567)
- ...

#### Screenshots (if appropriate)
<img width="917" alt="facet-name-hyphen" src="https://user-images.githubusercontent.com/24397553/32291391-288e24fa-befa-11e7-81da-5c74c141135a.png">



@bigcommerce/stencil-team 
