### PR TITLE
Removes duplicate sandbox attribute from amp-iframe element.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Removes duplicate amp-iframe attributes for Google Amp product-view temaplate [#1148](https://github.com/bigcommerce/cornerstone/pull/1148)
 
 ## 1.11.0 (2018-01-08)
 - Fixes functionality of carousel links in IE and Edge. [#1093](https://github.com/bigcommerce/cornerstone/pull/1093)

--- a/templates/components/amp/products/product-view.html
+++ b/templates/components/amp/products/product-view.html
@@ -33,7 +33,6 @@
                     layout="responsive"
                     sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-top-navigation allow-modals"
                     resizable
-                    sandbox="allow-scripts allow-forms allow-top-navigation"
                     src="{{product.amp_options_url}}">
                     <div class="button button--primary button--wide" overflow tabindex="0" role="button">Choose Options</div>
                 </amp-iframe>


### PR DESCRIPTION
#### What?

There was a duplicate attribute for 'sandbox' on the <amp-iframe> in the /templates/components/amp/products/product-view.html file. This is to remove the duplicate.

Normally the second attribute would not be rendered, but Google checks the source not the rendered DOM.

#### Tickets / Documentation

[JIRA STRF-4326](https://jira.bigcommerce.com/browse/STRF-4326)

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/23507446/34789608-86ba119c-f604-11e7-9f62-070422778afe.png)
