### PR TITLE
Avoid undefined context in WishList instance

### DIFF
--- a/assets/js/theme/account.js
+++ b/assets/js/theme/account.js
@@ -27,7 +27,7 @@ export default class Account extends PageManager {
         this.passwordRequirements = this.context.passwordRequirements;
 
         // Instantiates wish list JS
-        Wishlist.load();
+        Wishlist.load(this.context);
 
         if ($editAccountForm.length) {
             this.registerEditAccountValidation($editAccountForm);

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -18,7 +18,7 @@ export default class ProductDetails {
         this.listenQuantityChange();
         this.initRadioAttributes();
 
-        Wishlist.load();
+        Wishlist.load(this.context);
 
         const $form = $('form[data-cart-item-add]', $scope);
         const $productOptionsElement = $('[data-product-option-change]', $form);


### PR DESCRIPTION
#### What?

The value of `this.context` is `undefined` within WishList class instance, in the product and account pages. The class `constructor` expects a `context` parameter, but no parameter is provided when the instance is created from "product-details.js" and "account.js".

This has no side-effect when no customization is made to the theme. But any customization will expect `this.context` to have the `context` data, rather than `undefined`.

#### Tickets / Documentation

I have reported it here, but it seems it has been ignored or not understood:

- https://github.com/bigcommerce/cornerstone/commit/31bdddbf64293d85192cae00e966d531f527b150#r29038225

Thank you.