### PR TITLE
STRF-4373: Removing lazyload for logo in order-confirmation.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fix logo not loading on order confirmation page [#1159](https://github.com/bigcommerce/cornerstone/pull/1159)
 
 ## 1.12.1 (2018-01-23)
 - Fix event delegation error [#1151](https://github.com/bigcommerce/cornerstone/pull/1151)

--- a/templates/pages/order-confirmation.html
+++ b/templates/pages/order-confirmation.html
@@ -16,7 +16,7 @@
         <h2 class="checkoutHeader-heading">
             <a class="checkoutHeader-link" href="{{urls.home}}">
                 {{#if checkout.header_image}}
-                    <img alt="{{settings.store_logo.title}}" class="checkoutHeader-logo lazyload" id="logoImage" data-sizes="auto" src="{{cdn 'img/loading.svg'}}" data-src="{{ checkout.header_image }}"/>
+                    <img alt="{{settings.store_logo.title}}" class="checkoutHeader-logo" id="logoImage" src="{{ checkout.header_image }}"/>
                 {{ else }}
                     <span class="header-logo-text">{{settings.store_logo.title}}</span>
                 {{/if}}


### PR DESCRIPTION
#### What?

The image for the order-confirmation.html was not loading, and as with the issue in [STRF-4138](https://jira.bigcommerce.com/browse/STRF-4138), I've removed the lazyload for the logo for this template page.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [STRF-4138](https://jira.bigcommerce.com/browse/STRF-4138)
- [STRF-4373](https://jira.bigcommerce.com/browse/STRF-4373)

#### Screenshots (if appropriate)

[Before](https://www.screencast.com/t/VRojxYj1y8)

[After](https://www.screencast.com/t/cyl6e8sv1)
