### PR TITLE
CATALOG-1447 - Update product cards to use price ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix image-overlap on Orders page [#1137](https://github.com/bigcommerce/cornerstone/pull/1137)
 - Fixes issue with image zoom causing scrolling issues on mobile. [#1141](https://github.com/bigcommerce/cornerstone/pull/1141)
 - Fix mis-sized product images. [#1145](https://github.com/bigcommerce/cornerstone/pull/1145)
+- Remove "as low as" feature and add support for price ranges instead[#1143](https://github.com/bigcommerce/cornerstone/pull/1143)
 
 ## 1.10.0 (2017-11-15)
 - Fix spaces in faceted search option names [#1113](https://github.com/bigcommerce/cornerstone/pull/1113)

--- a/config.json
+++ b/config.json
@@ -266,7 +266,6 @@
     "optimizedCheckout-step-textColor": "#ffffff",
     "optimizedCheckout-form-textColor": "#666666",
     "optimizedCheckout-formField-borderColor": "#cccccc",
-    "price_as_low_as": false,
     "optimizedCheckout-formField-textColor": "#333333",
     "optimizedCheckout-formField-shadowColor": "#e5e5e5",
     "optimizedCheckout-formField-placeholderColor": "#999999",
@@ -289,7 +288,8 @@
     "social_icon_placement_bottom": "bottom_none",
     "geotrust_ssl_common_name": "",
     "geotrust_ssl_seal_size": "M",
-    "navigation_design": "simple"
+    "navigation_design": "simple",
+    "price_ranges": true
   },
   "read_only_files": [
     "/assets/scss/components/citadel",

--- a/schema.json
+++ b/schema.json
@@ -394,21 +394,21 @@
       },
       {
         "type": "heading",
-        "content": "Purchase options"
+        "content": "Pricing"
       },
       {
         "type": "checkbox",
-        "label": "Add 'As low as' text",
+        "label": "Price Ranges",
         "force_reload": true,
-        "id": "price_as_low_as"
+        "id": "price_ranges"
       },
       {
         "type": "paragraph",
-        "content": "Add 'As low as' pricing text to products with options on layout pages."
+        "content": "Show price ranges for products with variants - if disabled, will show the product price"
       },
       {
-        "type": "paragraph",
-        "content": "Only recommended if default options are set to lowest price available for each product"
+        "type": "heading",
+        "content": "Purchase options"
       },
       {
         "type": "checkbox",

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -81,11 +81,7 @@
 
         <div class="card-text" data-test-info-type="price">
             {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
-                {{#if price_range}}
-                    {{> components/products/price-range}}
-                {{else}}
-                    {{> components/products/price price=price customer=customer}}
-                {{/if}}
+                {{> components/products/price price=price}}
             {{else}}
                 {{> components/common/login-for-pricing}}
             {{/or}}

--- a/templates/components/products/price-range.html
+++ b/templates/components/products/price-range.html
@@ -1,3 +1,37 @@
-{{#with price_range}}
-    {{min.formatted}} - {{max.formatted}}
-{{/with}}
+{{#and price_range.min.with_tax price_range.max.with_tax}}
+    <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+        <span data-product-price-with-tax class="price">{{price_range.min.with_tax.formatted}} - {{price_range.max.with_tax.formatted}}</span>
+        {{#and price_range.min.without_tax price_range.max.without_tax}}
+            <abbr title="{{lang 'products.excluding_tax'}}">{{lang 'products.price_with_tax' tax_label=price_range.min.tax_label}}</abbr>
+        {{else if schema_org}}
+                <meta itemprop="availability" content="{{product.availability}}">
+                <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
+                <div itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
+                    <meta itemprop="minPrice" content="{{price_range.min.with_tax.value}}"  />
+                    <meta itemprop="price" content="{{price_range.min.with_tax.value}}">
+                    <meta itemprop="maxPrice" content="{{price_range.max.with_tax.value}}"  />
+                    <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
+                    <meta itemprop="valueAddedTaxIncluded" content="true">
+                </div>
+        {{/and}}
+    </div>
+{{/and}}
+{{#and price_range.min.without_tax price_range.max.without_tax}}
+    <div class="price-section price-section--withoutTax {{#and price_range.min.with_tax price_range.max.with_tax}}price-section--minor{{/and}}"  {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+        <span data-product-price-without-tax class="price price--withoutTax">{{price_range.min.without_tax.formatted}} - {{price_range.max.without_tax.formatted}}</span>
+        {{#and price_range.min.with_tax price_range.max.with_tax}}
+            <abbr title="{{lang 'products.excluding_tax'}}">{{lang 'products.price_without_tax' tax_label=price_range.min.tax_label}}</abbr>
+        {{/and}}
+        {{#if schema_org}}
+            <meta itemprop="availability" content="{{product.availability}}">
+            <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
+            <div itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
+                <meta itemprop="minPrice" content="{{price_range.min.without_tax.value}}"  />
+                <meta itemprop="price" content="{{price_range.min.without_tax.value}}">
+                <meta itemprop="maxPrice" content="{{price_range.max.without_tax.value}}"  />
+                <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
+                <meta itemprop="valueAddedTaxIncluded" content="false">
+            </div>
+        {{/if}}
+    </div>
+{{/and}}

--- a/templates/components/products/price.html
+++ b/templates/components/products/price.html
@@ -1,51 +1,5 @@
-{{#or has_options product.options.length}}
-    {{#if price.with_tax}}
-        <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
-            {{#if price.rrp_with_tax}}
-                <span data-product-rrp-with-tax class="price price--rrp">{{price.rrp_with_tax.formatted}}</span>
-            {{/if}}
-            {{#if page_type '!==' 'product'}}
-                {{#if theme_settings.price_as_low_as}}
-                    <span translate>As low as </span>
-                {{/if}}
-            {{/if}}
-            <span data-product-price-with-tax class="price">{{price.with_tax.formatted}}</span>
-            {{#if price.without_tax}}
-                {{lang 'products.price_with_tax' tax_label=price.tax_label}}
-            {{/if}}
-        </div>
-    {{/if}}
-    {{#if price.without_tax}}
-        <div class="price-section price-section--withoutTax {{#if price.with_tax}}price-section--minor{{/if}}"  {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
-            {{#if price.rrp_without_tax}}
-                <span data-product-rrp-without-tax class="price price--rrp">{{price.rrp_without_tax.formatted}}</span>
-            {{/if}}
-            {{#if schema_org}}
-                <meta itemprop="price" content="{{price.without_tax.value}}">
-                <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
-                <meta itemprop="availability" content="{{product.availability}}">
-                <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
-            {{/if}}
-            {{#if page_type '!==' 'product'}}
-                {{#if theme_settings.price_as_low_as}}
-                    <span translate>As low as </span>
-                {{/if}}
-            {{/if}}
-            <span data-product-price-without-tax class="price price--withoutTax">{{price.without_tax.formatted}}</span>
-            {{#if price.with_tax}}
-                <abbr title="{{lang 'products.excluding_tax'}}">{{lang 'products.price_without_tax' tax_label=price.tax_label}}</abbr>
-            {{/if}}
-        </div>
-    {{/if}}
-    {{#if page_type '===' 'product'}}
-        {{#if price.saved}}
-            <div class="price-section price-section--saving">
-                <span class="price">
-                    {{lang 'products.you_save' amount=price.saved.formatted}}
-                </span>
-            </div>
-        {{/if}}
-    {{/if}}
+{{#and price.price_range (if theme_settings.price_ranges '==' true)}}
+    {{> components/products/price-range price_range=price.price_range schema_org=schema_org}}
 {{else}}
     {{#if price.with_tax}}
         <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
@@ -53,8 +7,17 @@
                 <span data-product-rrp-with-tax class="price price--rrp">{{price.rrp_with_tax.formatted}}</span>
             {{/if}}
             <span data-product-price-with-tax class="price">{{price.with_tax.formatted}}</span>
+            {{#if schema_org}}
+                <meta itemprop="availability" content="{{product.availability}}">
+                <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
+                <div itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
+                    <meta itemprop="price" content="{{price.with_tax.value}}">
+                    <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
+                    <meta itemprop="valueAddedTaxIncluded" content="true">
+                </div>
+            {{/if}}
             {{#if price.without_tax}}
-                {{lang 'products.price_with_tax' tax_label=price.tax_label}}
+                <abbr title="{{lang 'products.excluding_tax'}}">{{lang 'products.price_with_tax' tax_label=price.tax_label}}</abbr>
             {{/if}}
         </div>
     {{/if}}
@@ -63,11 +26,16 @@
             {{#if price.rrp_without_tax}}
                 <span data-product-rrp-without-tax class="price price--rrp">{{price.rrp_without_tax.formatted}}</span>
             {{/if}}
-            {{#if schema_org}}
-                <meta itemprop="price" content="{{price.without_tax.value}}">
-                <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
-            {{/if}}
             <span data-product-price-without-tax class="price price--withoutTax">{{price.without_tax.formatted}}</span>
+            {{#if schema_org}}
+                <meta itemprop="availability" content="{{product.availability}}">
+                <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
+                <div itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
+                    <meta itemprop="price" content="{{price.without_tax.value}}">
+                    <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
+                    <meta itemprop="valueAddedTaxIncluded" content="false">
+                </div>
+            {{/if}}
             {{#if price.with_tax}}
                 <abbr title="{{lang 'products.excluding_tax'}}">{{lang 'products.price_without_tax' tax_label=price.tax_label}}</abbr>
             {{/if}}
@@ -82,4 +50,4 @@
             </div>
         {{/if}}
     {{/if}}
-{{/or}}
+{{/and}}


### PR DESCRIPTION
#### What?

-Remove "as low as" feature (no longer needed with price ranges)
-Add new "price range" boolean theme editor setting, defaulting to true, to display ranges
-Augment price component to support ranges if available and enabled (graceful fallback for stores not enabled)
-Update schema.org to use PriceSpecification so that we can correctly support ranges and also inc tax/exc tax

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [CATALOG-1447](https://jira.bigcommerce.com/browse/CATALOG-1447)
- [CATALOG-1450](https://jira.bigcommerce.com/browse/CATALOG-1450)

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/8922457/34699077-1f5602d6-f4a1-11e7-93ee-9984f3123c3b.png)

#### Other important notes
- This effectively removes support for display of Retail Price when there's a price range. This is intentional, because it might not make too much sense to display a singular Retail Price in conjunction with a price range. As retail prices get range support, we can add it back in.
- Similarly, I haven't yet done anything for the behavior of Sale Price
  
  