### PR TITLE
STRF-3168 - ItemAvailability schema for products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Fix product options unhiding indexing issue. [#1176](https://github.com/bigcommerce/cornerstone/pull/1176)
+- Fix ItemAvailability microdata schema for product pages. [#1174](https://github.com/bigcommerce/cornerstone/pull/1174)
 
 ## 1.13.2 (2018-02-28)
 

--- a/templates/components/products/price.html
+++ b/templates/components/products/price.html
@@ -28,7 +28,8 @@
             {{/if}}
             <span data-product-price-without-tax class="price price--withoutTax">{{price.without_tax.formatted}}</span>
             {{#if schema_org}}
-                <meta itemprop="availability" content="{{product.availability}}">
+                <meta itemprop="availability" itemtype="http://schema.org/ItemAvailability"
+                    content="http://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
                 <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
                 <div itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
                     <meta itemprop="price" content="{{price.without_tax.value}}">


### PR DESCRIPTION
#### What?

* fixes schema.org microdata ItemAvailability for product pages

#### Why?

* the `product.availability` field maps to the Availability text field under a product's Other Details section and therefore does not necessarily satisfy the enumerated fields for ItemAvailability.  now we're explicitly selecting one of those enums depending on the product's fields.  note that this will always show InStock when 'Track inventory by options' is enabled, regardless of the stock level of a variant.

#### Tickets

- [STRF-3168](https://jira.bigcommerce.com/browse/STRF-3168)
- https://forum.bigcommerce.com/s/question/0D51B00004ANw0v/here-is-an-improved-code-for-itemprop-availability-in-cornerstone-stencil-theme

#### Screenshots

* before
![screen shot 2018-02-28 at 3 49 37 pm](https://user-images.githubusercontent.com/1357197/36819631-113f1360-1c9f-11e8-9020-9935a1a2d884.png)

* after
![screen shot 2018-02-28 at 3 44 01 pm](https://user-images.githubusercontent.com/1357197/36819637-1808d488-1c9f-11e8-95a2-424422efa487.png)
![screen shot 2018-02-28 at 3 43 22 pm](https://user-images.githubusercontent.com/1357197/36819642-1d0bc580-1c9f-11e8-841c-c7adfc70327a.png)
![screen shot 2018-02-28 at 3 42 12 pm](https://user-images.githubusercontent.com/1357197/36819644-20033642-1c9f-11e8-8162-e50f33f4933c.png)

ping @bigcommerce/storefront-team 
