### PR TITLE
Fix duplicate input ID's in product review form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix prices not showing in quick search while logged in when "Restrict to Login" for price display is true [#1272](https://github.com/bigcommerce/cornerstone/pull/1272)
 - Display product reviews in tabbed content region of product page [#1273](https://github.com/bigcommerce/cornerstone/pull/1273)
 - Disable zoom and link for default "No Image" image. [#1278](https://github.com/bigcommerce/cornerstone/pull/1278)
+- Fix duplicate input ID's in product review form [#1276](https://github.com/bigcommerce/cornerstone/pull/1276)
 
 ## 2.1.0 (2018-06-01)
 - Add Newsletter summary section to subscription form. [#1248](https://github.com/bigcommerce/cornerstone/pull/1248)

--- a/templates/components/products/modals/writeReview.html
+++ b/templates/components/products/modals/writeReview.html
@@ -39,25 +39,25 @@
 
                 <!-- Name -->
                 {{#if product.reviews.author}}
-                    {{> components/common/forms/text name="revfromname" label=(lang 'products.reviews.form_write.name') value=product.reviews.author}}
+                    {{> components/common/forms/text id="revfromname" name="revfromname" label=(lang 'products.reviews.form_write.name') value=product.reviews.author}}
                 {{else}}
-                    {{> components/common/forms/text name="revfromname" label=(lang 'products.reviews.form_write.name') value=customer.name}}
+                    {{> components/common/forms/text id="revfromname" name="revfromname" label=(lang 'products.reviews.form_write.name') value=customer.name}}
                 {{/if}}
 
                 {{#if product.reviews.show_review_email}}
                     <!-- Email -->
                     {{#if product.reviews.email}}
-                        {{> components/common/forms/text name="email" required="false" label=(lang 'products.reviews.form_write.email') value=product.reviews.email}}
+                        {{> components/common/forms/text id="email" name="email" required="false" label=(lang 'products.reviews.form_write.email') value=product.reviews.email}}
                     {{else}}
-                        {{> components/common/forms/text name="email" required="false" label=(lang 'products.reviews.form_write.email') value=customer.email}}
+                        {{> components/common/forms/text id="email" name="email" required="false" label=(lang 'products.reviews.form_write.email') value=customer.email}}
                     {{/if}}
                 {{/if}}
 
                 <!-- Review Subject -->
-                {{> components/common/forms/text name="revtitle" required="true" label=(lang 'products.reviews.form_write.subject') value=product.reviews.title}}
+                {{> components/common/forms/text id="revtitle" name="revtitle" required="true" label=(lang 'products.reviews.form_write.subject') value=product.reviews.title}}
 
                 <!-- Comments -->
-                {{> components/common/forms/multiline name="revtext" required="true" label=(lang 'products.reviews.form_write.comments') value=product.reviews.text}}
+                {{> components/common/forms/multiline id="revtext" name="revtext" required="true" label=(lang 'products.reviews.form_write.comments') value=product.reviews.text}}
 
                 {{{product.reviews.recaptcha.markup}}}
 


### PR DESCRIPTION
### What?

Duplicate ID's were in the DOM on the write review form. This was happening because ID's weren't 
being passed to the form components.

**Before**
`{{> components/common/forms/text name="revfromname" label=(lang 'products.reviews.form_write.name') value=product.reviews.author}}`

**After**
`{{> components/common/forms/text id="writeReview-name" name="revfromname" label=(lang 'products.reviews.form_write.name') value=product.reviews.author}}`

### Documentation
- #1265 

### Sreenshots

**Before**
<img width="1552" alt="01 - before" src="https://user-images.githubusercontent.com/5056945/41567437-0c2783c2-7315-11e8-811f-145087156622.png">

**After**
<img width="1552" alt="02 - after" src="https://user-images.githubusercontent.com/5056945/41567438-0c3dca6a-7315-11e8-93d6-edb7a8c0931e.png">
