### PR TITLE
STRF-4391 - DO NOT MERGE - testing stencil-utils jQuery 3 bump alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ or just `grunt`.
 #### License
 
 (The MIT License)
-Copyright (C) 2015-2017 BigCommerce Inc.
+Copyright (C) 2015-present BigCommerce Inc.
 All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "BigCommerce",
   "license": "MIT",
   "dependencies": {
-    "@bigcommerce/stencil-utils": "github:mjschock/stencil-utils#STRF-4391",
+    "@bigcommerce/stencil-utils": "^1.1.1",
     "async": "^2.5.0",
     "babel-polyfill": "^6.26.0",
     "easyzoom": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "BigCommerce",
   "license": "MIT",
   "dependencies": {
-    "@bigcommerce/stencil-utils": "^1.0.10",
+    "@bigcommerce/stencil-utils": "github:mjschock/stencil-utils#STRF-4391",
     "async": "^2.5.0",
     "babel-polyfill": "^6.26.0",
     "easyzoom": "^2.5.0",


### PR DESCRIPTION
* this is just for testing purposes - want to make sure upstream jQuery 3 upgrade for stencil-utils doesn't break cornerstone
