### PR TITLE
Fix issue with duplicate IDs on product options, Fix issue #1136 (open correct product tabs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix Product Options hiding Add to Cart on a Google AMP page [#1214](https://github.com/bigcommerce/cornerstone/pull/1214)
 - Hide blank review stars when there are no reviews on a product [#1209](https://github.com/bigcommerce/cornerstone/pull/1209)
 - Fix styling of subpage links in Contact Us page [#1216](https://github.com/bigcommerce/cornerstone/pull/1216)
+- Add lazyloading to main product video and fix video thumbnail bug [#1217](https://github.com/bigcommerce/cornerstone/pull/1217)
 
 ## 1.17.0 (2018-04-26)
 - Fix empty object issue in app.js [#1204](https://github.com/bigcommerce/cornerstone/pull/1204)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix Product Options hiding Add to Cart on a Google AMP page [#1214](https://github.com/bigcommerce/cornerstone/pull/1214)
 - Hide blank review stars when there are no reviews on a product [#1209](https://github.com/bigcommerce/cornerstone/pull/1209)
 - Fix styling of subpage links in Contact Us page [#1216](https://github.com/bigcommerce/cornerstone/pull/1216)
+- Add lazyloading to main product video and fix video thumbnail bug [#1217](https://github.com/bigcommerce/cornerstone/pull/1217)
 - Fix duplicate IDs occurrence in product options in certain situations & syntax fix in carousel and bulk-discount-rates components [#1215](https://github.com/bigcommerce/cornerstone/pull/1215)
 
 ## 1.17.0 (2018-04-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 - Fix Product Options hiding Add to Cart on a Google AMP page [#1214](https://github.com/bigcommerce/cornerstone/pull/1214)
 - Hide blank review stars when there are no reviews on a product [#1209](https://github.com/bigcommerce/cornerstone/pull/1209)
 - Fix styling of subpage links in Contact Us page [#1216](https://github.com/bigcommerce/cornerstone/pull/1216)
-- Add lazyloading to main product video and fix video thumbnail bug [#1217](https://github.com/bigcommerce/cornerstone/pull/1217)
 - Fix duplicate IDs occurrence in product options in certain situations & syntax fix in carousel and bulk-discount-rates components [#1215](https://github.com/bigcommerce/cornerstone/pull/1215)
 
 ## 1.17.0 (2018-04-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Hide blank review stars when there are no reviews on a product [#1209](https://github.com/bigcommerce/cornerstone/pull/1209)
 - Fix styling of subpage links in Contact Us page [#1216](https://github.com/bigcommerce/cornerstone/pull/1216)
 - Add lazyloading to main product video and fix video thumbnail bug [#1217](https://github.com/bigcommerce/cornerstone/pull/1217)
+- Fix duplicate IDs occurrence in product options in certain situations & syntax fix in carousel and bulk-discount-rates components [#1215](https://github.com/bigcommerce/cornerstone/pull/1215)
 
 ## 1.17.0 (2018-04-26)
 - Fix empty object issue in app.js [#1204](https://github.com/bigcommerce/cornerstone/pull/1204)
@@ -16,7 +17,7 @@
 
 ## 1.16.0 (2018-04-12)
 - Add representation for products and variants with retail price that has sale price. [#1195](https://github.com/bigcommerce/cornerstone/pull/1195)
-- Fix but in quickview related to grabbing default prices for products with no default selection. [#1197](https://github.com/bigcommerce/cornerstone/pull/1197)
+- Fix buy in quickview related to grabbing default prices for products with no default selection. [#1197](https://github.com/bigcommerce/cornerstone/pull/1197)
 
 ## 1.15.0 (2018-04-04)
 - Fix image dimensions on AMP pages. [#1192](https://github.com/bigcommerce/cornerstone/pull/1192)

--- a/assets/js/theme/product/video-gallery.js
+++ b/assets/js/theme/product/video-gallery.js
@@ -37,7 +37,7 @@ export class VideoGallery {
 }
 
 export default function videoGallery() {
-    const pluginKey = 'videoGallery';
+    const pluginKey = 'video-gallery';
     const $videoGallery = $(`[data-${pluginKey}]`);
 
     $videoGallery.each((index, element) => {

--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -12,7 +12,7 @@
     <a href="{{url}}">
         <div class="heroCarousel-slide {{#if ../theme_settings.homepage_stretch_carousel_images}}heroCarousel-slide--stretch{{/if}}"
             style="background-image: url({{image}})">
-            <img class="heroCarousel-image" data-lazy="{{image}}" alt="{{alt_text}}" title="{{alt_text}}""
+            <img class="heroCarousel-image" data-lazy="{{image}}" alt="{{alt_text}}" title="{{alt_text}}"
              {{#if image_width}}width="{{image_width}}"{{/if}} {{#if image_height}}height="{{image_height}}"{{/if}} />
             {{#if heading}}
                 {{> components/carousel-content show_background=true}}

--- a/templates/components/products/bulk-discount-rates.html
+++ b/templates/components/products/bulk-discount-rates.html
@@ -2,7 +2,7 @@
     {{#if product}}<dt class="productView-info-name">{{lang 'products.bulk_pricing.title'}}</dt>{{/if}}
     <dd class="productView-info-value">
         <a href="{{url}}"
-           {{#unless is_ajax }}data-reveal-id="bulkPricingModal{{#if id}}-{{id}}-{{$index}}{{/if}}">{{/unless}}
+           {{#unless is_ajax }}data-reveal-id="bulkPricingModal{{#if id}}-{{id}}-{{$index}}{{/if}}"{{/unless}}>
             {{lang 'products.bulk_pricing.view'}}
         </a>
     </dd>

--- a/templates/components/products/options/input-checkbox.html
+++ b/templates/components/products/options/input-checkbox.html
@@ -7,11 +7,11 @@
         {{/if}}
     </label>
 
-    <input 
+    <input
         class="form-checkbox"
         type="checkbox"
         name="attribute[{{id}}]"
-        id="attribute-{{id}}"
+        id="attribute-check-{{id}}"
         value="{{value}}"
         {{#if checked}}
             checked
@@ -19,5 +19,5 @@
         {{/if}}
         {{#if required}}required{{/if}}>
 
-    <label class="form-label {{class}}" for="attribute-{{id}}">{{label}}</label>
+    <label class="form-label {{class}}" for="attribute-check-{{id}}">{{label}}</label>
 </div>

--- a/templates/components/products/options/input-file.html
+++ b/templates/components/products/options/input-file.html
@@ -1,5 +1,5 @@
 <div class="form-field" data-product-attribute="input-file">
-    <label class="form-label form-label--alternate form-label--inlineSmall" for="attribute_{{id}}">
+    <label class="form-label form-label--alternate form-label--inlineSmall" for="attribute_file_{{id}}">
         {{ this.display_name }}:
 
         {{#if required}}
@@ -7,7 +7,7 @@
         {{/if}}
     </label>
 
-    <input class="form-file" type="file" id="attribute_{{id}}" name="attribute[{{this.id}}]" {{#if required}}required{{/if}}>
+    <input class="form-file" type="file" id="attribute_file_{{id}}" name="attribute[{{this.id}}]" {{#if required}}required{{/if}}>
     {{#if original_name}}
         {{{lang 'products.file_option_set' url=file_url name=original_name}}}
         <label>{{lang 'cart.remove_file'}}<input type="checkbox" name="{{file_remove}}"></label>

--- a/templates/components/products/options/input-numbers.html
+++ b/templates/components/products/options/input-numbers.html
@@ -1,5 +1,5 @@
 <div class="form-field" data-product-attribute="input-number">
-    <label class="form-label form-label--alternate form-label--inlineSmall" for="attribute_{{id}}">
+    <label class="form-label form-label--alternate form-label--inlineSmall" for="attribute_number_{{id}}">
         {{ this.display_name }}:
 
         {{#if required}}
@@ -7,5 +7,5 @@
         {{/if}}
     </label>
 
-    <input class="form-input" type="number" id="attribute_{{id}}" {{#unless this.integer_only}}step="any"{{/unless}} name="attribute[{{this.id}}]" value="{{this.prefill}}" {{#if required}}required{{/if}}>
+    <input class="form-input" type="number" id="attribute_number_{{id}}" {{#unless this.integer_only}}step="any"{{/unless}} name="attribute[{{this.id}}]" value="{{this.prefill}}" {{#if required}}required{{/if}}>
 </div>

--- a/templates/components/products/options/input-text.html
+++ b/templates/components/products/options/input-text.html
@@ -1,5 +1,5 @@
 <div class="form-field" data-product-attribute="input-text">
-    <label class="form-label form-label--alternate form-label--inlineSmall" for="attribute_{{id}}">
+    <label class="form-label form-label--alternate form-label--inlineSmall" for="attribute_text_{{id}}">
         {{ this.display_name }}:
 
         {{#if required}}
@@ -7,5 +7,5 @@
         {{/if}}
     </label>
 
-    <input class="form-input form-input--small" type="text" id="attribute_{{id}}" name="attribute[{{this.id}}]" value="{{this.prefill}}" {{#if required}}required{{/if}}>
+    <input class="form-input form-input--small" type="text" id="attribute_text_{{id}}" name="attribute[{{this.id}}]" value="{{this.prefill}}" {{#if required}}required{{/if}}>
 </div>

--- a/templates/components/products/options/product-list.html
+++ b/templates/components/products/options/product-list.html
@@ -16,9 +16,9 @@
                            type="radio"
                            name="attribute[{{id}}]"
                            value="0"
-                           id="attribute_0_{{id}}"
+                           id="attribute_productlist_0_{{id}}"
                            checked="{{#if defaultValue '==' 0}}checked{{/if}}" required>
-                    <label class="form-label" for="attribute_0_{{id}}">{{lang 'products.none'}}</label>
+                    <label class="form-label" for="attribute_productlist_0_{{id}}">{{lang 'products.none'}}</label>
                 </li>
             {{/unless}}
             {{#each values}}
@@ -34,13 +34,13 @@
                             type="radio"
                             name="attribute[{{../id}}]"
                             value="{{id}}"
-                            id="attribute_{{id}}"
+                            id="attribute_productlist_{{id}}"
                             {{#if selected}}
                                 checked
                                 data-default
                             {{/if}}
                             {{#if ../required}}required{{/if}}>
-                        <label data-product-attribute-value="{{id}}" class="form-label" for="attribute_{{id}}">{{label}}</label>
+                        <label data-product-attribute-value="{{id}}" class="form-label" for="attribute_productlist_{{id}}">{{label}}</label>
                     </div>
                 </li>
             {{/each}}
@@ -53,7 +53,7 @@
                value="0"
                id="attribute_0_{{id}}"
                {{#if defaultValue '==' 0}}checked{{/if}}>
-        <label class="form-label" for="attribute_0_{{id}}">{{lang 'products.none'}}</label>
+        <label class="form-label" for="attribute_productlist_0_{{id}}">{{lang 'products.none'}}</label>
         {{/unless}}
         {{#each values}}
             <input
@@ -64,7 +64,7 @@
                 id="attribute_{{id}}"
                 {{#if selected}}checked{{/if}}
                 {{#if ../required}}required{{/if}}>
-            <label data-product-attribute-value="{{id}}" class="form-label" for="attribute_{{id}}">{{label}}</label>
+            <label data-product-attribute-value="{{id}}" class="form-label" for="attribute_productlist_{{id}}">{{label}}</label>
         {{/each}}
     {{/if}}
 </div>

--- a/templates/components/products/options/set-radio.html
+++ b/templates/components/products/options/set-radio.html
@@ -11,7 +11,7 @@
         <input
             class="form-radio"
             type="radio"
-            id="attribute_{{id}}"
+            id="attribute_radio_{{id}}"
             name="attribute[{{../id}}]"
             value="{{id}}"
             {{#if selected}}
@@ -19,6 +19,6 @@
                 data-default
             {{/if}}
             {{#if ../required}}required{{/if}}>
-        <label data-product-attribute-value="{{id}}" class="form-label" for="attribute_{{id}}">{{this.label}}</label>
+        <label data-product-attribute-value="{{id}}" class="form-label" for="attribute_radio_{{id}}">{{this.label}}</label>
     {{/each}}
 </div>

--- a/templates/components/products/options/set-rectangle.html
+++ b/templates/components/products/options/set-rectangle.html
@@ -10,7 +10,7 @@
         <input
             class="form-radio"
             type="radio"
-            id="attribute_{{id}}"
+            id="attribute_rectangle_{{id}}"
             name="attribute[{{../id}}]"
             value="{{id}}"
             {{#if selected}}
@@ -18,7 +18,7 @@
                 data-default
             {{/if}}
             {{#if ../required}}required{{/if}}>
-        <label class="form-option" for="attribute_{{id}}" data-product-attribute-value="{{id}}">
+        <label class="form-option" for="attribute_rectangle_{{id}}" data-product-attribute-value="{{id}}">
             <span class="form-option-variant">{{this.label}}</span>
         </label>
     {{/each}}

--- a/templates/components/products/options/set-select.html
+++ b/templates/components/products/options/set-select.html
@@ -1,5 +1,5 @@
 <div class="form-field" data-product-attribute="set-select">
-    <label class="form-label form-label--alternate form-label--inlineSmall" for="attribute_{{id}}">
+    <label class="form-label form-label--alternate form-label--inlineSmall" for="attribute_select_{{id}}">
         {{ this.display_name }}:
 
         {{#if required}}
@@ -7,7 +7,7 @@
         {{/if}}
     </label>
 
-    <select class="form-select form-select--small" name="attribute[{{this.id}}]" id="attribute_{{id}}" {{#if required}}required{{/if}}>
+    <select class="form-select form-select--small" name="attribute[{{this.id}}]" id="attribute_select_{{id}}" {{#if required}}required{{/if}}>
         <option value="">{{lang 'products.choose_options'}}</option>
         {{#each this.values}}
             <option data-product-attribute-value="{{id}}" value="{{id}}" {{#if selected}}selected data-default{{/if}}>{{label}}</option>

--- a/templates/components/products/options/swatch.html
+++ b/templates/components/products/options/swatch.html
@@ -9,8 +9,8 @@
     </label>
 
     {{#each this.values}}
-        <input class="form-radio" type="radio" name="attribute[{{../id}}]" value="{{id}}" id="attribute_{{id}}" {{#if selected}}checked data-default{{/if}} {{#if ../required}}required{{/if}}>
-        <label class="form-option form-option-swatch" for="attribute_{{id}}" data-product-attribute-value="{{id}}">
+        <input class="form-radio" type="radio" name="attribute[{{../id}}]" value="{{id}}" id="attribute_swatch_{{id}}" {{#if selected}}checked data-default{{/if}} {{#if ../required}}required{{/if}}>
+        <label class="form-option form-option-swatch" for="attribute_swatch_{{id}}" data-product-attribute-value="{{id}}">
             {{#if image}}
                 <span class='form-option-variant form-option-variant--pattern' title="{{this.label}}" style="background-image: url('{{getImage image "swatch_option_size"}}');"></span>
             {{/if}}

--- a/templates/components/products/options/textarea.html
+++ b/templates/components/products/options/textarea.html
@@ -1,5 +1,5 @@
 <div class="form-field" data-product-attribute="textarea">
-    <label class="form-label form-label--alternate form-label--inlineSmall" for="attribute_{{id}}">
+    <label class="form-label form-label--alternate form-label--inlineSmall" for="attribute_textarea_{{id}}">
         {{display_name}}:
 
         {{#if required}}
@@ -7,7 +7,7 @@
         {{/if}}
     </label>
 
-    <textarea class="form-input" id="attribute_{{id}}" name="attribute[{{id}}]" {{#if required}}required{{/if}}>
+    <textarea class="form-input" id="attribute_textarea_{{id}}" name="attribute[{{id}}]" {{#if required}}required{{/if}}>
         {{prefill}}
     </textarea>
 </div>

--- a/templates/components/products/videos.html
+++ b/templates/components/products/videos.html
@@ -15,6 +15,7 @@
         <div class="videoGallery-main">
             <iframe
                 id="player"
+                class="lazyload"
                 type="text/html"
                 width="640"
                 height="390"
@@ -22,7 +23,7 @@
                 webkitAllowFullScreen
                 mozallowfullscreen
                 allowFullScreen
-                src="//www.youtube.com/embed/{{this.featured.id}}"
+                data-src="//www.youtube.com/embed/{{this.featured.id}}"
                 data-video-player>
             </iframe>
         </div>


### PR DESCRIPTION
### Fix issue with duplicate IDs on product options

#### What?

In certain circumstances, product option elements end up with the same ID causing a clash, stopping some options being selected.

Each option component has been given a descriptive ID to prevent the clash. As the add to cart action relies on the name attribute, this does not interfere with the cart system.

#### Screenshots

[Video of issue before changes](https://www.useloom.com/share/1e740a49826f44cdbd56f81bd01bd7d3)

[Video after changes](https://www.useloom.com/share/9fe6d969da9445da91532da6f301de23)


### Open correct product page tabs when URL refers to them

#### What?

When the product page URL contains a fragment identifier that relates to tabbed content, i.e. `#tab-similar` or `#tab-warranty`, the correct tab should appear when the page loads.

#### Related Issue

#1136 