### PR TITLE
parse '{}' instead of empty object in app.js to avoid SyntaxError

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -58,7 +58,7 @@ const pageClasses = {
  * @returns {*}
  */
 window.stencilBootstrap = function stencilBootstrap(pageType, contextJSON = null, loadGlobal = true) {
-    const context = JSON.parse(contextJSON || {});
+    const context = JSON.parse(contextJSON || '{}');
 
     return {
         load() {


### PR DESCRIPTION
#### What?

Right now, if no contextJSON argument is passed to the stencilBootstrap function, JSON.parse will try to parse an empty object, which will throw a SyntaxError because the argument supplied is not a string.

#### Tickets / Documentation

N/A

#### Screenshots (if appropriate)

N/A
