### PR TITLE
Add schema microdata for breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Fix product options unhiding indexing issue. [#1176](https://github.com/bigcommerce/cornerstone/pull/1176)
+- Add schema microdata for breadcrumbs. [#1175](https://github.com/bigcommerce/cornerstone/pull/1175)
 - Fix ItemAvailability microdata schema for product pages. [#1174](https://github.com/bigcommerce/cornerstone/pull/1174)
 - Fix invoice.css styles. [#1171](https://github.com/bigcommerce/cornerstone/pull/1171)
 

--- a/templates/components/common/breadcrumbs.html
+++ b/templates/components/common/breadcrumbs.html
@@ -1,11 +1,12 @@
-<ul class="breadcrumbs">
+<ul class="breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">
     {{#each breadcrumbs}}
-        <li class="breadcrumb {{#if @last}}is-active{{/if}}">
+        <li class="breadcrumb {{#if @last}}is-active{{/if}}" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
             {{#if url}}
-                <a href="{{url}}" class="breadcrumb-label">{{name}}</a>
+                <a href="{{url}}" class="breadcrumb-label" itemprop="item">{{name}}</a>
             {{else}}
-                <span class="breadcrumb-label">{{name}}</span>
+                <span class="breadcrumb-label" itemprop="name">{{name}}</span>
             {{/if}}
+            <meta itemprop="position" content="{{@index}}" />
         </li>
     {{/each}}
 </ul>


### PR DESCRIPTION
#### What?

Adds microdata schema for breadcrumbs.

#### Screenshots (if appropriate)

![screen shot 2018-02-28 at 4 19 25 pm](https://user-images.githubusercontent.com/1357197/36820581-68e59d74-1ca3-11e8-84c1-dfa1cde0f5d2.png)

