### PR TITLE
Webpack 4 + Javascript optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: node_js
 node_js:
-- 4
+  - 6
 sudo: required
 dist: trusty
 install:
-- bundle install
-- npm install -g grunt-cli
-- npm install -g bigcommerce/stencil-cli
-- npm install
+  - bundle install
+  - npm install -g grunt-cli
+  - npm install -g bigcommerce/stencil-cli
+  - npm install
 script:
-- grunt check
-- stencil bundle
+  - grunt check
+  - stencil bundle

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -63,32 +63,16 @@ window.stencilBootstrap = function stencilBootstrap(pageType, contextJSON = null
     return {
         load() {
             $(async () => {
-                let globalClass;
-                let pageClass;
-                let PageClass;
+                // Load globals
+                if (loadGlobal) {
+                    Global.load(context);
+                }
 
-                // Finds the appropriate class from the pageType.
+                // Find the appropriate page loader based on pageType
                 const pageClassImporter = pageClasses[pageType];
                 if (typeof pageClassImporter === 'function') {
-                    PageClass = (await pageClassImporter()).default;
-                }
-
-                if (loadGlobal) {
-                    globalClass = new Global();
-                    globalClass.context = context;
-                }
-
-                if (PageClass) {
-                    pageClass = new PageClass(context);
-                    pageClass.context = context;
-                }
-
-                if (globalClass) {
-                    globalClass.load();
-                }
-
-                if (pageClass) {
-                    pageClass.load();
+                    const PageClass = (await pageClassImporter()).default;
+                    PageClass.load(context);
                 }
             });
         },

--- a/assets/js/theme/account.js
+++ b/assets/js/theme/account.js
@@ -15,7 +15,7 @@ export default class Account extends PageManager {
         this.$body = $('body');
     }
 
-    loaded(next) {
+    onReady() {
         const $editAccountForm = classifyForm('form[data-edit-account-form]');
         const $addressForm = classifyForm('form[data-address-form]');
         const $inboxForm = classifyForm('form[data-inbox-form]');
@@ -67,8 +67,6 @@ export default class Account extends PageManager {
         }
 
         this.bindDeleteAddress();
-
-        next();
     }
 
     /**

--- a/assets/js/theme/auth.js
+++ b/assets/js/theme/auth.js
@@ -167,9 +167,8 @@ export default class Auth extends PageManager {
 
     /**
      * Request is made in this function to the remote endpoint and pulls back the states for country.
-     * @param next
      */
-    loaded(next) {
+    onReady() {
         const $createAccountForm = classifyForm(this.formCreateSelector);
         const $loginForm = classifyForm('.login-form');
         const $forgotPasswordForm = classifyForm('.forgot-password-form');
@@ -193,7 +192,5 @@ export default class Auth extends PageManager {
         if ($createAccountForm.length) {
             this.registerCreateAccountValidator($createAccountForm);
         }
-
-        next();
     }
 }

--- a/assets/js/theme/brand.js
+++ b/assets/js/theme/brand.js
@@ -4,7 +4,7 @@ import $ from 'jquery';
 import FacetedSearch from './common/faceted-search';
 
 export default class Brand extends CatalogPage {
-    loaded() {
+    onReady() {
         if ($('#facetedSearch').length > 0) {
             this.initFacetedSearch();
         } else {

--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -8,7 +8,7 @@ import { defaultModal } from './global/modal';
 import swal from 'sweetalert2';
 
 export default class Cart extends PageManager {
-    loaded(next) {
+    onReady() {
         this.$cartContent = $('[data-cart-content]');
         this.$cartMessages = $('[data-cart-status]');
         this.$cartTotals = $('[data-cart-totals]');
@@ -16,8 +16,6 @@ export default class Cart extends PageManager {
             .hide(); // TODO: temporary until roper pulls in his cart components
 
         this.bindEvents();
-
-        next();
     }
 
     cartUpdate($target) {

--- a/assets/js/theme/category.js
+++ b/assets/js/theme/category.js
@@ -4,7 +4,7 @@ import $ from 'jquery';
 import FacetedSearch from './common/faceted-search';
 
 export default class Category extends CatalogPage {
-    loaded() {
+    onReady() {
         if ($('#facetedSearch').length > 0) {
             this.initFacetedSearch();
         } else {

--- a/assets/js/theme/compare.js
+++ b/assets/js/theme/compare.js
@@ -3,7 +3,7 @@ import $ from 'jquery';
 import swal from 'sweetalert2';
 
 export default class Compare extends PageManager {
-    loaded() {
+    onReady() {
         const message = this.context.compareRemoveMessage;
 
         $('body').on('click', '[data-comparison-remove]', event => {

--- a/assets/js/theme/contact-us.js
+++ b/assets/js/theme/contact-us.js
@@ -4,7 +4,7 @@ import $ from 'jquery';
 import forms from './common/models/forms';
 
 export default class ContactUs extends PageManager {
-    loaded() {
+    onReady() {
         this.registerContactFormValidation();
     }
 

--- a/assets/js/theme/global.js
+++ b/assets/js/theme/global.js
@@ -1,6 +1,5 @@
 import $ from 'jquery';
 import './common/select-option-plugin';
-import 'html5-history-api';
 import PageManager from './page-manager';
 import quickSearch from './global/quick-search';
 import currencySelector from './global/currency-selector';
@@ -15,21 +14,10 @@ import maintenanceMode from './global/maintenanceMode';
 import carousel from './common/carousel';
 import 'lazysizes';
 import loadingProgressBar from './global/loading-progress-bar';
-import FastClick from 'fastclick';
 import sweetAlert from './global/sweet-alert';
 
-function fastClick(element) {
-    return new FastClick(element);
-}
-
 export default class Global extends PageManager {
-    /**
-     * You can wrap the execution in this method with an asynchronous function map using the async library
-     * if your global modules need async callback handling.
-     * @param next
-     */
-    loaded(next) {
-        fastClick(document.body);
+    onReady() {
         quickSearch();
         currencySelector();
         foundation($(document));
@@ -43,6 +31,5 @@ export default class Global extends PageManager {
         maintenanceMode(this.context.maintenanceMode);
         loadingProgressBar();
         sweetAlert();
-        next();
     }
 }

--- a/assets/js/theme/page-manager.js
+++ b/assets/js/theme/page-manager.js
@@ -1,35 +1,22 @@
-import async from 'async';
+import $ from 'jquery';
 
 export default class PageManager {
     constructor(context) {
         this.context = context;
     }
 
-    before(next) {
-        next();
-    }
-
-    loaded(next) {
-        next();
-    }
-
-    after(next) {
-        next();
-    }
-
     type() {
         return this.constructor.name;
     }
 
-    load() {
-        async.series([
-            this.before.bind(this), // Executed first after constructor()
-            this.loaded.bind(this), // Main module logic
-            this.after.bind(this), // Clean up method that can be overridden for cleanup.
-        ], (err) => {
-            if (err) {
-                throw new Error(err);
-            }
+    onReady() {
+    }
+
+    static load(context) {
+        const page = new this(context);
+
+        $(document).ready(() => {
+            page.onReady.bind(page)();
         });
     }
 }

--- a/assets/js/theme/product.js
+++ b/assets/js/theme/product.js
@@ -16,7 +16,7 @@ export default class Product extends PageManager {
         this.$reviewLink = $('[data-reveal-id="modal-review-form"]');
     }
 
-    before(next) {
+    onReady() {
         // Listen for foundation modal close events to sanitize URL after review.
         $(document).on('close.fndtn.reveal', () => {
             if (this.url.indexOf('#write_review') !== -1 && typeof window.history.replaceState === 'function') {
@@ -24,10 +24,6 @@ export default class Product extends PageManager {
             }
         });
 
-        next();
-    }
-
-    loaded(next) {
         let validator;
 
         // Init collapsible
@@ -53,13 +49,7 @@ export default class Product extends PageManager {
             return false;
         });
 
-        next();
-    }
-
-    after(next) {
         this.productReviewHandler();
-
-        next();
     }
 
     productReviewHandler() {

--- a/assets/js/theme/search.js
+++ b/assets/js/theme/search.js
@@ -57,7 +57,7 @@ export default class Search extends CatalogPage {
         urlUtils.goToUrl(url);
     }
 
-    loaded() {
+    onReady() {
         const $searchForm = $('[data-advanced-search-form]');
         const $categoryTreeContainer = $searchForm.find('[data-search-category-tree]');
         const url = Url.parse(window.location.href, true);

--- a/assets/js/theme/wishlist.js
+++ b/assets/js/theme/wishlist.js
@@ -83,7 +83,7 @@ export default class WishList extends PageManager {
         });
     }
 
-    load() {
+    onReady() {
         const $addWishListForm = $('.wishlist-form');
 
         if ($addWishListForm.length) {
@@ -92,10 +92,5 @@ export default class WishList extends PageManager {
 
         this.wishlistDeleteConfirm();
         this.wishListHandler();
-    }
-
-    loaded(next) {
-        this.load();
-        next();
     }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,4 @@
-var webpackTestConfig = require('./webpack.conf.js');
+var webpackTestConfig = require('./webpack.dev.js');
 
 module.exports = function (config) {
     config.set({

--- a/package.json
+++ b/package.json
@@ -7,12 +7,9 @@
   "license": "MIT",
   "dependencies": {
     "@bigcommerce/stencil-utils": "^1.1.2",
-    "async": "^2.5.0",
     "babel-polyfill": "^6.26.0",
     "easyzoom": "^2.5.0",
-    "fastclick": "^1.0.6",
     "foundation-sites": "^5.5.3",
-    "html5-history-api": "^4.2.7",
     "jquery": "^3.3.1",
     "jquery-migrate": "^1.4.1",
     "jstree": "vakata/jstree",
@@ -26,15 +23,15 @@
   "devDependencies": {
     "@bigcommerce/citadel": "^2.15.1",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.1",
-    "babel-loader": "^7.1.2",
-    "babel-plugin-dynamic-import-webpack": "^1.0.1",
-    "babel-plugin-lodash": "^3.2.11",
+    "babel-eslint": "^8.2.2",
+    "babel-loader": "^7.1.4",
+    "babel-plugin-dynamic-import-webpack": "^1.0.2",
+    "babel-plugin-lodash": "^3.3.2",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-regenerator": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.2.2",
-    "clean-webpack-plugin": "^0.1.17",
+    "babel-preset-env": "^1.6.1",
+    "clean-webpack-plugin": "^0.1.19",
     "core-js": "^2.5.0",
     "es6-shim": "^0.35.3",
     "eslint": "^4.8.0",
@@ -62,7 +59,12 @@
     "lodash-webpack-plugin": "^0.11.2",
     "regenerator-runtime": "^0.11.0",
     "time-grunt": "^1.2.2",
-    "uglify-js": "^3.0.28",
-    "webpack": "^3.6.0"
+    "webpack": "^4.1.1",
+    "webpack-cli": "^2.0.11",
+    "webpack-merge": "^4.1.2"
+  },
+  "scripts": {
+    "build": "webpack --config webpack.prod.js",
+    "buildDev": "webpack --config webpack.dev.js"
   }
 }

--- a/stencil.conf.js
+++ b/stencil.conf.js
@@ -1,5 +1,6 @@
 var webpack = require('webpack');
-var webpackConfig = require('./webpack.conf.js');
+var devConfig = require('./webpack.dev.js');
+var prodConfig = require('./webpack.prod.js');
 
 /**
  * Watch options for the core watcher
@@ -26,7 +27,7 @@ var watchOptions = {
  */
 function development() {
     // Rebuild the bundle once at bootup
-    webpack(webpackConfig).watch({}, err => {
+    webpack(devConfig).watch({}, err => {
         if (err) {
             console.error(err.message, err.details);
         }
@@ -39,23 +40,11 @@ function development() {
  * Hook into the `stencil bundle` command and build your files before they are packaged as a .zip
  */
 function production() {
-    webpackConfig.watch = false;
-    webpackConfig.devtool = false;
-    webpackConfig.plugins.push(new webpack.LoaderOptionsPlugin({
-        minimize: true,
-    }));
-    webpackConfig.plugins.push(new webpack.optimize.UglifyJsPlugin({
-        comments: false,
-        compress: {
-            warnings: true,
-        },
-        sourceMap: false, // Toggle to turn on source maps.
-    }));
-
-    webpack(webpackConfig).run(err => {
+    webpack(prodConfig).run(err => {
         if (err) {
             console.error(err.message, err.details);
-            throw err;
+            process.exit(1);
+            return;
         }
 
         process.send('done');

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,13 +1,12 @@
-var CleanWebpackPlugin = require('clean-webpack-plugin'),
-    config = require('./config.json'),
-    LodashModuleReplacementPlugin = require('lodash-webpack-plugin'),
+var CleanPlugin = require('clean-webpack-plugin'),
+    LodashPlugin = require('lodash-webpack-plugin'),
     path = require('path'),
     webpack = require('webpack');
 
+// Common configuration, with extensions in webpack.dev.js and webpack.prod.js.
 module.exports = {
     bail: true,
     context: __dirname,
-    devtool: 'source-map',
     entry: {
         main: './assets/js/app.js',
     },
@@ -19,9 +18,6 @@ module.exports = {
                 use: {
                     loader: 'babel-loader',
                     options: {
-                        cacheDirectory: true,
-                        compact: true,
-                        minified: true,
                         plugins: [
                             'dynamic-import-webpack', // Needed for dynamic imports.
                             'lodash', // Automagically tree-shakes lodash.
@@ -34,8 +30,8 @@ module.exports = {
                                 useBuiltIns: true, // Tree-shake babel-polyfill.
                             }],
                         ],
-                    }
-                }
+                    },
+                },
             },
             {
                 test: /jquery-migrate/,
@@ -49,36 +45,24 @@ module.exports = {
         path: path.resolve(__dirname, "assets/dist"),
     },
     plugins: [
-        new CleanWebpackPlugin(['assets/dist'], {
+        new CleanPlugin(['assets/dist'], {
             verbose: false,
             watch: false,
         }),
-        new webpack.LoaderOptionsPlugin({
-             minimize: true,
-        }),
-        new LodashModuleReplacementPlugin, // Complements 'babel-plugin-lodash by shrinking it's cherry-picked builds further.
+        new LodashPlugin, // Complements babel-plugin-lodash by shrinking its cherry-picked builds further.
         new webpack.ProvidePlugin({
             $: 'jquery',
             jQuery: 'jquery',
             'window.jQuery': 'jquery',
         }),
-        new webpack.optimize.CommonsChunkPlugin({
-            children: true,
-            minChunks: 2,
-        }),
     ],
     resolve: {
         alias: {
-            'async': path.resolve(__dirname, 'node_modules/async/dist/async.min.js'),
-            'html5-history-api': path.resolve(__dirname, 'node_modules/html5-history-api/history.min.js'),
-            jquery: path.resolve(__dirname, 'node_modules/jquery/dist/jquery.min.js'),
             'jquery-migrate': path.resolve(__dirname, 'node_modules/jquery-migrate/dist/jquery-migrate.min.js'),
-            'jquery-zoom': path.resolve(__dirname, 'node_modules/jquery-zoom/jquery.zoom.min.js'),
             jstree: path.resolve(__dirname, 'node_modules/jstree/dist/jstree.min.js'),
             'pace': path.resolve(__dirname, 'node_modules/pace/pace.min.js'),
             'slick-carousel': path.resolve(__dirname, 'node_modules/slick-carousel/slick/slick.min.js'),
             sweetalert2: path.resolve(__dirname, 'node_modules/sweetalert2/dist/sweetalert2.min.js'),
         },
     },
-    watch: false,
 };

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,0 +1,13 @@
+var webpack = require('webpack');
+var merge = require('webpack-merge');
+var commonConfig = require('./webpack.common.js');
+
+module.exports = merge(commonConfig, {
+    mode: 'development',
+    devtool: 'source-map',
+    plugins: [
+        new webpack.DefinePlugin({
+            'process.env.NODE_ENV': 'development',
+        }),
+    ],
+});

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,12 @@
+var webpack = require('webpack');
+var merge = require('webpack-merge');
+var commonConfig = require('./webpack.common.js');
+
+module.exports = merge(commonConfig, {
+    mode: 'production',
+    plugins: [
+        new webpack.DefinePlugin({
+            'process.env.NODE_ENV': 'production',
+        }),
+    ],
+});


### PR DESCRIPTION
## What?

* Upgrade to webpack 4
* Clean up stencil bootstrap
* Simplify interface for PageManager and get rid of async library dependency
* Get rid of html5-history-api library dependency (no longer needed)
* Get rid of fastclick library dependency (no longer needed)
* Upgrade several babel dependencies
* Separate webpack config into common, dev, prod, and add npm scripts to build
* Get rid of minifications in babel loader, instead rely on webpack
* Get rid of LoaderOptionsPlugin
* Get rid of CommonsChunkPlugin (webpack 4 will automaticaly do this for prod)

## Performance Impact
* Initial load of javascript is down from 450kb to 350kb. This PR lowers time to first paint by 50ms and time to first interactive by 210ms.

## Screenshots

#### Before
<img width="1132" alt="screen shot 2018-03-11 at 2 47 33 pm" src="https://user-images.githubusercontent.com/168657/37258848-33cf9cd4-253b-11e8-95af-440c4ed931d6.png">


#### After
<img width="1130" alt="screen shot 2018-03-11 at 2 47 40 pm" src="https://user-images.githubusercontent.com/168657/37258849-3943eaa8-253b-11e8-9789-517d59a9e672.png">
