### PR TITLE
CATALOG-2408 - Bulk Pricing updates per-variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Fix "Shop by Price" toggle in theme editor to hide Shop by Price when faceted search is not enabled. [#1161](https://github.com/bigcommerce/cornerstone/pull/1161)
 - Fix slick-next and slick-prev so that they are centered across all screen sizes. [#1166](https://github.com/bigcommerce/cornerstone/pull/1166)
+- Add support for per-variant bulk pricing tier display on PDP [#1167](https://github.com/bigcommerce/cornerstone/pull/1167)
 
 ## 1.13.0 (2018-02-05)
 - Fix logo not loading on order confirmation page [#1159](https://github.com/bigcommerce/cornerstone/pull/1159)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "BigCommerce",
   "license": "MIT",
   "dependencies": {
-    "@bigcommerce/stencil-utils": "^1.1.1",
+    "@bigcommerce/stencil-utils": "^1.1.2",
     "async": "^2.5.0",
     "babel-polyfill": "^6.26.0",
     "easyzoom": "^2.5.0",

--- a/templates/components/products/bulk-discount-rates.html
+++ b/templates/components/products/bulk-discount-rates.html
@@ -1,11 +1,12 @@
 {{#if bulk_discount_rates.length}}
-    <dt class="productView-info-name">{{lang 'products.bulk_pricing.title'}}</dt>
+    {{#if product}}<dt class="productView-info-name">{{lang 'products.bulk_pricing.title'}}</dt>{{/if}}
     <dd class="productView-info-value">
-        <a href="{{url}}" data-reveal-id="bulkPricingModal-{{id}}-{{$index}}">
+        <a href="{{url}}"
+           {{#unless is_ajax }}data-reveal-id="bulkPricingModal{{#if id}}-{{id}}-{{$index}}{{/if}}">{{/unless}}
             {{lang 'products.bulk_pricing.view'}}
         </a>
     </dd>
-    <div id="bulkPricingModal-{{id}}-{{$index}}" class="modal modal--small" data-reveal>
+    <div id="bulkPricingModal{{#if id}}-{{id}}-{{$index}}{{/if}}" class="modal modal--small" data-reveal>
         <div class="modal-header">
             <h2 class="modal-header-title">{{lang 'products.bulk_pricing.modal_title'}}</h2>
             <a href="#" class="modal-close" aria-label="Close"><span aria-hidden="true">&#215;</span></a>
@@ -13,20 +14,20 @@
         <div class="modal-body">
             <p>{{lang 'products.bulk_pricing.instructions'}}</p>
             <ul>
-            {{#each bulk_discount_rates}}
+                {{#each bulk_discount_rates}}
                 <li>
                     {{lang 'products.bulk_pricing.range' min=min max=max}}
                     {{#if type '===' 'percent'}}
-                        {{lang 'products.bulk_pricing.percent' discount=discount.formatted}}
+                    {{lang 'products.bulk_pricing.percent' discount=discount.formatted}}
                     {{/if}}
                     {{#if type '===' 'fixed'}}
-                        {{lang 'products.bulk_pricing.fixed' discount=discount.formatted}}
+                    {{lang 'products.bulk_pricing.fixed' discount=discount.formatted}}
                     {{/if}}
                     {{#if type '===' 'price'}}
-                        {{lang 'products.bulk_pricing.price' discount=discount.formatted}}
+                    {{lang 'products.bulk_pricing.price' discount=discount.formatted}}
                     {{/if}}
                 </li>
-            {{/each}}
+                {{/each}}
             </ul>
         </div>
     </div>

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -135,41 +135,10 @@
                         {{/if}}
                     {{/if}}
                 {{/if}}
-                {{#if product.bulk_discount_rates.length}}
-                    <dt class="productView-info-name">{{lang 'products.bulk_pricing.title'}}</dt>
-                    <dd class="productView-info-value">
-                        <a href="{{product.url}}"
-                            {{#unless is_ajax }}data-reveal-id="bulkPricingModal" {{/unless}}>
-                            {{lang 'products.bulk_pricing.view'}}
-                        </a>
-                    </dd>
 
-                    <div id="bulkPricingModal" class="modal modal--small" data-reveal>
-                        <div class="modal-header">
-                            <h2 class="modal-header-title">{{lang 'products.bulk_pricing.modal_title'}}</h2>
-                            <a href="#" class="modal-close" aria-label="Close"><span aria-hidden="true">&#215;</span></a>
-                        </div>
-                        <div class="modal-body">
-                            <p>{{lang 'products.bulk_pricing.instructions'}}</p>
-                            <ul>
-                            {{#each product.bulk_discount_rates}}
-                                <li>
-                                    {{lang 'products.bulk_pricing.range' min=min max=max}}
-                                    {{#if type '===' 'percent'}}
-                                        {{lang 'products.bulk_pricing.percent' discount=discount.formatted}}
-                                    {{/if}}
-                                    {{#if type '===' 'fixed'}}
-                                        {{lang 'products.bulk_pricing.fixed' discount=discount.formatted}}
-                                    {{/if}}
-                                    {{#if type '===' 'price'}}
-                                        {{lang 'products.bulk_pricing.price' discount=discount.formatted}}
-                                    {{/if}}
-                                </li>
-                            {{/each}}
-                            </ul>
-                        </div>
-                    </div>
-                {{/if}}
+                <div class="productView-info-bulkPricing">
+                    {{> components/products/bulk-discount-rates bulk_discount_rates=product.bulk_discount_rates}}
+                </div>
 
                 {{#each product.custom_fields}}
                     <dt class="productView-info-name">{{name}}:</dt>


### PR DESCRIPTION
#### What?

Price Lists support different bulk pricing tiers for each variant, so we need to update the viewModel whenever these tiers change.

#### Tickets / Documentation

- [CATALOG-2408](https://jira.bigcommerce.com/browse/CATALOG-2408)

#### Screenshots (if appropriate)

![GIF](https://i.imgur.com/VgjfBjT.gif)
