### PR TITLE
fix(catalog): CATALOG-3085 default selection in quickview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Add representation for products and variants with retail price that has sale price. [#1195](https://github.com/bigcommerce/cornerstone/pull/1195) 
+- Fix but in quickview related to grabbing default prices for products with no default selection. [#1197](https://github.com/bigcommerce/cornerstone/pull/1197)
 
 ## 1.15.0 (2018-04-04)
 - Fix image dimensions on AMP pages. [#1192](https://github.com/bigcommerce/cornerstone/pull/1192)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -41,7 +41,11 @@ export default class ProductDetails {
                 const attributesData = response.data || {};
                 const attributesContent = response.content || {};
                 this.updateProductAttributes(attributesData);
-                this.updateView(attributesData, attributesContent);
+                if (hasDefaultOptions) {
+                    this.updateView(attributesData, attributesContent);
+                } else {
+                    this.updateDefaultAttributesForOOS(attributesData);
+                }
             });
         } else {
             this.updateProductAttributes(productAttributesData);
@@ -443,18 +447,24 @@ export default class ProductDetails {
             viewModel.stock.$input.text(data.stock);
         }
 
+        this.updateDefaultAttributesForOOS(data);
+
+        // If Bulk Pricing rendered HTML is available
+        if (data.bulk_discount_rates && content) {
+            viewModel.$bulkPricing.html(content);
+        } else if (typeof (data.bulk_discount_rates) !== 'undefined') {
+            viewModel.$bulkPricing.html('');
+        }
+    }
+
+    updateDefaultAttributesForOOS(data) {
+        const viewModel = this.getViewModel(this.$scope);
         if (!data.purchasable || !data.instock) {
             viewModel.$addToCart.prop('disabled', true);
             viewModel.$increments.prop('disabled', true);
         } else {
             viewModel.$addToCart.prop('disabled', false);
             viewModel.$increments.prop('disabled', false);
-        }
-        // If Bulk Pricing rendered HTML is available
-        if (data.bulk_discount_rates && content) {
-            viewModel.$bulkPricing.html(content);
-        } else if (typeof (data.bulk_discount_rates) !== 'undefined') {
-            viewModel.$bulkPricing.html('');
         }
     }
 


### PR DESCRIPTION
#### What?
   refrain from updating the price shown on
    quickview by default when the modal is rendered unless theres an
    actual default selection to be made.

#### Tickets / Documentation
- [Ticket](https://jira.bigcommerce.com/browse/CATALOG-3085)


#### Screenshots (if appropriate)
Before: The quickview page would instantly make a request for stock/price based on selection even if the product doesnt have a default selection, which would result in getting the base price.
![screen shot 2018-03-29 at 4 38 01 pm](https://user-images.githubusercontent.com/6434219/38118442-9e45c1a0-336f-11e8-8c64-7aaeadf11cb2.png)

After: The quickview page still makes the default request so that it can mark things as OOS when necessary, but it doesnt try to change the price in the view if its not applicable. 
![screen shot 2018-03-29 at 4 36 42 pm](https://user-images.githubusercontent.com/6434219/38118472-bb68a112-336f-11e8-8b88-c9c7222da5c6.png)
