### PR TITLE
STRF-4302 - Fix mis-sized product images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixes functionality of date picker option on product pages. [#1125](https://github.com/bigcommerce/cornerstone/pull/1125)
 - Fix image-overlap on Orders page [#1137](https://github.com/bigcommerce/cornerstone/pull/1137)
 - Fixes issue with image zoom causing scrolling issues on mobile. [#1141](https://github.com/bigcommerce/cornerstone/pull/1141)
+- Fix mis-sized product images. [#1145](https://github.com/bigcommerce/cornerstone/pull/1145)
 
 ## 1.10.0 (2017-11-15)
 - Fix spaces in faceted search option names [#1113](https://github.com/bigcommerce/cornerstone/pull/1113)

--- a/assets/scss/components/foundation/lazyLoad/_lazyLoad.scss
+++ b/assets/scss/components/foundation/lazyLoad/_lazyLoad.scss
@@ -3,7 +3,7 @@
 }
 
 @mixin lazy-loaded-img() {
-    position: relative;
+    position: absolute;
     top: 0;
     bottom: 0;
     left: 0;

--- a/assets/scss/components/stencil/account/_account.scss
+++ b/assets/scss/components/stencil/account/_account.scss
@@ -44,6 +44,8 @@
 
     .account-product-image {
         @include lazy-loaded-img;
+
+        position: relative;
     }
 }
 


### PR DESCRIPTION
#### What?

* this fixes a bug introduced by #1137.  now `position: relative` is only used for 'account' pages which includes the orders page

#### Ticket

- [STRF-4302](https://jira.bigcommerce.com/browse/STRF-4302)

#### Screenshots

![screen shot 2018-01-04 at 3 32 54 pm](https://user-images.githubusercontent.com/1357197/34588953-a1d64bf2-f164-11e7-8a00-076baacc9c87.png)

![screen shot 2018-01-04 at 3 33 10 pm](https://user-images.githubusercontent.com/1357197/34588955-a5af517e-f164-11e7-8e4a-c703311a97bb.png)

ping @bigcommerce/storefront-team   