### PR TITLE
Disable zoom and link for default "No Image" image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add alias for lazysizes module to bundle minified library [#1275](https://github.com/bigcommerce/cornerstone/pull/1275)
 - Fix prices not showing in quick search while logged in when "Restrict to Login" for price display is true [#1272](https://github.com/bigcommerce/cornerstone/pull/1272)
 - Display product reviews in tabbed content region of product page [#1273](https://github.com/bigcommerce/cornerstone/pull/1273)
+- Disable zoom and link for default "No Image" image. [#1278](https://github.com/bigcommerce/cornerstone/pull/1278)
 
 ## 2.1.0 (2018-06-01)
 - Add Newsletter summary section to subscription form. [#1248](https://github.com/bigcommerce/cornerstone/pull/1248)

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -151,17 +151,23 @@
 
     <section class="productView-images" data-image-gallery>
         <figure class="productView-image"
-                data-image-gallery-main
-                data-zoom-image="{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}"
+                {{#if product.main_image}}
+                    data-image-gallery-main
+                    data-zoom-image="{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}"
+                {{/if}}
                 >
             <div class="productView-img-container">
-                <a href="{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}">
-                    <img class="productView-image--default lazyload" 
-                         data-sizes="auto" 
-                         src="{{cdn 'img/loading.svg'}}" 
-                         data-src="{{getImage product.main_image 'product_size' (cdn theme_settings.default_image_product)}}"
-                         alt="{{product.main_image.alt}}" title="{{product.main_image.alt}}" data-main-image>
-                </a>
+                {{#if product.main_image}}
+                    <a href="{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}">
+                        <img class="productView-image--default lazyload"
+                             data-sizes="auto"
+                             src="{{cdn 'img/loading.svg'}}"
+                             data-src="{{getImage product.main_image 'product_size' (cdn theme_settings.default_image_product)}}"
+                             alt="{{product.main_image.alt}}" title="{{product.main_image.alt}}" data-main-image>
+                    </a>
+                {{else}}
+                    <img class="productView-image--default" src="{{cdn theme_settings.default_image_product}}">
+                {{/if}}
             </div>
         </figure>
         <ul class="productView-thumbnails"{{#gt product.images.length 5}} data-slick='{


### PR DESCRIPTION
#### What?

When a product has no images Cornerstone will display a default "No Image" image.

This image is zoomable, like other product images. And clicking on the image (if you can manage to click the 0x0 <a/> element) will open the full-size version of the image in the current view.

This PR removes that behavior. If a product has no images and thus displays the "No Image" image, the "No Image" image is treated like placeholder text. It does not zoom. It has no link.

#### Tickets / Documentation

- [STRF-5007](https://jira.bigcommerce.com/browse/STRF-5007)

#### Screenshots (if appropriate)

##### Before

Product Details Page:

![productbefore](https://user-images.githubusercontent.com/1546172/41618050-f2e659fe-73b6-11e8-81e1-224eb3fa302d.gif)

Quick View:

![quickbefore](https://user-images.githubusercontent.com/1546172/41618059-f739fee8-73b6-11e8-9098-6a01ee162aff.gif)

##### After

Product Details Page:

![productafter](https://user-images.githubusercontent.com/1546172/41618063-fe292e7c-73b6-11e8-9da6-db6b17a99f80.gif)

Quick View:

![quickafter](https://user-images.githubusercontent.com/1546172/41618069-0247fb64-73b7-11e8-9aaf-5a0608769f19.gif)
