### PR TITLE
STRF-4455: Fixing easyzoom on mobile viewports in landscape from preventing scro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix logo not loading on order confirmation page [#1159](https://github.com/bigcommerce/cornerstone/pull/1159)
 - Add support in Cornerstone to consume AMP ID [#1155](https://github.com/bigcommerce/cornerstone/pull/1155)
 - Fix option selection reset bug when a variation is out of stock [#1160](https://github.com/bigcommerce/cornerstone/pull/1160)
+- Fix easyzoom preventing page scrolling on mobile [#1164](https://github.com/bigcommerce/cornerstone/pull/1164)
 
 ## 1.12.1 (2018-01-23)
 - Fix event delegation error [#1151](https://github.com/bigcommerce/cornerstone/pull/1151)

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -34,7 +34,7 @@
         margin-top: spacing("half");
     }
 
-    @media (min-width: $screen-xxsmall) and (max-width: $screen-xsmall) {
+    @media (min-width: $screen-xxsmall) and (max-width: $screen-medium) {
         pointer-events: none;
     }
 }


### PR DESCRIPTION
#### What?

When mobile devices are in landscape (Android, iPad, iPhone) the image zoom triggers while the touch is detected on the image and covers almost all of the screen that is needed to scroll. This prevents the user from going back up or scrolling further down.

#### Tickets / Documentation

- [STRF-4455](https://jira.bigcommerce.com/browse/STRF-4455)

#### Screenshots (if appropriate)
Before:
![before](https://user-images.githubusercontent.com/23507446/35754042-a43729dc-0827-11e8-820f-56ce58a2776f.gif)

 @After:
![after](https://user-images.githubusercontent.com/23507446/35754055-aff08886-0827-11e8-9faa-92b4e30d3d2f.gif)

@mjschock 