### PR TITLE
Revert #1273

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 - Fix arrow placement on currency dropdown menu [#1267](https://github.com/bigcommerce/cornerstone/pull/1267)
 - Add alias for lazysizes module to bundle minified library [#1275](https://github.com/bigcommerce/cornerstone/pull/1275)
 - Fix prices not showing in quick search while logged in when "Restrict to Login" for price display is true [#1272](https://github.com/bigcommerce/cornerstone/pull/1272)
-- Display product reviews in tabbed content region of product page [#1273](https://github.com/bigcommerce/cornerstone/pull/1273)
 - Fix duplicate input ID's in product review form [#1276](https://github.com/bigcommerce/cornerstone/pull/1276)
 
 ## 2.1.0 (2018-06-01)

--- a/assets/js/theme/product/reviews.js
+++ b/assets/js/theme/product/reviews.js
@@ -32,17 +32,13 @@ export default class {
     }
 
     collapseReviews() {
-        const $reviewTab = $('#tab-reviews');
-
         // We're in paginating state, do not collapse
         if (window.location.hash && window.location.hash.indexOf('#product-reviews') === 0) {
             return;
         }
 
-        // force collapse on page load if product reviews are displayed in tabs
-        if (!$reviewTab) {
-            this.$collapsible.trigger(CollapsibleEvents.click);
-        }
+        // force collapse on page load
+        this.$collapsible.trigger(CollapsibleEvents.click);
     }
 
     /**

--- a/assets/scss/components/foundation/tabs/_tabs.scss
+++ b/assets/scss/components/foundation/tabs/_tabs.scss
@@ -46,52 +46,26 @@
     }
 }
 
-.tab-content {
-    //
-    // State for when tab-content has js generated of calculated content, like carousel
-    //
-    // Purpose: The content being display: none, means any js calculated dimensions
-    // are incorrect as the elements inside the tab-content have no dimensions to grab.
-    // Carousel is a prime example. It needs widths to calculate the layout and slides
-    // -----------------------------------------------------------------------------
-    &.has-jsContent {
-        display: block;
-        height: 0;
-        overflow: hidden;
-        padding: 0;
-        visibility: hidden;
 
-        // scss-lint:disable NestingDepth
-        &.is-active {
-            height: auto;
-            overflow: visible;
-            padding: $tabs-content-padding;
-            visibility: visible;
-        }
-        // scss-lint:enable NestingDepth
-    }
+//
+// State for when tab-content has js generated of calculated content, like carousel
+//
+// Purpose: The content being display: none, means any js calculated dimensions
+// are incorrect as the elements inside the tab-content have no dimensions to grab.
+// Carousel is a prime example. It needs widths to calculate the layout and slides
+// -----------------------------------------------------------------------------
 
+.tab-content.has-jsContent {
+    display: block;
+    height: 0;
+    overflow: hidden;
+    padding: 0;
+    visibility: hidden;
 
-    //
-    // Product review displays in tabs
-    //
-    // Purpose: Display product reviews within tabbed content on product pages.
-    // -----------------------------------------------------------------------------
-    .productReview {
-        @include breakpoint("small") {
-            width: grid-calc(6, $total-columns);
-        }
-
-        @include breakpoint("medium") {
-            width: grid-calc(4, $total-columns);
-        }
-
-        @include breakpoint("large") {
-            width: grid-calc(6, $total-columns);
-        }
-    }
-
-    .productReviews {
-        border-top: 0;
+    &.is-active {
+        height: auto;
+        overflow: visible;
+        padding: $tabs-content-padding;
+        visibility: visible;
     }
 }

--- a/config.json
+++ b/config.json
@@ -68,7 +68,6 @@
     "show_accept_paypal": false,
     "show_accept_visa": false,
     "show_product_details_tabs": true,
-    "show_product_reviews_tabs": false,
     "show_product_weight": true,
     "show_product_dimensions": false,
     "product_list_display_mode": "grid",

--- a/schema.json
+++ b/schema.json
@@ -1168,12 +1168,6 @@
         "id": "show_product_details_tabs"
       },
       {
-         "type": "checkbox",
-         "label": "Product reviews in tabs",
-         "force_reload": true,
-         "id": "show_product_reviews_tabs"
-      },
-      {
         "type": "checkbox",
         "label": "Show product weight",
         "force_reload": true,

--- a/templates/components/products/description-tabs.html
+++ b/templates/components/products/description-tabs.html
@@ -7,11 +7,6 @@
             <a class="tab-title" href="#tab-warranty">{{lang 'products.warranty'}}</a>
         </li>
     {{/if}}
-    {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs}}
-        <li class="tab">
-            <a class="tab-title productView-reviewTabLink" href="#tab-reviews">{{lang 'products.reviews.header' total=product.reviews.total}}</a>
-        </li>
-    {{/all}}
 </ul>
 <div class="tabs-contents">
     <div class="tab-content is-active" id="tab-description">
@@ -23,9 +18,4 @@
            {{{product.warranty}}}
        </div>
    {{/if}}
-   {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs}}
-       <div class="tab-content" id="tab-reviews">
-           {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
-       </div>
-   {{/all}}
 </div>

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -23,9 +23,9 @@ product:
             {{> components/products/videos product.videos}}
         {{/if}}
 
-        {{#all settings.show_product_reviews (if theme_settings.show_product_reviews_tabs '!==' true)}}
+        {{#if settings.show_product_reviews}}
             {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
-        {{/all}}
+        {{/if}}
 
         {{> components/products/tabs}}
 


### PR DESCRIPTION
#### What?

Revert "Display product reviews in tabbed content region of product page:" #1273 

This is pretty awesome and needs to be revisited, but will not make it into 2.2.0. Current issues are:

* Default behavior has changed for non-tabbed reviews. Reviews should be *hidden* by default when opening a product page.
* When reviews are tabbed, they still have the "Hide Reviews" option, which is unnecessary in this configuration.

#### Tickets / Documentation

- [#1273](#1273)