### PR TITLE
STRF-4154 - Disable pointer events and product image zoom for mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixes mobile swatch selectability styling. [#1131](https://github.com/bigcommerce/cornerstone/pull/1131)
 - Fix Logo not loading on UCO page [#1132](https://github.com/bigcommerce/cornerstone/pull/1132)
 - Fixes functionality of date picker option on product pages. [#1125](https://github.com/bigcommerce/cornerstone/pull/1125)
+- Fixes issue with image zoom causing scrolling issues on mobile. [#1140](https://github.com/bigcommerce/cornerstone/pull/1140)
 
 ## 1.10.0 (2017-11-15)
 - Fix spaces in faceted search option names [#1113](https://github.com/bigcommerce/cornerstone/pull/1113)

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -33,6 +33,10 @@
     + .productView-thumbnails {
         margin-top: spacing("half");
     }
+
+    @media (min-width: $screen-xxsmall) and (max-width: $screen-xsmall) {
+        pointer-events: none;
+    }
 }
 
 .productView-img-container {


### PR DESCRIPTION
#### What?
This PR addresses the issue that was caused by the ez zoom plugin on mobile. A mobile user is not able to scroll a product page due to the zoom effect.  Pointer events have been disabled for the product image for mobile breakpoints.

#### Tickets / Documentation
- [STRF-4154](https://jira.bigcommerce.com/browse/STRF-4154)
- ...

#### Screenshots (if appropriate)
![cornerstone-product-zoom](https://user-images.githubusercontent.com/24397553/34421389-dc2a1cda-ebc3-11e7-99de-98ee5f53e5e2.png)
![cornerstone-product-zoomfix](https://user-images.githubusercontent.com/24397553/34421419-fb407ca4-ebc3-11e7-99c9-eb3846c526f1.png)

@bigcommerce/storefront-team 
