### PR TITLE
STRF-4220 - Fix image-overlap on Orders page

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,9 @@
         "global-require": 0,
         "newline-per-chained-call": 0,
         "arrow-parens": 0,
-        "prefer-destructuring": 0
+        "prefer-destructuring": 0,
+        "import/no-named-as-default": 0,
+        "import/no-named-as-default-member": 0
     },
     "env": {
         "es6": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixes mobile swatch selectability styling. [#1131](https://github.com/bigcommerce/cornerstone/pull/1131)
 - Fix Logo not loading on UCO page [#1132](https://github.com/bigcommerce/cornerstone/pull/1132)
 - Fixes functionality of date picker option on product pages. [#1125](https://github.com/bigcommerce/cornerstone/pull/1125)
+- Fix image-overlap on Orders page [#1137](https://github.com/bigcommerce/cornerstone/pull/1137)
 
 ## 1.10.0 (2017-11-15)
 - Fix spaces in faceted search option names [#1113](https://github.com/bigcommerce/cornerstone/pull/1113)

--- a/assets/scss/components/foundation/lazyLoad/_lazyLoad.scss
+++ b/assets/scss/components/foundation/lazyLoad/_lazyLoad.scss
@@ -3,7 +3,7 @@
 }
 
 @mixin lazy-loaded-img() {
-    position: absolute;
+    position: relative;
     top: 0;
     bottom: 0;
     left: 0;


### PR DESCRIPTION
#### What?

* Fixes issue where the order image would overlap order information (for Firefox)

#### Tickets / Documentation

- [STRF-4220](https://jira.bigcommerce.com/browse/STRF-4220)

#### Screenshots (if appropriate)

### before
![before](https://user-images.githubusercontent.com/1357197/34227755-294bfd04-e583-11e7-9df4-ddcbcbd92ed3.png)

### after
![after](https://user-images.githubusercontent.com/1357197/34227769-362d753e-e583-11e7-9474-45f10f4ec155.png)

ping @bigcommerce/storefront-team

cc @BC-EChristensen - wondering if you have any concerns with this change, as it relates to lazy loading of the images?