### PR TITLE
fix(storefront): STRF-4718 Contact Us subpage link styling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix overlapping logo when using "original" sizing and large logos [#1213](https://github.com/bigcommerce/cornerstone/pull/1213)
 - Fix Product Options hiding Add to Cart on a Google AMP page [#1214](https://github.com/bigcommerce/cornerstone/pull/1214)
 - Hide blank review stars when there are no reviews on a product [#1209](https://github.com/bigcommerce/cornerstone/pull/1209)
+- Fix styling of subpage links in Contact Us page [#1216](https://github.com/bigcommerce/cornerstone/pull/1216)
 
 ## 1.17.0 (2018-04-26)
 - Fix empty object issue in app.js [#1204](https://github.com/bigcommerce/cornerstone/pull/1204)

--- a/templates/pages/contact-us.html
+++ b/templates/pages/contact-us.html
@@ -7,8 +7,8 @@
     <h1 class="page-heading">{{page.title}}</h1>
 
     {{#if page.sub_pages}}
-        <nav class="navBar">
-            <ul class="navBar-section">
+        <nav class="navBar navBar--sub">
+            <ul class="navBar-section account-navigation">
                 {{#each page.sub_pages}}
                     <li class="navBar-item"><a class="navBar-action" href="{{url}}">{{title}}</a></li>
                 {{/each}}


### PR DESCRIPTION
#### What?

Brought the `{{#if page.sub_pages}}` section in the `contact-us.html` template in line with the same section in `page.html`. This follows the workaround in the associated ticket.

#### Tickets / Documentation

- [STRF-4718](https://jira.bigcommerce.com/browse/STRF-4718)