### PR TITLE
fix(storefront): STRF-4786 Do not escape blog summary HTML.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Fix for sort disappearing on range update with product filtering [#1232](https://github.com/bigcommerce/cornerstone/pull/1232)
+- No longer escaping HTML content in blog summaries. [#1238](https://github.com/bigcommerce/cornerstone/pull/1238)
 
 ## 1.18.0 (2018-05-09)
 - Add the +/- icons for the category filtering [#1211](https://github.com/bigcommerce/cornerstone/pull/1211)

--- a/templates/components/blog/post.html
+++ b/templates/components/blog/post.html
@@ -21,7 +21,7 @@
             {{#if post.body}}
                 {{{post.body}}}
             {{else}}
-                {{post.summary}}
+                {{{post.summary}}}
                 {{#if post.show_read_more}}
                     &hellip; <a href="{{url}}">read more</a>
                 {{/if}}


### PR DESCRIPTION
#### What?

Blog summary content was being escaped, resulting in space characters to show up as `&nbsp;`. Now that content is being un-escaped like content in blog posts.

Note that this does not apply to all whitespace characters. Tabs are not treated as "tabs" in the summary and will not show up. Newlines are not part of the blog summary.

#### Tickets / Documentation

- [STRF-4786](https://jira.bigcommerce.com/browse/STRF-4786)
- [Handlebars HTML Escaping](http://handlebarsjs.com/#html-escaping)

#### Screenshots (if appropriate)

Before:

![before](https://user-images.githubusercontent.com/1546172/40015275-9dc8413c-5767-11e8-9aff-901777af7515.png)

After:

![after](https://user-images.githubusercontent.com/1546172/40015282-a20bb4fe-5767-11e8-9236-371186688949.png)