### PR TITLE
Revert #1278

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 - Add alias for lazysizes module to bundle minified library [#1275](https://github.com/bigcommerce/cornerstone/pull/1275)
 - Fix prices not showing in quick search while logged in when "Restrict to Login" for price display is true [#1272](https://github.com/bigcommerce/cornerstone/pull/1272)
 - Display product reviews in tabbed content region of product page [#1273](https://github.com/bigcommerce/cornerstone/pull/1273)
-- Disable zoom and link for default "No Image" image. [#1278](https://github.com/bigcommerce/cornerstone/pull/1278)
 - Fix duplicate input ID's in product review form [#1276](https://github.com/bigcommerce/cornerstone/pull/1276)
 
 ## 2.1.0 (2018-06-01)

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -151,23 +151,17 @@
 
     <section class="productView-images" data-image-gallery>
         <figure class="productView-image"
-                {{#if product.main_image}}
-                    data-image-gallery-main
-                    data-zoom-image="{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}"
-                {{/if}}
+                data-image-gallery-main
+                data-zoom-image="{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}"
                 >
             <div class="productView-img-container">
-                {{#if product.main_image}}
-                    <a href="{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}">
-                        <img class="productView-image--default lazyload"
-                             data-sizes="auto"
-                             src="{{cdn 'img/loading.svg'}}"
-                             data-src="{{getImage product.main_image 'product_size' (cdn theme_settings.default_image_product)}}"
-                             alt="{{product.main_image.alt}}" title="{{product.main_image.alt}}" data-main-image>
-                    </a>
-                {{else}}
-                    <img class="productView-image--default" src="{{cdn theme_settings.default_image_product}}">
-                {{/if}}
+                <a href="{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}">
+                    <img class="productView-image--default lazyload"
+                         data-sizes="auto"
+                         src="{{cdn 'img/loading.svg'}}"
+                         data-src="{{getImage product.main_image 'product_size' (cdn theme_settings.default_image_product)}}"
+                         alt="{{product.main_image.alt}}" title="{{product.main_image.alt}}" data-main-image>
+                </a>
             </div>
         </figure>
         <ul class="productView-thumbnails"{{#gt product.images.length 5}} data-slick='{


### PR DESCRIPTION
#### What?

Revert changes to disable zoom and link behavior on "No Image" image: https://github.com/bigcommerce/cornerstone/pull/1278

This naively assumed that a product without an image would only have variants without images. This isn't the case, and was caught by one of the data sets in ProductOptionRuleUITest::testProductOptionRules

#### Tickets / Documentation

- [STRF-5007](https://jira.bigcommerce.com/browse/STRF-5007)