### PR TITLE
add lazyload to main video and fix thumbnail bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix Product Options hiding Add to Cart on a Google AMP page [#1214](https://github.com/bigcommerce/cornerstone/pull/1214)
 - Hide blank review stars when there are no reviews on a product [#1209](https://github.com/bigcommerce/cornerstone/pull/1209)
 - Fix styling of subpage links in Contact Us page [#1216](https://github.com/bigcommerce/cornerstone/pull/1216)
+- Add lazyloading to main product video and fix video thumbnail bug [#1217](https://github.com/bigcommerce/cornerstone/pull/1217)
 
 ## 1.17.0 (2018-04-26)
 - Fix empty object issue in app.js [#1204](https://github.com/bigcommerce/cornerstone/pull/1204)

--- a/assets/js/theme/product/video-gallery.js
+++ b/assets/js/theme/product/video-gallery.js
@@ -37,7 +37,7 @@ export class VideoGallery {
 }
 
 export default function videoGallery() {
-    const pluginKey = 'videoGallery';
+    const pluginKey = 'video-gallery';
     const $videoGallery = $(`[data-${pluginKey}]`);
 
     $videoGallery.each((index, element) => {

--- a/templates/components/products/videos.html
+++ b/templates/components/products/videos.html
@@ -15,6 +15,7 @@
         <div class="videoGallery-main">
             <iframe
                 id="player"
+                class="lazyload"
                 type="text/html"
                 width="640"
                 height="390"
@@ -22,7 +23,7 @@
                 webkitAllowFullScreen
                 mozallowfullscreen
                 allowFullScreen
-                src="//www.youtube.com/embed/{{this.featured.id}}"
+                data-src="//www.youtube.com/embed/{{this.featured.id}}"
                 data-video-player>
             </iframe>
         </div>


### PR DESCRIPTION
#### What?

I originally made this just to lazyload the main video on product page load, but then I noticed that there is an existing bug that will not update the main video when the thumbnails are selected

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [1217](https://github.com/bigcommerce/cornerstone/issues/1217)

#### Screenshots (if appropriate)


[video](https://screencast.com/t/f8jWdRIGmf4)
