### PR TITLE
Add dns prefetch & preconnect for urls we know we are going to hit

### DIFF
--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -9,6 +9,11 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
         {{{stylesheet '/assets/css/theme.css'}}}
 
+        <link rel="dns-prefetch preconnect" href="//fonts.gstatic.com" crossorigin>
+        <link rel="dns-prefetch preconnect" href="//cdn8.bigcommerce.com" crossorigin>
+        <link rel="dns-prefetch preconnect" href="//cdn7.bigcommerce.com" crossorigin>
+        <link rel="dns-prefetch preconnect" href="https://event.jirafe.com" crossorigin>
+
         <script>
             WebFontConfig = {
                 classes: false,


### PR DESCRIPTION
## What?
It adds `dns-prefetch` & `preconnect` to domain names which we know we are going to hit.

### DNS prefetching
This notifies the client that there are assets we'll need later from a specific URL so the browser can resolve the DNS as quickly as possible. Say we need a resource, like an image or an audio file, from the URL example.com. In the <head> of the document we'd write:

### Preconnect
Much like the DNS prefetch method, preconnect will resolve the DNS but it will also make the TCP handshake, and optional TLS negotiation. It can be used like this:

## Tickets / Documentation

Add links to any relevant tickets and documentation.
- https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types
- https://css-tricks.com/prefetching-preloading-prebrowsing/
- https://www.igvita.com/2015/08/17/eliminating-roundtrips-with-preconnect/

## Screenshots (if appropriate)
Check `link` in the screenshot.
![screen shot 2018-03-09 at 11 09 41 am](https://user-images.githubusercontent.com/319659/37225102-6cad0468-238a-11e8-9294-09334581653a.png)
