### PR TITLE
split stencil bootstrap away from the rest of the theme bundle

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -57,40 +57,34 @@ const pageClasses = {
  * @param contextJSON
  * @returns {*}
  */
-window.stencilBootstrap = function stencilBootstrap(pageType, contextJSON = null, loadGlobal = true) {
-    const context = JSON.parse(contextJSON || {});
 
-    return {
-        load() {
-            $(async () => {
-                let globalClass;
-                let pageClass;
-                let PageClass;
+$(async () => {
+    let globalClass;
+    let pageClass;
+    let PageClass;
+    const { context, pageType, loadGlobal } = window.stencilBootstrap;
 
-                // Finds the appropriate class from the pageType.
-                const pageClassImporter = pageClasses[pageType];
-                if (typeof pageClassImporter === 'function') {
-                    PageClass = (await pageClassImporter()).default;
-                }
+    // Finds the appropriate class from the pageType.
+    const pageClassImporter = pageClasses[pageType];
+    if (typeof pageClassImporter === 'function') {
+        PageClass = (await pageClassImporter()).default;
+    }
 
-                if (loadGlobal) {
-                    globalClass = new Global();
-                    globalClass.context = context;
-                }
+    if (loadGlobal) {
+        globalClass = new Global();
+        globalClass.context = context;
+    }
 
-                if (PageClass) {
-                    pageClass = new PageClass(context);
-                    pageClass.context = context;
-                }
+    if (PageClass) {
+        pageClass = new PageClass(context);
+        pageClass.context = context;
+    }
 
-                if (globalClass) {
-                    globalClass.load();
-                }
+    if (globalClass) {
+        globalClass.load();
+    }
 
-                if (pageClass) {
-                    pageClass.load();
-                }
-            });
-        },
-    };
-};
+    if (pageClass) {
+        pageClass.load();
+    }
+});

--- a/assets/js/bootstrap.js
+++ b/assets/js/bootstrap.js
@@ -1,0 +1,13 @@
+__webpack_public_path__ = window.__webpack_public_path__; // eslint-disable-line
+
+/**
+ * This function gets added to the global window and then called
+ * on page load with the current template loaded and JS Context passed in
+ * @param pageType String
+ * @param contextJSON
+ * @returns {*}
+ */
+window.stencilBootstrap = function stencilBootstrap(pageType, contextJSON = null, loadGlobal = true) {
+    const context = JSON.parse(contextJSON || {});
+    window.stencilBootstrap = { context, pageType, loadGlobal };
+};

--- a/templates/layout/amp-iframe.html
+++ b/templates/layout/amp-iframe.html
@@ -29,12 +29,16 @@
         {{#block "page"}} {{/block}}
 
         <script>window.__webpack_public_path__ = "{{cdn 'assets/dist/'}}";</script>
-        <script src="{{cdn 'assets/dist/theme-bundle.main.js'}}"></script>
+        <script src="{{cdn 'assets/dist/theme-bundle.bootstrap.js'}}"></script>
 
         <script>
             // Exported in app.js
-            window.stencilBootstrap("{{page_type}}", {{jsContext}}, false).load();
+            window.stencilBootstrap("{{page_type}}", {{jsContext}}, false);
         </script>
+
+
+        <script defer src="{{cdn 'assets/dist/theme-bundle.main.js'}}"></script>
+
         <script type="text/javascript" charset="utf-8">
             function postHeight() {
                 window.parent.postMessage({

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -59,12 +59,14 @@
         {{> components/common/footer }}
 
         <script>window.__webpack_public_path__ = "{{cdn 'assets/dist/'}}";</script>
-        <script src="{{cdn 'assets/dist/theme-bundle.main.js'}}"></script>
+        <script src="{{cdn 'assets/dist/theme-bundle.bootstrap.js'}}"></script>
 
         <script>
             // Exported in app.js
-            window.stencilBootstrap("{{page_type}}", {{jsContext}}).load();
+            window.stencilBootstrap("{{page_type}}", {{jsContext}});
         </script>
+
+        <script defer src="{{cdn 'assets/dist/theme-bundle.main.js'}}"></script>
 
         {{{footer.scripts}}}
         {{{snippet 'footer'}}}

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -10,6 +10,7 @@ module.exports = {
     devtool: 'source-map',
     entry: {
         main: './assets/js/app.js',
+        bootstrap: './assets/js/bootstrap.js',
     },
     module: {
         rules: [


### PR DESCRIPTION
#### What?

Splits the bootstrap section of the webpack scripts from the rest of the scripts, allowing us to defer loading 231kb of the scripts, only loading 1.3kb synchronously.

(AMP page still needs to be changed)
