### PR TITLE
STRF-4146: Don't lazy load logo if size is unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 ## Draft
 - Add the +/- icons for the category filtering [#1211](https://github.com/bigcommerce/cornerstone/pull/1211)
+- Fix overlapping logo when using "original" sizing and large logos [#1213](https://github.com/bigcommerce/cornerstone/pull/1213)
 
 ## 1.17.0 (2018-04-26)
-- Add the +/- icons for the category filtering [#1211](https://github.com/bigcommerce/cornerstone/pull/1211)
 - Fix empty object issue in app.js [#1204](https://github.com/bigcommerce/cornerstone/pull/1204)
 - Fix product layout when shop by price disabled [#1205](https://github.com/bigcommerce/cornerstone/pull/1205)
 - Fix brands import statement in app.js [#1202](https://github.com/bigcommerce/cornerstone/pull/1202)
 - Fix broken 403/404 page search box in mobile [#1203](https://github.com/bigcommerce/cornerstone/pull/1203)
 
 ## 1.16.0 (2018-04-12)
-- Add representation for products and variants with retail price that has sale price. [#1195](https://github.com/bigcommerce/cornerstone/pull/1195) 
+- Add representation for products and variants with retail price that has sale price. [#1195](https://github.com/bigcommerce/cornerstone/pull/1195)
 - Fix but in quickview related to grabbing default prices for products with no default selection. [#1197](https://github.com/bigcommerce/cornerstone/pull/1197)
 
 ## 1.15.0 (2018-04-04)

--- a/assets/scss/layouts/header/_header.scss
+++ b/assets/scss/layouts/header/_header.scss
@@ -9,6 +9,9 @@
 //    margin. This centers the text logo properly.
 // 4. When the word "cart" is added to the mobile header's cart link, add more
 //    margin to compensate.
+// 5. When logo size is set to "original", we don't have advance knowledge of the
+//    image size, so we can't use absolute positioning + padding to reserve space
+//    for lazy loading.
 //
 // -----------------------------------------------------------------------------
 
@@ -170,7 +173,13 @@
     }
 }
 
+.header-logo-image-unknown-size { // 5
+    max-height: remCalc($header-height) - $header-logo-marginVertical * 2;
 
+    @include breakpoint("medium") {
+        max-height: none;
+    }
+}
 
 //
 // Mobile Menu Toggle

--- a/schema.json
+++ b/schema.json
@@ -458,12 +458,12 @@
         "force_reload": true,
         "options": [
           {
-            "value": "original",
-            "label": "Original (as uploaded)"
-          },
-          {
             "value": "250x100",
             "label": "Optimized for theme"
+          },
+          {
+            "value": "original",
+            "label": "Original (as uploaded)"
           },
           {
             "value": "custom",

--- a/templates/components/common/header.html
+++ b/templates/components/common/header.html
@@ -24,5 +24,4 @@
     <div class="navPages-container" id="menu" data-menu>
         {{> components/common/navigation-menu}}
     </div>
-
 </header>

--- a/templates/components/common/store-logo.html
+++ b/templates/components/common/store-logo.html
@@ -1,8 +1,12 @@
 <a href="{{urls.home}}">
     {{#if settings.store_logo.image}}
-        <div class="header-logo-image-container">
-            <img class="header-logo-image lazyload" data-sizes="auto" src="{{cdn 'img/loading.svg'}}" data-src="{{getImage settings.store_logo.image 'logo_size'}}" alt="{{settings.store_logo.title}}" title="{{settings.store_logo.title}}">
-        </div>
+        {{#if theme_settings.logo_size '===' 'original'}}
+            <img class="header-logo-image-unknown-size" src="{{getImage settings.store_logo.image 'logo_size'}}" alt="{{settings.store_logo.title}}" title="{{settings.store_logo.title}}">
+        {{else}}
+            <div class="header-logo-image-container">
+                <img class="header-logo-image lazyload" data-sizes="auto" src="{{cdn 'img/loading.svg'}}" data-src="{{getImage settings.store_logo.image 'logo_size'}}" alt="{{settings.store_logo.title}}" title="{{settings.store_logo.title}}">
+            </div>
+        {{/if}}
     {{else}}
         <span class="header-logo-text">{{settings.store_logo.title}}</span>
     {{/if}}


### PR DESCRIPTION
## What?
* Our lazy loading solution relies on advance knowledge of the image dimensions. When `logo_size` is set to `original` in the theme settings, we don't have this information. For large logos, this leads to overlapping of the menu.
* For original sized images, don't use lazy loading or reserving space for the image via absolute positioning. Hopefully not many users will use this setting because it will impact frontend performance. To partially mitigate this, I reordered the options for `logo_size` so our optimized setting appears first in the list.
* The large diff in `schema.json` is due to changing the line endings from dos to unix. The only change of substance is reordering the options for `logo_size`

## Tickets / Documentation
- [Jira](https://jira.bigcommerce.com/browse/STRF-4146)

## Screenshots

### Before
<img width="1409" alt="screen shot 2018-04-27 at 11 16 06 am" src="https://user-images.githubusercontent.com/168657/39378156-6c6924de-4a0c-11e8-9bf3-cf5c3116f5ee.png">

### After

#### With "original" sized logo (desktop)
<img width="1438" alt="screen shot 2018-04-27 at 11 09 54 am" src="https://user-images.githubusercontent.com/168657/39377890-9ba2bc70-4a0b-11e8-9233-d501717c4b4d.png">

#### With "original" sized logo (mobile)
<img width="394" alt="screen shot 2018-04-27 at 11 10 52 am" src="https://user-images.githubusercontent.com/168657/39377919-b35cbe88-4a0b-11e8-8ded-2ac1497b4182.png">

#### With "optimized for theme" sized logo (250x100) (desktop):
<img width="1436" alt="screen shot 2018-04-27 at 11 11 37 am" src="https://user-images.githubusercontent.com/168657/39377957-cf371a18-4a0b-11e8-894a-9aae05f0a934.png">

#### With "optimized for theme" sized logo (250x100) (mobile):
<img width="396" alt="screen shot 2018-04-27 at 11 14 10 am" src="https://user-images.githubusercontent.com/168657/39378087-2f901982-4a0c-11e8-95e3-d233a933efff.png">
