### PR TITLE
Fix prices not showing in quick search while logged in when "Restrict to Login" for price display is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix for Changing Menu Colors In Theme Editor Not Respected In Mobile View [#1266](https://github.com/bigcommerce/cornerstone/pull/1266)
 - Fix arrow placement on currency dropdown menu [#1267](https://github.com/bigcommerce/cornerstone/pull/1267)
 - Add alias for lazysizes module to bundle minified library [#1275](https://github.com/bigcommerce/cornerstone/pull/1275)
+- Fix prices not showing in quick search while logged in when "Restrict to Login" for price display is true [#1272](https://github.com/bigcommerce/cornerstone/pull/1272)
 
 ## 2.1.0 (2018-06-01)
 - Add Newsletter summary section to subscription form. [#1248](https://github.com/bigcommerce/cornerstone/pull/1248)

--- a/templates/components/search/quick-results.html
+++ b/templates/components/search/quick-results.html
@@ -6,7 +6,7 @@
 
         {{#each product_results.products}}
         <li class="product">
-            {{> components/products/card alternate=true show_compare=../show_compare theme_settings=../theme_settings}}
+            {{> components/products/card alternate=true show_compare=../show_compare theme_settings=../theme_settings customer=../customer}}
         </li>
         {{/each}}
     </ul>


### PR DESCRIPTION
In theme options, if "Restrict to Login" for price display is set true, and a user searches the store while logged in, prices don't display and "Log in for pricing" message displays.

#### What?

Pass the {{customer}} variable to the card component, allowing pricing to display while searching the site after logging in.

#### Tickets / Documentation

- #1240 

#### Screenshots

**Before**
<img width="1551" alt="01 before" src="https://user-images.githubusercontent.com/5056945/41504077-fc977a84-7198-11e8-8ade-54ca3a419913.png">

**After**
<img width="1551" alt="02 after" src="https://user-images.githubusercontent.com/5056945/41504078-fcaff0f0-7198-11e8-9633-512232d5f9ee.png">
