### PR TITLE
STRF-4502 - Fix invoice styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Fix product options unhiding indexing issue. [#1176](https://github.com/bigcommerce/cornerstone/pull/1176)
 - Fix ItemAvailability microdata schema for product pages. [#1174](https://github.com/bigcommerce/cornerstone/pull/1174)
+- Fix invoice.css styles. [#1171](https://github.com/bigcommerce/cornerstone/pull/1171)
 
 ## 1.13.2 (2018-02-28)
 

--- a/templates/pages/account/orders/invoice.html
+++ b/templates/pages/account/orders/invoice.html
@@ -1,5 +1,5 @@
 {{#partial "head"}}
-    <link href="{{cdn 'assets/css/invoice.css'}}" rel="stylesheet">
+    {{{ stylesheet '/assets/css/invoice.css' }}}
 {{/partial}}
 
 {{#partial "page"}}


### PR DESCRIPTION
#### What?

* fixes the invoice.css styles which were broken because the cdn helper doesn't properly handle configId.  they're now using the stylesheet helper like the others.

#### Ticket

- [STRF-4502](https://jira.bigcommerce.com/browse/STRF-4502)

#### Screenshots

* after
<img width="902" alt="screen shot 2018-02-27 at 1 19 12 pm" src="https://user-images.githubusercontent.com/1357197/36755397-e7edeede-1bc0-11e8-979a-1ae2e6c4760e.png">

* before
![GIF](http://g.recordit.co/Towdq7C0zE.gif)

ping @bigcommerce/storefront-team 
