### PR TITLE
Bug Fix: Remove lazy loading from UCO header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add image width & height for carousel images. [#1126](https://github.com/bigcommerce/cornerstone/pull/1126)
 - Fix Bold featured products clickability. [#1130](https://github.com/bigcommerce/cornerstone/pull/1130)
 - Fixes mobile swatch selectability styling. [#1131](https://github.com/bigcommerce/cornerstone/pull/1131)
+- Fix Logo not loading on UCO page [#1132](https://github.com/bigcommerce/cornerstone/pull/1132) 
 
 ## 1.10.0 (2017-11-15)
 - Fix spaces in faceted search option names [#1113](https://github.com/bigcommerce/cornerstone/pull/1113)

--- a/templates/pages/checkout.html
+++ b/templates/pages/checkout.html
@@ -17,7 +17,7 @@
         <h2 class="checkoutHeader-heading">
             <a class="checkoutHeader-link" href="{{urls.home}}">
                 {{#if checkout.header_image}}
-                    <img alt="{{settings.store_logo.title}}" class="checkoutHeader-logo lazyload" id="logoImage" data-sizes="auto" src="{{cdn 'img/loading.svg'}}" data-src="{{ checkout.header_image }}"/>
+                    <img alt="{{settings.store_logo.title}}" class="checkoutHeader-logo" id="logoImage" src="{{ checkout.header_image }}"/>
                 {{ else }}
                     <span class="header-logo-text">{{settings.store_logo.title}}</span>
                 {{/if}}


### PR DESCRIPTION
#### What?
This PR addresses a bug where the logo does not show up on the UCO cart page. This is due to some libraries required for lazy loading not being included on the UCO page. 

#### Tickets / Documentation
[STRF-4138](https://jira.bigcommerce.com/browse/STRF-4138)

#### Screenshots (if appropriate)
<img width="1418" alt="screen shot 2017-12-06 at 4 10 34 pm" src="https://user-images.githubusercontent.com/24397553/33692014-1f9f8c82-daa0-11e7-81d1-b44b334c12a1.png">

cc @bigcommerce/stencil-team 
