### PR TITLE
Delete browserlist

### DIFF
--- a/browserlist
+++ b/browserlist
@@ -1,3 +1,0 @@
-> 1%
-last 2 versions
-Firefox ESR


### PR DESCRIPTION
#### What?

As discussed at #1206, this file is currently useless.

When the time comes (Babel 7 release), a `browserslist` (plural at browser**s**) can be introduced.

#### Tickets / Documentation

- [Is "browserlist" file used?](https://github.com/bigcommerce/cornerstone/issues/1206)
