### PR TITLE
fix(storefront): STRF-4866 Fix missing quantity/selection for AMP product Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fix quantity edit on Simple Product AMP pages. [#1257](https://github.com/bigcommerce/cornerstone/pull/1257)
 
 ## 2.1.0 (2018-06-01)
 - Add Newsletter summary section to subscription form. [#1248](https://github.com/bigcommerce/cornerstone/pull/1248)

--- a/templates/components/amp/products/product-view.html
+++ b/templates/components/amp/products/product-view.html
@@ -28,17 +28,13 @@
     </section>
     <div class="productView-action">
         {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
-            {{#if product.options}}
-                <amp-iframe height="400" width="250"
-                    layout="responsive"
-                    sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-top-navigation allow-modals"
-                    resizable
-                    src="{{product.amp_options_url}}">
-                    <div class="button button--primary button--wide" overflow tabindex="0" role="button">Choose Options</div>
-                </amp-iframe>
-            {{else}}
-                <a class="button button--primary button--wide" role="button" href="{{product.cart_url}}">Add To Cart</a>
-            {{/if}}
+            <amp-iframe height="400" width="250"
+                layout="responsive"
+                sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-top-navigation allow-modals"
+                resizable
+                src="{{product.amp_options_url}}">
+                <div class="button button--primary button--wide" overflow tabindex="0" role="button">Choose Options</div>
+            </amp-iframe>
         {{/or}}
         {{#if product.out_of_stock}}
             {{#if product.out_of_stock_message}}

--- a/templates/pages/amp/product.html
+++ b/templates/pages/amp/product.html
@@ -16,9 +16,7 @@ product:
     {{#if settings.add_this.buttons}}
         <script async custom-element="amp-social-share" src="https://cdn.ampproject.org/v0/amp-social-share-0.1.js"></script>
     {{/if}}
-    {{#if product.options}}
-        <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
-    {{/if}}
+    <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
     {{#if product.videos}}
         <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
     {{/if}}


### PR DESCRIPTION
This ticket effectively re-adds the logic in this PR https://github.com/bigcommerce/cornerstone/pull/1242.
We determined the test that caused us to roll back was incorrect.