### PR TITLE
fix(storefront): STRF-4804 Fix Store Logo image size for Amp Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Fix for sort disappearing on range update with product filtering [#1232](https://github.com/bigcommerce/cornerstone/pull/1232)
 - No longer escaping HTML content in blog summaries. [#1238](https://github.com/bigcommerce/cornerstone/pull/1238)
+- Fix logo image dimensions on AMP pages. [#1239](https://github.com/bigcommerce/cornerstone/pull/1239)
 
 ## 1.18.0 (2018-05-09)
 - Add the +/- icons for the category filtering [#1211](https://github.com/bigcommerce/cornerstone/pull/1211)

--- a/templates/components/amp/common/store-logo.html
+++ b/templates/components/amp/common/store-logo.html
@@ -1,9 +1,15 @@
 <a href="{{urls.home}}" class="amp-header-link">
     {{#if settings.store_logo.image}}
-        <amp-img
-            src="{{getImage settings.store_logo.image 'logo_size'}}"
-            width="100"
-            height="50"
+        <amp-img src="{{getImage settings.store_logo.image 'logo_size'}}"
+            {{#if theme_settings.logo_size '===' 'original' }}
+                width="100"
+                height="50"
+            {{else}}
+                width="{{first (split theme_settings.logo_size 'x')}}"
+                height="{{last (split theme_settings.logo_size 'x')}}"
+                layout="responsive"
+                sizes="(min-height: {{last (split theme_settings.logo_size 'x')}}%)"
+            {{/if}}
             alt="{{settings.store_logo.title}}">
         </amp-img>
     {{else}}


### PR DESCRIPTION
⚠️  this does not fix then entire issue ⚠️ 
#### What?
Store logo is distorted on AMP pages on mobile or desktop. We were not respecting the logo settings when specified.  There is still an issue however where if the image is larger than 250x50 then it doesn't get sized according to css properly. 

below is an example of it still being incorrect for too large of a logo
![screen shot 2018-05-16 at 1 42 36 pm](https://user-images.githubusercontent.com/4246575/40143016-1d2df248-590f-11e8-9260-7ddb8077a8d7.png)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.
- [STRF-4804](https://jira.bigcommerce.com/browse/STRF-4804)

@mattolson @mjschock @Ubersmake 