### PR TITLE
Fix issue #1136 (open correct product tabs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix Product Options hiding Add to Cart on a Google AMP page [#1214](https://github.com/bigcommerce/cornerstone/pull/1214)
 - Hide blank review stars when there are no reviews on a product [#1209](https://github.com/bigcommerce/cornerstone/pull/1209)
 - Fix styling of subpage links in Contact Us page [#1216](https://github.com/bigcommerce/cornerstone/pull/1216)
+- Open correct product page tabs when URL contains a fragment identifier referring to that content [#1220](https://github.com/bigcommerce/cornerstone/pull/1220)
 
 ## 1.17.0 (2018-04-26)
 - Fix empty object issue in app.js [#1204](https://github.com/bigcommerce/cornerstone/pull/1204)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -18,6 +18,7 @@ export default class ProductDetails {
         this.listenQuantityChange();
         this.initRadioAttributes();
         this.wishlist = new Wishlist().load();
+        this.getTabRequests();
 
         const $form = $('form[data-cart-item-add]', $scope);
         const $productOptionsElement = $('[data-product-option-change]', $form);
@@ -594,5 +595,24 @@ export default class ProductDetails {
 
             $radio.attr('data-state', $radio.prop('checked'));
         });
+    }
+
+    /**
+     * Check for fragment identifier in URL requesting a specific tab
+     */
+    getTabRequests() {
+        if (window.location.hash && window.location.hash.indexOf('#tab-') === 0) {
+            const $activeTab = $('.tabs').has(`[href='${window.location.hash}']`);
+            const $tabContent = $(`${window.location.hash}`);
+
+            $activeTab.find('.tab')
+                .removeClass('is-active')
+                .has(`[href='${window.location.hash}']`)
+                .addClass('is-active');
+
+            $tabContent.addClass('is-active')
+                .siblings()
+                .removeClass('is-active');
+        }
     }
 }


### PR DESCRIPTION
#### What?

When the product page URL contains a fragment identifier that relates to tabbed content, i.e. #tab-similar or #tab-warranty, the correct tab should appear when the page loads.

#### Related Issue

- #1136 

#### Screenshots

##### Before
![before-changes](https://user-images.githubusercontent.com/6369235/39623961-58232794-4f8f-11e8-825b-a31993769f24.gif)

##### After
![after-changes](https://user-images.githubusercontent.com/6369235/39623968-623321ee-4f8f-11e8-9657-8af6e90fc338.gif)
