### PR TITLE
STRF-4158 - Fix Bold Featured Products Clickability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Fixes functionality of carousel links in IE and Edge. [#1093](https://github.com/bigcommerce/cornerstone/pull/1093)
 - Add image width & height for carousel images. [#1126](https://github.com/bigcommerce/cornerstone/pull/1126)
+- Fix Bold featured products clickability. [#1130](https://github.com/bigcommerce/cornerstone/pull/1130)
 
 ## 1.10.0 (2017-11-15)
 - Fix spaces in faceted search option names [#1113](https://github.com/bigcommerce/cornerstone/pull/1113)

--- a/assets/scss/layouts/products/_productGrid.scss
+++ b/assets/scss/layouts/products/_productGrid.scss
@@ -145,6 +145,8 @@
         @include breakpoint("medium") {
             @include grid-column(12);
 
+            float: none;
+
             // scss-lint:disable SelectorDepth, NestingDepth
             .product {
                 @include grid-column(4, $float: none);


### PR DESCRIPTION
#### What?

* `config.json` overode `homepage_featured_products_column_count` for Bold themes, causing the clickabilty to break.

#### Tickets / Documentation

- [STRF-4158](https://jira.bigcommerce.com/browse/STRF-4158)

ping @bigcommerce/stencil-team 
