### PR TITLE
MERC-3389: Move Google Font CSS loading to end of body.

### DIFF
--- a/templates/layout/amp-iframe.html
+++ b/templates/layout/amp-iframe.html
@@ -8,7 +8,6 @@
         <link href="{{ head.favicon }}" rel="shortcut icon">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
         {{{stylesheet '/assets/css/theme.css'}}}
-        {{ getFontsCollection }}
         <script src="{{cdn 'assets/modernizr-custom.js'}}"></script>
 
         {{{ head.scripts }}}
@@ -46,5 +45,6 @@
             }, false);
         </script>
 
+        {{ getFontsCollection }}
     </body>
 </html>

--- a/templates/layout/amp.html
+++ b/templates/layout/amp.html
@@ -10,7 +10,6 @@
         {{{ head.config }}}
         {{#block "head"}} {{/block}}
         <link href="{{ head.favicon }}" rel="shortcut icon">
-        <link href="https://fonts.googleapis.com/css?family=Karla:400|Montserrat:400|Oswald:300" rel="stylesheet">
         {{#block "amp-style"}} {{/block}}
         {{{head.rsslinks}}}
         {{inject 'themeSettings' theme_settings}}
@@ -27,5 +26,6 @@
     </head>
     <body>
         {{#block "page"}} {{/block}}
+        <link href="https://fonts.googleapis.com/css?family=Karla:400|Montserrat:400|Oswald:300" rel="stylesheet">
     </body>
 </html>

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -8,7 +8,6 @@
         <link href="{{ head.favicon }}" rel="shortcut icon">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
         {{{stylesheet '/assets/css/theme.css'}}}
-        {{ getFontsCollection }}
         <script src="{{cdn 'assets/modernizr-custom.js'}}"></script>
 
         {{{head.scripts}}}
@@ -40,6 +39,7 @@
             window.stencilBootstrap("{{page_type}}", {{jsContext}}).load();
         </script>
 
+        {{ getFontsCollection }}
         {{{footer.scripts}}}
         {{{snippet 'footer'}}}
     </body>


### PR DESCRIPTION
#### What?

Currently we are loading the Google WebFont CSS in the HTML head of the page. Since loading CSS is a blocking operation, the page will be blocked from rendering the document while we are fetching the script.

Also since this blocks, if the web font css goes down, the entire page will be blocked from loading. In the following screenshot, you can see 99% of the page will be failed to render if the source goes down. This is referred to as a "Single Point of Failure" (SPOF).

<img width="1552" alt="screen shot 2018-03-06 at 11 02 29 pm" src="https://user-images.githubusercontent.com/955777/37078106-bf9efb30-2192-11e8-8727-a7a942ee4fad.png">

#### Tickets / Documentation

- Tool Used: [Spof-O-Matic](https://chrome.google.com/webstore/detail/spof-o-matic/plikhggfbplemddobondkeogomgoodeg?hl=en-US)
- [Frontend SPOF](https://www.stevesouders.com/blog/2010/06/01/frontend-spof/)
