### PR TITLE
Fix minor ESLint errors in webpack.common.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix indefinite load spinner for products without an image in order history. [#1284](https://github.com/bigcommerce/cornerstone/pull/1284)
 - Fix Webpack DefinePlugin configuration. [#1286](https://github.com/bigcommerce/cornerstone/pull/1286)
 - Disable zoom and link for default "No Image" image. [#1291](https://github.com/bigcommerce/cornerstone/pull/1291)
+- Fix for ESLint "quotes" and "quote-props" errors. [#1280](https://github.com/bigcommerce/cornerstone/pull/1280)
 
 ## 2.2.0 (2018-06-22)
 - Fix quantity edit on Simple Product AMP pages. [#1257](https://github.com/bigcommerce/cornerstone/pull/1257)

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -42,7 +42,7 @@ module.exports = {
     output: {
         chunkFilename: 'theme-bundle.chunk.[name].js',
         filename: 'theme-bundle.[name].js',
-        path: path.resolve(__dirname, "assets/dist"),
+        path: path.resolve(__dirname, 'assets/dist'),
     },
     plugins: [
         new CleanPlugin(['assets/dist'], {
@@ -60,8 +60,8 @@ module.exports = {
         alias: {
             'jquery-migrate': path.resolve(__dirname, 'node_modules/jquery-migrate/dist/jquery-migrate.min.js'),
             jstree: path.resolve(__dirname, 'node_modules/jstree/dist/jstree.min.js'),
-            'lazysizes': path.resolve(__dirname, 'node_modules/lazysizes/lazysizes.min.js'),
-            'pace': path.resolve(__dirname, 'node_modules/pace/pace.min.js'),
+            lazysizes: path.resolve(__dirname, 'node_modules/lazysizes/lazysizes.min.js'),
+            pace: path.resolve(__dirname, 'node_modules/pace/pace.min.js'),
             'slick-carousel': path.resolve(__dirname, 'node_modules/slick-carousel/slick/slick.min.js'),
             'svg-injector': path.resolve(__dirname, 'node_modules/svg-injector/dist/svg-injector.min.js'),
             sweetalert2: path.resolve(__dirname, 'node_modules/sweetalert2/dist/sweetalert2.min.js'),


### PR DESCRIPTION
#### What?

Just some minor cleanup for consistency in `webpack.common.js` by removing unnecessary quotes from single string properties and use single quotes for theme bundle output path. Added benefit of removing ESLint errors thrown in Atom.

- `Strings must use singlequote. (quotes) 45:39`
- `Unnecessarily quoted property 'lazysizes' found. (quote-props) 63:13`
- `Unnecessarily quoted property 'pace' found. (quote-props) 64:13`