### PR TITLE
fix(storefront): STRF-4497 Removed default whitespace in textarea product option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Hide blank review stars when there are no reviews on a product [#1209](https://github.com/bigcommerce/cornerstone/pull/1209)
 - Fix styling of subpage links in Contact Us page [#1216](https://github.com/bigcommerce/cornerstone/pull/1216)
 - Add lazyloading to main product video and fix video thumbnail bug [#1217](https://github.com/bigcommerce/cornerstone/pull/1217)
+- Fix for excess whitespace in multiline text field product option [#1222](https://github.com/bigcommerce/cornerstone/pull/1222)
 
 ## 1.17.0 (2018-04-26)
 - Fix empty object issue in app.js [#1204](https://github.com/bigcommerce/cornerstone/pull/1204)

--- a/templates/components/products/options/textarea.html
+++ b/templates/components/products/options/textarea.html
@@ -7,7 +7,5 @@
         {{/if}}
     </label>
 
-    <textarea class="form-input" id="attribute_{{id}}" name="attribute[{{id}}]" {{#if required}}required{{/if}}>
-        {{prefill}}
-    </textarea>
+    <textarea class="form-input" id="attribute_{{id}}" name="attribute[{{id}}]" {{#if required}}required{{/if}}>{{prefill}}</textarea>
 </div>


### PR DESCRIPTION
#### What?

Removed whitespace appearing in a textarea (multi-line text field) product option. This whitespace appeared regardless of default placeholder text, or lack thereof.

#### Tickets / Documentation

- [STRF-4497](https://jira.bigcommerce.com/browse/STRF-4497)

#### Screenshots
##### Before
![4497before](https://user-images.githubusercontent.com/1546172/39549619-5ef4e558-4e13-11e8-9e00-c0580410e4e9.gif)

##### After
![4497after](https://user-images.githubusercontent.com/1546172/39549628-64cc1596-4e13-11e8-9d37-dfaf93e24311.gif)