### PR TITLE
STRF-4282 - Add support in Cornerstone to consume AMP ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Fix logo not loading on order confirmation page [#1159](https://github.com/bigcommerce/cornerstone/pull/1159)
+- Add support in Cornerstone to consume AMP ID [#1155](https://github.com/bigcommerce/cornerstone/pull/1155)
 
 ## 1.12.1 (2018-01-23)
 - Fix event delegation error [#1151](https://github.com/bigcommerce/cornerstone/pull/1151)

--- a/config.json
+++ b/config.json
@@ -41,7 +41,6 @@
     "Firefox ESR"
   ],
   "settings": {
-    "amp_analytics_id": "",
     "homepage_new_products_count": 12,
     "homepage_featured_products_count": 8,
     "homepage_top_products_count": 8,

--- a/schema.json
+++ b/schema.json
@@ -2577,15 +2577,5 @@
         "id": "optimizedCheckout-loadingToaster-textColor"
       }
     ]
-  },
-  {
-    "name": "Google AMP (beta)",
-    "settings": [
-      {
-        "type": "text",
-        "label": "AMP Analytics ID",
-        "id": "amp_analytics_id"
-      }
-    ]
   }
 ]

--- a/templates/layout/amp.html
+++ b/templates/layout/amp.html
@@ -20,7 +20,7 @@
         {{{snippet 'htmlhead'}}}
         <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
         <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
-        {{#if theme_settings.amp_analytics_id}}
+        {{#if settings.amp_analytics_id}}
             <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
         {{/if}}
         {{#block "amp-scripts"}}{{/block}}

--- a/templates/pages/amp/category.html
+++ b/templates/pages/amp/category.html
@@ -42,12 +42,12 @@ category:
     </main>
     {{> components/amp/category/subcategories}}
     {{> components/amp/common/footer }}
-    {{#if theme_settings.amp_analytics_id}}
+    {{#if settings.amp_analytics_id}}
         <amp-analytics type="googleanalytics">
             <script type="application/json">
             {
                 "vars": {
-                    "account": "{{theme_settings.amp_analytics_id}}"
+                    "account": "{{settings.amp_analytics_id}}"
                 },
                 "extraUrlParams": {
                     "cd1": "{{page_type}}",

--- a/templates/pages/amp/product.html
+++ b/templates/pages/amp/product.html
@@ -28,12 +28,12 @@ product:
     <div itemscope itemtype="http://schema.org/Product">
         {{> components/amp/products/product-view schema=true}}
     </div>
-    {{#if theme_settings.amp_analytics_id}}
+    {{#if settings.amp_analytics_id}}
         <amp-analytics type="googleanalytics">
             <script type="application/json">
             {
                 "vars": {
-                    "account": "{{theme_settings.amp_analytics_id}}"
+                    "account": "{{settings.amp_analytics_id}}"
                 },
                 "extraUrlParams": {
                     "cd1": "{{page_type}}",


### PR DESCRIPTION
#### What?

Adds support to consume AMP ID (on the product and/or category rather than config)

#### Tickets

- [STRF-4282](https://jira.bigcommerce.com/browse/STRF-4282)
- [STRF-4245](https://jira.bigcommerce.com/browse/STRF-4245)

#### GIFs

http://g.recordit.co/eD9i23HoIt.gif
http://g.recordit.co/RpAKTvRMxh.gif

ping @bigcommerce/storefront-team @bookernath 