### PR TITLE
Fix broken 403/404 page search box in mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Fix brands import statement in app.js [#1202](https://github.com/bigcommerce/cornerstone/pull/1202)
+- Fix broken 403/404 page search box in mobile [#1203](https://github.com/bigcommerce/cornerstone/pull/1203)
 
 ## 1.16.0 (2018-04-12)
 - Add representation for products and variants with retail price that has sale price. [#1195](https://github.com/bigcommerce/cornerstone/pull/1195) 

--- a/templates/components/common/search-box.html
+++ b/templates/components/common/search-box.html
@@ -3,7 +3,7 @@
     <fieldset class="form-fieldset">
         <div class="form-field">
             <label class="form-label is-srOnly" for="search_query_adv">{{lang 'search.results.form_label'}}</label>
-            <div class="form-prefixPostfix">
+            <div class="form-prefixPostfix wrap">
                 <input class="form-input" id="search_query_adv" name="search_query_adv" value="{{forms.search.query}}">
                 <input class="button button--primary form-prefixPostfix-button--postfix" type="submit" value="{{lang 'search.results.form_button_text'}}">
             </div>


### PR DESCRIPTION
### **What?**

The search box on the 403 and 404 pages displayed poorly in mobile viewports. Adding the `.wrap` class to the `form-prefixPostfix` div sets `flex-wrap: wrap;`

**Before**
<img width="512" alt="1 before" src="https://user-images.githubusercontent.com/5056945/38792501-1b4c95d0-4102-11e8-9b46-3663464bb64d.png">

**After**
<img width="512" alt="2 after" src="https://user-images.githubusercontent.com/5056945/38792504-20583a3e-4102-11e8-8cb9-8d474ffda190.png">

**References**

- https://github.com/bigcommerce/cornerstone/issues/1168