### PR TITLE
fix(storefront): STRF-2456 Fixing Schema Org meta tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix for sort disappearing on range update with product filtering [#1232](https://github.com/bigcommerce/cornerstone/pull/1232)
 - No longer escaping HTML content in blog summaries. [#1238](https://github.com/bigcommerce/cornerstone/pull/1238)
 - Fix logo image dimensions on AMP pages. [#1239](https://github.com/bigcommerce/cornerstone/pull/1239)
+- Fix product pricing schema.org microdata. [#1233](https://github.com/bigcommerce/cornerstone/pull/1233)
 
 ## 1.18.0 (2018-05-09)
 - Add the +/- icons for the category filtering [#1211](https://github.com/bigcommerce/cornerstone/pull/1211)

--- a/templates/components/products/price-range.html
+++ b/templates/components/products/price-range.html
@@ -2,18 +2,19 @@
     <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
         <span data-product-price-with-tax class="price">{{price_range.min.with_tax.formatted}} - {{price_range.max.with_tax.formatted}}</span>
         {{#and price_range.min.without_tax price_range.max.without_tax}}
-            <abbr title="{{lang 'products.excluding_tax'}}">{{lang 'products.price_with_tax' tax_label=price_range.min.tax_label}}</abbr>
-        {{else if schema_org}}
-                <meta itemprop="availability" content="{{product.availability}}">
-                <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
-                <div itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
-                    <meta itemprop="minPrice" content="{{price_range.min.with_tax.value}}"  />
-                    <meta itemprop="price" content="{{price_range.min.with_tax.value}}">
-                    <meta itemprop="maxPrice" content="{{price_range.max.with_tax.value}}"  />
-                    <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
-                    <meta itemprop="valueAddedTaxIncluded" content="true">
-                </div>
+            <abbr title="{{lang 'products.including_tax'}}">{{lang 'products.price_with_tax' tax_label=price_range.min.tax_label}}</abbr>
         {{/and}}
+        {{#if schema_org}}
+            <meta itemprop="availability" content="{{product.availability}}">
+            <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
+            <div itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
+                <meta itemprop="minPrice" content="{{price_range.min.with_tax.value}}"  />
+                <meta itemprop="price" content="{{price_range.min.with_tax.value}}">
+                <meta itemprop="maxPrice" content="{{price_range.max.with_tax.value}}"  />
+                <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
+                <meta itemprop="valueAddedTaxIncluded" content="true">
+            </div>
+        {{/if}}
     </div>
 {{/and}}
 {{#and price_range.min.without_tax price_range.max.without_tax}}

--- a/templates/components/products/price.html
+++ b/templates/components/products/price.html
@@ -2,19 +2,19 @@
     {{> components/products/price-range price_range=price.price_range schema_org=schema_org}}
 {{else}}
     {{#if price.with_tax}}
-        <div class="price-section price-section--withTax rrp-price--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+        <div class="price-section price-section--withTax rrp-price--withTax">
             {{#if price.rrp_with_tax}}
                 {{lang 'products.retail_price'}}
                 <span data-product-rrp-with-tax class="price price--rrp"> {{price.rrp_with_tax.formatted}}</span>
             {{/if}}
         </div>
-        <div class="price-section price-section--withTax non-sale-price---withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+        <div class="price-section price-section--withTax non-sale-price---withTax">
             {{#if price.non_sale_price_with_tax}}
                 {{lang 'products.price_was'}}
                 <span data-product-non-sale-price-with-tax class="price price--rrp"> {{price.non_sale_price_with_tax.formatted}}</span>
             {{/if}}
         </div>
-        <div>
+        <div {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
             <span class="price-now-label">
                 {{#if price.non_sale_price_with_tax}}
                     {{lang 'products.price_now'}}
@@ -36,19 +36,19 @@
         </div>
     {{/if}}
     {{#if price.without_tax}}
-        <div class="price-section rrp-price--withoutTax price-section--withoutTax {{#if price.with_tax}}price-section--minor{{/if}}"  {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+        <div class="price-section rrp-price--withoutTax price-section--withoutTax {{#if price.with_tax}}price-section--minor{{/if}}">
             {{#if price.rrp_without_tax}}
                 {{lang 'products.retail_price'}}
                 <span data-product-rrp-price-without-tax class="price price--rrp"> {{price.rrp_without_tax.formatted}}</span>
             {{/if}}
         </div>
-        <div class="price-section non-sale-price---withoutTax price-section--withoutTax {{#if price.with_tax}}price-section--minor{{/if}}"  {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+        <div class="price-section non-sale-price---withoutTax price-section--withoutTax {{#if price.with_tax}}price-section--minor{{/if}}">
             {{#if price.non_sale_price_without_tax}}
                 {{lang 'products.price_was'}}
                 <span data-product-non-sale-price-without-tax class="price price--rrp"> {{price.non_sale_price_without_tax.formatted}}</span>
             {{/if}}
         </div>
-        <div>
+        <div {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
             <span class="price-now-label">
                 {{#if price.non_sale_price_without_tax}}
                     {{lang 'products.price_now'}}

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -11,10 +11,11 @@
     <section class="productView-details">
         <div class="productView-product">
             <h1 class="productView-title" {{#if schema}}itemprop="name"{{/if}}>{{product.title}}</h1>
-
-            <h2 class="productView-brand"{{#if schema}} itemprop="brand" itemscope itemtype="http://schema.org/Brand"{{/if}}>
-                <a href="{{product.brand.url}}"{{#if schema}} itemprop="url"{{/if}}><span{{#if schema}} itemprop="name"{{/if}}>{{product.brand.name}}</span></a>
-            </h2>
+            {{#if product.brand}}
+                <h2 class="productView-brand"{{#if schema}} itemprop="brand" itemscope itemtype="http://schema.org/Brand"{{/if}}>
+                    <a href="{{product.brand.url}}"{{#if schema}} itemprop="url"{{/if}}><span{{#if schema}} itemprop="name"{{/if}}>{{product.brand.name}}</span></a>
+                </h2>
+            {{/if}}
             {{#if product.call_for_price}}
                 <p class="productView-price">
                     <span>{{product.call_for_price}}</span>
@@ -28,36 +29,38 @@
                 {{/or}}
             </div>
             {{{region name="product_below_price"}}}
-            <div class="productView-rating"{{#if schema}} itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating"{{/if}}>
-                {{#if settings.show_product_rating}}
-                    {{#if product.num_reviews '>' 0}}
-                        {{#if schema}}
-                            <meta itemprop="ratingValue" content="{{product.rating}}">
-                            <meta itemprop="ratingCount" content="{{product.num_reviews}}">
-                            <meta itemprop="reviewCount" content="{{product.num_reviews}}">
-                        {{/if}}
-                    {{/if}}
-                    {{> components/products/ratings rating=product.rating}}
-                    <span class="productView-reviewLink">
+            {{#if product.rating}}
+                <div class="productView-rating"{{#if schema}} itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating"{{/if}}>
+                    {{#if settings.show_product_rating}}
                         {{#if product.num_reviews '>' 0}}
-                            <a href="{{product.url}}#product-reviews">
-                                {{lang 'products.reviews.link_to_review' total=product.num_reviews}}
-                            </a>
-                        {{else}}
-                            {{lang 'products.reviews.link_to_review' total=product.num_reviews}}
+                            {{#if schema}}
+                                <meta itemprop="ratingValue" content="{{product.rating}}">
+                                <meta itemprop="ratingCount" content="{{product.num_reviews}}">
+                                <meta itemprop="reviewCount" content="{{product.num_reviews}}">
+                            {{/if}}
                         {{/if}}
-                    </span>
-                {{/if}}
-                {{#if settings.show_product_reviews}}
-                    <span class="productView-reviewLink">
-                        <a href="{{product.url}}{{#if is_ajax}}#write_review{{/if}}"
-                           {{#unless is_ajax }}data-reveal-id="modal-review-form"{{/unless}}>
-                           {{lang 'products.reviews.new'}}
-                        </a>
-                    </span>
-                    {{> components/products/modals/writeReview}}
-                {{/if}}
-            </div>
+                        {{> components/products/ratings rating=product.rating}}
+                        <span class="productView-reviewLink">
+                            {{#if product.num_reviews '>' 0}}
+                                <a href="{{product.url}}#product-reviews">
+                                    {{lang 'products.reviews.link_to_review' total=product.num_reviews}}
+                                </a>
+                            {{else}}
+                                {{lang 'products.reviews.link_to_review' total=product.num_reviews}}
+                            {{/if}}
+                        </span>
+                    {{/if}}
+                    {{#if settings.show_product_reviews}}
+                        <span class="productView-reviewLink">
+                            <a href="{{product.url}}{{#if is_ajax}}#write_review{{/if}}"
+                               {{#unless is_ajax }}data-reveal-id="modal-review-form"{{/unless}}>
+                               {{lang 'products.reviews.new'}}
+                            </a>
+                        </span>
+                        {{> components/products/modals/writeReview}}
+                    {{/if}}
+                </div>
+            {{/if}}
             {{product.detail_messages}}
             <dl class="productView-info">
                 {{#if product.sku}}


### PR DESCRIPTION
#### What?

We are adding schema.org offer tags on div's that schema.org doesn't care about what price was
it only cares about what price currently is afaict  I need to validate still that price-range schema works.

- [x] Test case about simple product
- [x] Test case about complex product
- [x] Test case about pricelist enabled product
- [x] Test case about Product with varying Tax inclusion settings.

#### Tickets / Documentation

- [STRF-2456](https://jira.bigcommerce.com/browse/STRF-2456)

#### Screenshots

Fixed product schema with "was" and "currently" prices
![screen shot 2018-05-11 at 5 10 11 pm](https://user-images.githubusercontent.com/4246575/39951393-47aed46c-553e-11e8-97f8-fb8ee5a37a05.png)

