### PR TITLE
fix(catalog): CATALOG-2913 individual low inventory count for skus

### DIFF
--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -464,6 +464,9 @@ export default class ProductDetails {
             viewModel.stock.$container.removeClass('u-hiddenVisually');
 
             viewModel.stock.$input.text(data.stock);
+        } else {
+            viewModel.stock.$container.addClass('u-hiddenVisually');
+            viewModel.stock.$input.text(data.stock);
         }
 
         this.updateDefaultAttributesForOOS(data);


### PR DESCRIPTION
#### What?

 address STOCK_LEVEL_DISPLAY_SHOW_WHEN_LOW 
   setting for skus. We were not properly switching back and forth
    between skus that were above and below their own respective
    threshholds.


#### Tickets / Documentation

- [CATALOG-2913](https://jira.bigcommerce.com/browse/CATALOG-2913)


### Dependency 
in order for this to work completely, this FE change depends on a BC pr 
please see ticket for additional info.
