### PR TITLE
fix(storefront): STRF-4764 Adding the +/- icons back for the category…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Draft
+- Add the +/- icons for the category filtering [#1211](https://github.com/bigcommerce/cornerstone/pull/1211)
+
 ## 1.17.0 (2018-04-26)
 - Add the +/- icons for the category filtering [#1211](https://github.com/bigcommerce/cornerstone/pull/1211)
 - Fix empty object issue in app.js [#1204](https://github.com/bigcommerce/cornerstone/pull/1204)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Add the +/- icons for the category filtering [#1211](https://github.com/bigcommerce/cornerstone/pull/1211)
 - Fix empty object issue in app.js [#1204](https://github.com/bigcommerce/cornerstone/pull/1204)
 - Fix product layout when shop by price disabled [#1205](https://github.com/bigcommerce/cornerstone/pull/1205)
 - Fix brands import statement in app.js [#1202](https://github.com/bigcommerce/cornerstone/pull/1202)

--- a/assets/scss/components/foundation/accordion/_accordion.scss
+++ b/assets/scss/components/foundation/accordion/_accordion.scss
@@ -84,10 +84,6 @@
 
     .accordion-indicator {
         fill: color("greys", "light");
-
-        @include breakpoint("medium") {
-            visibility: hidden;
-        }
     }
 
     .accordion-navigation-actions {


### PR DESCRIPTION
#### What?

Placing the +/- icons back on the category filtering.

#### Tickets / Documentation
- https://jira.bigcommerce.com/browse/STRF-4764

#### Testing
Verified manually on FFox, Chrome, Safari by adjusting browser to diff widths.

#### Screenshots (if appropriate)

<img width="1680" alt="screen shot 2018-04-24 at 5 39 13 pm" src="https://user-images.githubusercontent.com/5466439/39220503-6e97247c-47e6-11e8-921c-0d7f45ce4de5.png">

@mattolson @tpietsch @junedkazi @davidwrpayne 