### PR TITLE
fix(storefront): STRF-4840 Options hide Add To Cart in AMP.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Add the +/- icons for the category filtering [#1211](https://github.com/bigcommerce/cornerstone/pull/1211)
 - Fix overlapping logo when using "original" sizing and large logos [#1213](https://github.com/bigcommerce/cornerstone/pull/1213)
+- Fix Product Options hiding Add to Cart on a Google AMP page [#1214](https://github.com/bigcommerce/cornerstone/pull/1214)
 
 ## 1.17.0 (2018-04-26)
 - Fix empty object issue in app.js [#1204](https://github.com/bigcommerce/cornerstone/pull/1204)

--- a/templates/components/amp/products/product-options.html
+++ b/templates/components/amp/products/product-options.html
@@ -6,7 +6,7 @@
             {{#each product.customizations}}
                 {{{dynamicComponent 'components/products/customizations'}}}
             {{/each}}
-            <div data-product-option-change style="display:none;">
+            <div data-product-option-change>
                 {{#each product.options}}
                     {{{dynamicComponent 'components/products/options'}}}
                 {{/each}}


### PR DESCRIPTION
#### What?

On a Google AMP Product Page, Options would hide Add to Cart under a very specific set of conditions. This only affected products with options.

* If a window is too short to display either options or the button, there is no issue.
* If a window is only long enough to display product options, the Add to Cart button will not appear.
* If a window is tall enough to display both options and the button, there is no issue.

It seems that some CSS is targeting what was originally `<div data-product-option-change style="display:none;">`. When this style was removed it would cause issues if Options would "push" Add to Cart below the viewable window.

Because this code is only called if there are product options to begin with (see `templates/components/amp/products/product-view`, there's no need to have a style that would hide it on-load.

Tested in macOS Sierra on Chrome, Firefox 55, and Safari, and on Android Chrome with a Nokia 6.

#### Tickets / Documentation

- [STRF-4840](https://jira.bigcommerce.com/browse/STRF-4840)