### PR TITLE
Changed Slick Carousel lazyLoad technique to Anticipated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Fix quantity edit on Simple Product AMP pages. [#1257](https://github.com/bigcommerce/cornerstone/pull/1257)
+- Fix empty image on carousel wrap. [#1263](https://github.com/bigcommerce/cornerstone/pull/1263)
 
 ## 2.1.0 (2018-06-01)
 - Add Newsletter summary section to subscription form. [#1248](https://github.com/bigcommerce/cornerstone/pull/1248)

--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -6,7 +6,7 @@
         "slidesToScroll": 1,
         "autoplay": true,
         "autoplaySpeed": {{carousel.swap_frequency}},
-        "lazyLoad": "ondemand"
+        "lazyLoad": "anticipated"
     }'>
     {{#each carousel.slides}}
     <a href="{{url}}">


### PR DESCRIPTION
#### What?

Cornerstone has an issue where the first image in a carousel appears to reload on wrap. This "reload" happens despite the browser not making any new GETs.

This behavior is fixed by changing the Slick Carousel's lazy load technique back from `ondemand` to `anticipated`.

Slick Carousel's documentation has, at time of this PR, removed mentions of `anticipated` as a lazyLoad technique: https://github.com/kenwheeler/slick/blob/a2aa3fec335c50aceb58f6ef6d22df8e5f3238e1/README.markdown. The only two documented options are `ondemand` and `progressive`. `progressive` is markedly worse than `ondemand` in terms of performance. However, `anticipated` is still used to determine logic in `slick.js`, in both 1.8.1 and 1.9.0:

1.8.1: https://github.com/kenwheeler/slick/blob/ee7d37faeb92c4619ffeefeba2cc4c733f39b1b3/slick/slick.js
1.9.0: https://github.com/kenwheeler/slick/blob/a2aa3fec335c50aceb58f6ef6d22df8e5f3238e1/slick/slick.js

This PR comes after digging into Slick Carousel with #1259.

#### Tickets / Documentation

- [Slick Carousel](https://github.com/kenwheeler/slick)
- [STRF-4979](https://jira.bigcommerce.com/browse/STRF-4979)
- [Lighthouse Report Viewer](https://googlechrome.github.io/lighthouse/viewer2x/)

#### Screenshots and Reports

Reports were done on a test store. These stores are light, with very few products and zero customizations. The margin in performance should be significantly wider on a live store.

These reports were generated by Lighthouse and can be viewed in a human-readable form at https://googlechrome.github.io/lighthouse/viewer2x/.

##### Before: ondemand

![ondemand](https://user-images.githubusercontent.com/1546172/41183171-15ff73e4-6b2e-11e8-8a7d-c9f81cdd8175.gif)

[ondemand.txt](https://github.com/bigcommerce/cornerstone/files/2086317/ondemand.txt)

##### After: anticipated

![anticipated](https://user-images.githubusercontent.com/1546172/41183177-1dbb56e8-6b2e-11e8-88e0-bb3e77589b35.gif)

[anticipated.txt](https://github.com/bigcommerce/cornerstone/files/2086319/anticipated.txt)