### PR TITLE
Add alias for lazysizes module to bundle minified library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix svg arrows missing on AMP product pages. [#1258](https://github.com/bigcommerce/cornerstone/pull/1258)
 - Fix for Changing Menu Colors In Theme Editor Not Respected In Mobile View [#1266](https://github.com/bigcommerce/cornerstone/pull/1266)
 - Fix arrow placement on currency dropdown menu [#1267](https://github.com/bigcommerce/cornerstone/pull/1267)
+- Add alias for lazysizes module to bundle minified library [#1275](https://github.com/bigcommerce/cornerstone/pull/1275)
 
 ## 2.1.0 (2018-06-01)
 - Add Newsletter summary section to subscription form. [#1248](https://github.com/bigcommerce/cornerstone/pull/1248)

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -60,6 +60,7 @@ module.exports = {
         alias: {
             'jquery-migrate': path.resolve(__dirname, 'node_modules/jquery-migrate/dist/jquery-migrate.min.js'),
             jstree: path.resolve(__dirname, 'node_modules/jstree/dist/jstree.min.js'),
+            'lazysizes': path.resolve(__dirname, 'node_modules/lazysizes/lazysizes.min.js'),
             'pace': path.resolve(__dirname, 'node_modules/pace/pace.min.js'),
             'slick-carousel': path.resolve(__dirname, 'node_modules/slick-carousel/slick/slick.min.js'),
             'svg-injector': path.resolve(__dirname, 'node_modules/svg-injector/dist/svg-injector.min.js'),


### PR DESCRIPTION
### What?

Add webpack alias for lazysizes module so the minified library is bundled. End up saving ~10KB.

**Before**
<img width="2160" alt="01 before" src="https://user-images.githubusercontent.com/5056945/41548976-434b410e-72d9-11e8-9990-ce02cdc9c964.png">

**After**
<img width="2160" alt="02 after" src="https://user-images.githubusercontent.com/5056945/41548977-435f21c4-72d9-11e8-9801-a948f443dba7.png">
