### PR TITLE
Don't clear bulk pricing rules when feature is disabled.

### DIFF
--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -395,11 +395,10 @@ export default class ProductDetails {
             viewModel.$addToCart.prop('disabled', false);
             viewModel.$increments.prop('disabled', false);
         }
-
         // If Bulk Pricing rendered HTML is available
         if (data.bulk_discount_rates && content) {
             viewModel.$bulkPricing.html(content);
-        } else {
+        } else if (typeof (data.bulk_discount_rates) !== 'undefined') {
             viewModel.$bulkPricing.html('');
         }
     }


### PR DESCRIPTION
Previous PR was removing catalog bulk pricing rules if the bulk pricing experiment was off for a store. We should make sure not to delete information in that case. This change reduces dependency on the deployment of another feature.

ping @mjschock 