### PR TITLE
Remove duplicate import of normalize at theme.scss

### DIFF
--- a/assets/scss/theme.scss
+++ b/assets/scss/theme.scss
@@ -62,15 +62,13 @@
 // Components
 // -----------------------------------------------------------------------------
 //
-// 1. Import Citadel's normalize dependency.
-// 2. Import Citadel's components.
+// 1. Import Citadel's components.
 // 2. Import Stencil's component additions and custom components.
 //
 // -----------------------------------------------------------------------------
 
-@import "../../node_modules/@bigcommerce/citadel/dist/vendor/normalize/normalize"; // 1
-@import "../../node_modules/@bigcommerce/citadel/dist/components/components"; // 2
-@import "components/components"; // 3
+@import "../../node_modules/@bigcommerce/citadel/dist/components/components"; // 1
+@import "components/components"; // 2
 
 
 // Layouts


### PR DESCRIPTION
#### What?

Normalize is already being imported at line 35.

It does not seem necessary to import it a second time, again, at line 71.

#### Tickets / Documentation

N/A

#### Screenshots (if appropriate)

N/A