### PR TITLE
Changed Slick Carousel lazyLoad technique to Progressive.

### DIFF
--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -6,7 +6,7 @@
         "slidesToScroll": 1,
         "autoplay": true,
         "autoplaySpeed": {{carousel.swap_frequency}},
-        "lazyLoad": "ondemand"
+        "lazyLoad": "progressive"
     }'>
     {{#each carousel.slides}}
     <a href="{{url}}">


### PR DESCRIPTION
#### What?

Cornerstone has an issue where the first image in a carousel appears to reload on wrap. This "reload" happens despite the browser not making any new GETs.

This behavior is fixed by changing the Slick Carousel's lazy load technique from "ondemand" to "progressive". Note that this does technically make page performance worse, since progressive will attempt to load all images on the carousel at once instead of when a slide scrolls.

#### Tickets / Documentation

- [Slick Carousel](https://github.com/kenwheeler/slick)
- [STRF-4979](https://jira.bigcommerce.com/browse/STRF-4979)
- [Lighthouse Report Viewer](https://googlechrome.github.io/lighthouse/viewer2x/)

#### Screenshots and Reports

Reports were done on a test store. These stores are light, with very few products and zero customizations. The margin in performance should be significantly wider on a live store.

These reports were generated by Lighthouse and can be viewed in a human-readable form at https://googlechrome.github.io/lighthouse/viewer2x/.

##### Before: ondemand

![ondemand](https://user-images.githubusercontent.com/1546172/41122078-3cdfb6ca-6a4f-11e8-8764-6779e445a351.gif)

[ondemand.txt](https://github.com/bigcommerce/cornerstone/files/2081844/ondemand.txt)

##### After: progressive

![progressive](https://user-images.githubusercontent.com/1546172/41122137-70933f82-6a4f-11e8-9893-c9eedc88bf4a.gif)

[progressive.txt](https://github.com/bigcommerce/cornerstone/files/2081848/progressive.txt)

