### PR TITLE
STRF-4340 Set slick-next/prev to have top 50%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Fix "Shop by Price" toggle in theme editor to hide Shop by Price when faceted search is not enabled. [#1161](https://github.com/bigcommerce/cornerstone/pull/1161)
+- Fix slick-next and slick-prev so that they are centered across all screen sizes. [#1166](https://github.com/bigcommerce/cornerstone/pull/1166)
 
 ## 1.13.0 (2018-02-05)
 - Fix logo not loading on order confirmation page [#1159](https://github.com/bigcommerce/cornerstone/pull/1159)

--- a/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
+++ b/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
@@ -42,11 +42,7 @@
 
     .slick-next,
     .slick-prev {
-        top: 20%;
-
-        @include breakpoint("medium") {
-            top: 50%;
-        }
+        top: 50%;
     }
 
     .slick-next {


### PR DESCRIPTION
#### What?

The slick-next and slick-prev nav arrows for the carousel had a top spacing of 20% which on smaller screens pushed them very close to the top of the page, and not centered like it is on medium and large size devices. This fix, allows the nav arrows to be centered across all device screen sizes.

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/STRF-4340

#### Screenshots (if appropriate)

<img width="537" alt="slick-next previous 20 percent" src="https://user-images.githubusercontent.com/20480124/36242676-5685aea8-1271-11e8-9acb-1f20319efdcc.png">

<img width="519" alt="slick-next previous 50 percent" src="https://user-images.githubusercontent.com/20480124/36242680-5e38886e-1271-11e8-806b-fab26420d74b.png">

ping @junedkazi @mjschock 