### PR TITLE
Display product reviews in tabbed content region of product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix arrow placement on currency dropdown menu [#1267](https://github.com/bigcommerce/cornerstone/pull/1267)
 - Add alias for lazysizes module to bundle minified library [#1275](https://github.com/bigcommerce/cornerstone/pull/1275)
 - Fix prices not showing in quick search while logged in when "Restrict to Login" for price display is true [#1272](https://github.com/bigcommerce/cornerstone/pull/1272)
+- Display product reviews in tabbed content region of product page [#1273](https://github.com/bigcommerce/cornerstone/pull/1273)
 
 ## 2.1.0 (2018-06-01)
 - Add Newsletter summary section to subscription form. [#1248](https://github.com/bigcommerce/cornerstone/pull/1248)

--- a/assets/js/theme/product/reviews.js
+++ b/assets/js/theme/product/reviews.js
@@ -32,13 +32,17 @@ export default class {
     }
 
     collapseReviews() {
+        const $reviewTab = $('#tab-reviews');
+
         // We're in paginating state, do not collapse
         if (window.location.hash && window.location.hash.indexOf('#product-reviews') === 0) {
             return;
         }
 
-        // force collapse on page load
-        this.$collapsible.trigger(CollapsibleEvents.click);
+        // force collapse on page load if product reviews are displayed in tabs
+        if (!$reviewTab) {
+            this.$collapsible.trigger(CollapsibleEvents.click);
+        }
     }
 
     /**

--- a/assets/scss/components/foundation/tabs/_tabs.scss
+++ b/assets/scss/components/foundation/tabs/_tabs.scss
@@ -46,26 +46,52 @@
     }
 }
 
+.tab-content {
+    //
+    // State for when tab-content has js generated of calculated content, like carousel
+    //
+    // Purpose: The content being display: none, means any js calculated dimensions
+    // are incorrect as the elements inside the tab-content have no dimensions to grab.
+    // Carousel is a prime example. It needs widths to calculate the layout and slides
+    // -----------------------------------------------------------------------------
+    &.has-jsContent {
+        display: block;
+        height: 0;
+        overflow: hidden;
+        padding: 0;
+        visibility: hidden;
 
-//
-// State for when tab-content has js generated of calculated content, like carousel
-//
-// Purpose: The content being display: none, means any js calculated dimensions
-// are incorrect as the elements inside the tab-content have no dimensions to grab.
-// Carousel is a prime example. It needs widths to calculate the layout and slides
-// -----------------------------------------------------------------------------
+        // scss-lint:disable NestingDepth
+        &.is-active {
+            height: auto;
+            overflow: visible;
+            padding: $tabs-content-padding;
+            visibility: visible;
+        }
+        // scss-lint:enable NestingDepth
+    }
 
-.tab-content.has-jsContent {
-    display: block;
-    height: 0;
-    overflow: hidden;
-    padding: 0;
-    visibility: hidden;
 
-    &.is-active {
-        height: auto;
-        overflow: visible;
-        padding: $tabs-content-padding;
-        visibility: visible;
+    //
+    // Product review displays in tabs
+    //
+    // Purpose: Display product reviews within tabbed content on product pages.
+    // -----------------------------------------------------------------------------
+    .productReview {
+        @include breakpoint("small") {
+            width: grid-calc(6, $total-columns);
+        }
+
+        @include breakpoint("medium") {
+            width: grid-calc(4, $total-columns);
+        }
+
+        @include breakpoint("large") {
+            width: grid-calc(6, $total-columns);
+        }
+    }
+
+    .productReviews {
+        border-top: 0;
     }
 }

--- a/config.json
+++ b/config.json
@@ -68,6 +68,7 @@
     "show_accept_paypal": false,
     "show_accept_visa": false,
     "show_product_details_tabs": true,
+    "show_product_reviews_tabs": false,
     "show_product_weight": true,
     "show_product_dimensions": false,
     "product_list_display_mode": "grid",

--- a/schema.json
+++ b/schema.json
@@ -1168,6 +1168,12 @@
         "id": "show_product_details_tabs"
       },
       {
+         "type": "checkbox",
+         "label": "Product reviews in tabs",
+         "force_reload": true,
+         "id": "show_product_reviews_tabs"
+      },
+      {
         "type": "checkbox",
         "label": "Show product weight",
         "force_reload": true,

--- a/templates/components/products/description-tabs.html
+++ b/templates/components/products/description-tabs.html
@@ -7,6 +7,11 @@
             <a class="tab-title" href="#tab-warranty">{{lang 'products.warranty'}}</a>
         </li>
     {{/if}}
+    {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs}}
+        <li class="tab">
+            <a class="tab-title productView-reviewTabLink" href="#tab-reviews">{{lang 'products.reviews.header' total=product.reviews.total}}</a>
+        </li>
+    {{/all}}
 </ul>
 <div class="tabs-contents">
     <div class="tab-content is-active" id="tab-description">
@@ -18,4 +23,9 @@
            {{{product.warranty}}}
        </div>
    {{/if}}
+   {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs}}
+       <div class="tab-content" id="tab-reviews">
+           {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
+       </div>
+   {{/all}}
 </div>

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -23,9 +23,9 @@ product:
             {{> components/products/videos product.videos}}
         {{/if}}
 
-        {{#if settings.show_product_reviews}}
+        {{#all settings.show_product_reviews (if theme_settings.show_product_reviews_tabs '!==' true)}}
             {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
-        {{/if}}
+        {{/all}}
 
         {{> components/products/tabs}}
 


### PR DESCRIPTION
#### What?

Adds an option to display customer reviews in the details tabs area on product pages.

#### Screenshots

**False, desktop**
<img width="2160" alt="false 01 - desktop" src="https://user-images.githubusercontent.com/5056945/41555975-3708023c-72ee-11e8-8a39-0c00fe118e21.png">

**False, tablet**
<img width="1132" alt="false 02 - tablet" src="https://user-images.githubusercontent.com/5056945/41555976-371df61e-72ee-11e8-8c89-b2b72f299319.png">

**False, mobile**
<img width="512" alt="false 03 - mobile" src="https://user-images.githubusercontent.com/5056945/41555977-3735fea8-72ee-11e8-8a5e-1294dc66ff3a.png">

**True, desktop**
<img width="2160" alt="true 01 - desktop" src="https://user-images.githubusercontent.com/5056945/41555978-374b05a0-72ee-11e8-904a-21306dc6efe0.png">

**True, tablet**
<img width="1190" alt="true 02 - tablet" src="https://user-images.githubusercontent.com/5056945/41555979-376258b8-72ee-11e8-8747-75c89c6d42bb.png">

**True, mobile**
<img width="512" alt="true 03 - mobile" src="https://user-images.githubusercontent.com/5056945/41555981-3779c49e-72ee-11e8-8291-a0b8148fac63.png">
