### PR TITLE
hackathon: Save proper amount of space for carousel

### DIFF
--- a/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
+++ b/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
@@ -8,36 +8,29 @@
 //    large screens to scale image. Use visibility because the JS uses the height
 //    to set the slide size. (For browsers with object-fit only)
 //
-// 2. With JS on, minimise the jump in content as you progressively enhance the
-//    slider. Slowly fade and slide the height, instead of a jump in collapsing
-//    hidden content.
-//
-// 3. Visually overrides the top margin for '.body' defined in _body.scss.
+// 2. Visually overrides the top margin for '.body' defined in _body.scss.
 //    The '.body' top margin creates space between the header and page content.
 //    However, on the homepage, we want the carousel to be flush with the header.
 //
-// 4. Allows image to scale on large screens while preventing the top and bottom
+// 3. Allows image to scale on large screens while preventing the top and bottom
 //    from becoming cut off.
 // -----------------------------------------------------------------------------
 
 .heroCarousel {
-    margin-bottom: (spacing("double") + spacing("single"));
+    margin-bottom: 30px; // from slick-theme.scss
     margin-top: -(spacing("single")); // 3
 
     @include breakpoint("medium") {
         margin-top: -(spacing("single") + spacing("base")); // 3
     }
 
-    .js & { // 2
-        max-height: remCalc(0);
-        opacity: 0;
-        overflow: hidden;
-        transition: all 600ms ease-out;
-    }
-
     &.slick-initialized { // 2
         max-height: remCalc(1000);
         opacity: 1;
+    }
+
+    &:not(.slick-initialized) :not(.heroCarousel-slide--first).heroCarousel-slide {
+        display: none;
     }
 
     .slick-next,
@@ -105,6 +98,11 @@
     }
 }
 
+.heroCarousel-image-wrapper {
+    @include breakpoint("medium") {
+        max-height: remCalc(600px);
+    }
+}
 .no-objectfit .heroCarousel-image {
     @include breakpoint("medium") { // 1
         visibility: hidden;

--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -10,10 +10,12 @@
     }'>
     {{#each carousel.slides}}
     <a href="{{url}}">
-        <div class="heroCarousel-slide {{#if ../theme_settings.homepage_stretch_carousel_images}}heroCarousel-slide--stretch{{/if}}"
+        <div class="heroCarousel-slide {{#if ../theme_settings.homepage_stretch_carousel_images}}heroCarousel-slide--stretch{{/if}} {{#if @first}}heroCarousel-slide--first{{/if}}"
             style="background-image: url({{image}})">
-            <img class="heroCarousel-image" data-lazy="{{image}}" alt="{{alt_text}}" title="{{alt_text}}""
-             {{#if image_width}}width="{{image_width}}"{{/if}} {{#if image_height}}height="{{image_height}}"{{/if}} />
+            <div class="heroCarousel-image-wrapper" {{#if image_height}}{{#if image_width}}style="height: {{multiply (divide image_height image_width) 100}}vw"{{/if}}{{/if}}>
+                <img class="heroCarousel-image" data-lazy="{{image}}" alt="{{alt_text}}" title="{{alt_text}}"
+                {{#if image_width}}width="{{image_width}}"{{/if}} {{#if image_height}}height="{{image_height}}"{{/if}} />
+            </div>
             {{#if heading}}
                 {{> components/carousel-content show_background=true}}
             {{else}}


### PR DESCRIPTION
#### What?

Use the data we have on image height/width to size each slide of the carousel relative to page width before the image loads. This fixes the pop-in associated with the carousel loading, which in turn prevents images below the fold from lazy loading before necessary.