### PR TITLE
STRF-3496: Create year option in date picker if earliest year equals …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Add image width & height for carousel images. [#1126](https://github.com/bigcommerce/cornerstone/pull/1126)
 - Fix Bold featured products clickability. [#1130](https://github.com/bigcommerce/cornerstone/pull/1130)
 - Fixes mobile swatch selectability styling. [#1131](https://github.com/bigcommerce/cornerstone/pull/1131)
-- Fix Logo not loading on UCO page [#1132](https://github.com/bigcommerce/cornerstone/pull/1132) 
+- Fix Logo not loading on UCO page [#1132](https://github.com/bigcommerce/cornerstone/pull/1132)
+- Fixes functionality of date picker option on product pages. [#1125](https://github.com/bigcommerce/cornerstone/pull/1125)
 
 ## 1.10.0 (2017-11-15)
 - Fix spaces in faceted search option names [#1113](https://github.com/bigcommerce/cornerstone/pull/1113)

--- a/templates/components/products/options/date.html
+++ b/templates/components/products/options/date.html
@@ -29,5 +29,8 @@
                 {{$index}}
             </option>
         {{/for}}
+        {{#if earliest_year '==' latest_year}}
+        <option value="{{earliest_year}}">{{earliest_year}}</option>
+        {{/if}}
     </select>
 </div>

--- a/templates/components/products/options/date.html
+++ b/templates/components/products/options/date.html
@@ -30,7 +30,7 @@
             </option>
         {{/for}}
         {{#if earliest_year '==' latest_year}}
-        <option value="{{earliest_year}}">{{earliest_year}}</option>
+        <option value="{{earliest_year}}" selected="selected">{{earliest_year}}</option>
         {{/if}}
     </select>
 </div>


### PR DESCRIPTION
#### What?
When the date picker product option has a date restriction within one year, the year options do no populate on the product page, preventing a shopper from adding the item to the cart if the option is required.

This fix creates an option for the year if the earliest_year and latest_year are the same.

#### Tickets / Documentation
https://jira.bigcommerce.com/browse/STRF-3496

#### Screenshots (if appropriate)
Before:
![screen shot 2017-11-28 at 1 42 27 pm](https://user-images.githubusercontent.com/16565458/33340553-048c99bc-d442-11e7-83f4-5974c22f9e32.png)

After:
![screen shot 2017-11-28 at 1 43 24 pm](https://user-images.githubusercontent.com/16565458/33340601-26918ff4-d442-11e7-8721-37f03fd444e2.png)
