### PR TITLE
STRF-4154: Disable pointer events and product image zoom for mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix Logo not loading on UCO page [#1132](https://github.com/bigcommerce/cornerstone/pull/1132)
 - Fixes functionality of date picker option on product pages. [#1125](https://github.com/bigcommerce/cornerstone/pull/1125)
 - Fix image-overlap on Orders page [#1137](https://github.com/bigcommerce/cornerstone/pull/1137)
+- Fixes issue with image zoom causing scrolling issues on mobile. [#1140](https://github.com/bigcommerce/cornerstone/pull/1140)
 
 ## 1.10.0 (2017-11-15)
 - Fix spaces in faceted search option names [#1113](https://github.com/bigcommerce/cornerstone/pull/1113)

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -33,6 +33,10 @@
     + .productView-thumbnails {
         margin-top: spacing("half");
     }
+
+    @media (min-width: $screen-xxsmall) and (max-width: $screen-xsmall) {
+        pointer-events: none;
+    }
 }
 
 .productView-img-container {


### PR DESCRIPTION
#### What?
Users are unable to scroll on product pages when images are on the screen due to the zoom image feature.  This PR addresses that by disabling image zoom for smaller screen sizes.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [STRF-4154](https://jira.bigcommerce.com/browse/STRF-4154)
- ...

#### Screenshots (if appropriate)

![cornerstone-product-zoomfix](https://user-images.githubusercontent.com/24397553/34535023-70037112-f075-11e7-97c8-6ac6b50571b6.png)

