### PR TITLE
STRF-4056 Add image width & height for carousel images.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Fixes functionality of carousel links in IE and Edge. [#1093](https://github.com/bigcommerce/cornerstone/pull/1093)
+- Add image width & height for carousel images. [#1126](https://github.com/bigcommerce/cornerstone/pull/1126)
 
 ## 1.10.0 (2017-11-15)
 - Fix spaces in faceted search option names [#1113](https://github.com/bigcommerce/cornerstone/pull/1113)

--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -12,7 +12,8 @@
     <a href="{{url}}">
         <div class="heroCarousel-slide {{#if ../theme_settings.homepage_stretch_carousel_images}}heroCarousel-slide--stretch{{/if}}"
             style="background-image: url({{image}})">
-            <img class="heroCarousel-image" data-lazy="{{image}}" alt="{{alt_text}}" title="{{alt_text}}"/>
+            <img class="heroCarousel-image" data-lazy="{{image}}" alt="{{alt_text}}" title="{{alt_text}}""
+             {{#if image_width}}width="{{image_width}}"{{/if}} {{#if image_height}}height="{{image_height}}"{{/if}} />
             {{#if heading}}
                 {{> components/carousel-content show_background=true}}
             {{else}}


### PR DESCRIPTION
#### What?
Add image width & height for carousel images.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [STRF-4056](https://jira.bigcommerce.com/browse/STRF-4056)

#### Screenshots (if appropriate)
<img width="1510" alt="screen shot 2017-11-29 at 12 32 24 pm" src="https://user-images.githubusercontent.com/319659/33397798-a6599500-d501-11e7-9ea4-d06a740ce5b0.png">
