### PR TITLE
STRF-4526 - Remove AMP quick-search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Fix image dimensions on AMP pages. [#1192](https://github.com/bigcommerce/cornerstone/pull/1192)
+- Remove AMP quick-search. [#1191](https://github.com/bigcommerce/cornerstone/pull/1191)
 
 ## 1.14.0 (2018-03-12)
 - Fix product options unhiding indexing issue. [#1176](https://github.com/bigcommerce/cornerstone/pull/1176)

--- a/templates/components/amp/common/navigation-menu.html
+++ b/templates/components/amp/common/navigation-menu.html
@@ -1,7 +1,4 @@
 <nav class="navPages">
-    <div class="navPages-quickSearch">
-        {{> components/amp/common/quick-search}}
-    </div>
     <ul class="navPages-list">
         {{#each categories}}
             <li class="navPages-item">

--- a/templates/components/amp/common/quick-search.html
+++ b/templates/components/amp/common/quick-search.html
@@ -1,8 +1,0 @@
-<form class="form" method="get" action="{{urls.search}}" target="_top">
-    <fieldset class="form-fieldset">
-        <div class="form-field">
-            <input class="form-input" data-search-quick name="search_query" id="search_query" data-error-message="{{lang 'search.error.empty_field'}}" placeholder="{{lang 'search.quick_search.input_placeholder'}}" autocomplete="off">
-        </div>
-    </fieldset>
-</form>
-<section class="quickSearchResults" data-bind="html: results"></section>


### PR DESCRIPTION
#### What?

* removes the AMP quick-search page and page include

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [STRF-4526](https://jira.bigcommerce.com/browse/STRF-4526)

#### Screenshots

* before:
![screen shot 2018-03-12 at 2 25 31 pm](https://user-images.githubusercontent.com/1357197/37310756-2ec907e4-2602-11e8-8553-271dc2dfb51e.png)

* after:
![screen shot 2018-03-12 at 2 23 29 pm](https://user-images.githubusercontent.com/1357197/37310765-376eda86-2602-11e8-8247-6198a6a8817a.png)

ping @bigcommerce/storefront-team 