### PR TITLE
STRF-4527: Fix amp image sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fix image dimensions on AMP pages. [#1192](https://github.com/bigcommerce/cornerstone/pull/1192)
 
 ## 1.14.0 (2018-03-12)
 - Fix product options unhiding indexing issue. [#1176](https://github.com/bigcommerce/cornerstone/pull/1176)

--- a/templates/components/amp/products/card.html
+++ b/templates/components/amp/products/card.html
@@ -8,7 +8,7 @@
             {{/if}}
         {{/or}}
         <a data-vars-product-link="{{url}}" data-vars-product-id="{{id}}" data-vars-product-name="{{name}}" href="{{url}}">
-            <amp-img class="card-image" src="{{getImage image 'productgallery_size' (cdn theme_settings.default_image_product)}}" width="300" height="300" layout="responsive" alt="{{image.alt}}"></amp-img>
+          <amp-img class="card-image" src="{{getImage image 'productgallery_size' (cdn theme_settings.default_image_product)}}" width="{{first (split theme_settings.productgallery_size 'x')}}" height="{{last (split theme_settings.productgallery_size 'x')}}" layout="responsive" alt="{{image.alt}}"></amp-img>
         </a>
     </figure>
     <div class="card-body">

--- a/templates/components/amp/products/list-item.html
+++ b/templates/components/amp/products/list-item.html
@@ -1,6 +1,6 @@
 <article class="listItem">
     <figure class="listItem-figure">
-        <amp-img src="{{getImage image 'productgallery_size' (cdn theme_settings.default_image_product)}}" width="300" height="300" layout="responsive" alt="{{image.alt}}"></amp-img>
+        <amp-img src="{{getImage image 'productgallery_size' (cdn theme_settings.default_image_product)}}" width="{{first (split theme_settings.productgallery_size 'x')}}" height="{{last (split theme_settings.productgallery_size 'x')}}" layout="responsive" alt="{{image.alt}}"></amp-img>
     </figure>
     <div class="listItem-body">
         <div class="listItem-content">


### PR DESCRIPTION
## What?

* Instead of hardcoding 300x300, use the actual image dimensions
  for product images on the product list

## Screenshots

#### Before
<img width="397" alt="screen shot 2018-03-12 at 5 29 09 pm" src="https://user-images.githubusercontent.com/168657/37316372-da069b94-261b-11e8-9c8b-6e60798a6ad1.png">


#### After
<img width="393" alt="screen shot 2018-03-12 at 5 28 14 pm" src="https://user-images.githubusercontent.com/168657/37316375-deb3f592-261b-11e8-9244-ca4e4f36730c.png">

