### PR TITLE
MERC-3034: Add head.scripts reference to checkout & order_confirmation pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Draft
 
+- Add head.scripts reference to checkout & order_confirmation pages [#1158](https://github.com/bigcommerce/cornerstone/pull/1158)
+
 ## 1.12.1 (2018-01-23)
 - Fix event delegation error [#1151](https://github.com/bigcommerce/cornerstone/pull/1151)
 

--- a/templates/pages/checkout.html
+++ b/templates/pages/checkout.html
@@ -8,6 +8,8 @@
     window.language = {{{langJson 'optimized_checkout'}}};
 </script>
 
+{{{head.scripts}}}
+
 {{/partial}}
 
 {{#partial "page"}}

--- a/templates/pages/order-confirmation.html
+++ b/templates/pages/order-confirmation.html
@@ -7,6 +7,8 @@
     window.language = {{{langJson 'optimized_checkout'}}};
 </script>
 
+{{{head.scripts}}}
+
 {{/partial}}
 
 {{#partial "page"}}


### PR DESCRIPTION
#### What?

Adds support for rendering head.scripts on the checkout and order_confirmation pages.

#### Tickets / Documentation

- [MERC-3034](https://jira.bigcommerce.com/browse/MERC-3034)

#### Screenshots (if appropriate)

N/A