### PR TITLE
Display product reviews in tabbed content region of product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add alias for lazysizes module to bundle minified library [#1275](https://github.com/bigcommerce/cornerstone/pull/1275)
 - Fix prices not showing in quick search while logged in when "Restrict to Login" for price display is true [#1272](https://github.com/bigcommerce/cornerstone/pull/1272)
 - Fix duplicate input ID's in product review form [#1276](https://github.com/bigcommerce/cornerstone/pull/1276)
+- Display product reviews in tabbed content region of product page [#1282](https://github.com/bigcommerce/cornerstone/pull/1282)
 
 ## 2.1.0 (2018-06-01)
 - Add Newsletter summary section to subscription form. [#1248](https://github.com/bigcommerce/cornerstone/pull/1248)

--- a/assets/scss/components/foundation/tabs/_tabs.scss
+++ b/assets/scss/components/foundation/tabs/_tabs.scss
@@ -46,26 +46,52 @@
     }
 }
 
+.tab-content {
+    //
+    // State for when tab-content has js generated of calculated content, like carousel
+    //
+    // Purpose: The content being display: none, means any js calculated dimensions
+    // are incorrect as the elements inside the tab-content have no dimensions to grab.
+    // Carousel is a prime example. It needs widths to calculate the layout and slides
+    // -----------------------------------------------------------------------------
+    &.has-jsContent {
+        display: block;
+        height: 0;
+        overflow: hidden;
+        padding: 0;
+        visibility: hidden;
 
-//
-// State for when tab-content has js generated of calculated content, like carousel
-//
-// Purpose: The content being display: none, means any js calculated dimensions
-// are incorrect as the elements inside the tab-content have no dimensions to grab.
-// Carousel is a prime example. It needs widths to calculate the layout and slides
-// -----------------------------------------------------------------------------
+        // scss-lint:disable NestingDepth
+        &.is-active {
+            height: auto;
+            overflow: visible;
+            padding: $tabs-content-padding;
+            visibility: visible;
+        }
+        // scss-lint:enable NestingDepth
+    }
 
-.tab-content.has-jsContent {
-    display: block;
-    height: 0;
-    overflow: hidden;
-    padding: 0;
-    visibility: hidden;
 
-    &.is-active {
-        height: auto;
-        overflow: visible;
-        padding: $tabs-content-padding;
-        visibility: visible;
+    //
+    // Product review displays in tabs
+    //
+    // Purpose: Display product reviews within tabbed content on product pages.
+    // -----------------------------------------------------------------------------
+    .productReview {
+        @include breakpoint("small") {
+            width: grid-calc(6, $total-columns);
+        }
+
+        @include breakpoint("medium") {
+            width: grid-calc(4, $total-columns);
+        }
+
+        @include breakpoint("large") {
+            width: grid-calc(6, $total-columns);
+        }
+    }
+
+    .productReviews {
+        border-top: 0;
     }
 }

--- a/config.json
+++ b/config.json
@@ -68,6 +68,7 @@
     "show_accept_paypal": false,
     "show_accept_visa": false,
     "show_product_details_tabs": true,
+    "show_product_reviews_tabs": false,
     "show_product_weight": true,
     "show_product_dimensions": false,
     "product_list_display_mode": "grid",

--- a/schema.json
+++ b/schema.json
@@ -1168,6 +1168,12 @@
         "id": "show_product_details_tabs"
       },
       {
+         "type": "checkbox",
+         "label": "Product reviews in tabs",
+         "force_reload": true,
+         "id": "show_product_reviews_tabs"
+      },
+      {
         "type": "checkbox",
         "label": "Show product weight",
         "force_reload": true,

--- a/templates/components/products/description-tabs.html
+++ b/templates/components/products/description-tabs.html
@@ -7,6 +7,11 @@
             <a class="tab-title" href="#tab-warranty">{{lang 'products.warranty'}}</a>
         </li>
     {{/if}}
+    {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs}}
+        <li class="tab">
+            <a class="tab-title productView-reviewTabLink" href="#tab-reviews">{{lang 'products.reviews.header' total=product.reviews.total}}</a>
+        </li>
+    {{/all}}
 </ul>
 <div class="tabs-contents">
     <div class="tab-content is-active" id="tab-description">
@@ -18,4 +23,9 @@
            {{{product.warranty}}}
        </div>
    {{/if}}
+   {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs}}
+       <div class="tab-content" id="tab-reviews">
+           {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
+       </div>
+   {{/all}}
 </div>

--- a/templates/components/products/reviews.html
+++ b/templates/components/products/reviews.html
@@ -2,14 +2,16 @@
 <section class="toggle productReviews" id="product-reviews" data-product-reviews>
     <h4 class="toggle-title">
         {{lang 'products.reviews.header' total=reviews.total}}
-        <a class="toggleLink is-open" data-collapsible href="#productReviews-content">
-            <span class="toggleLink-text toggleLink-text--on">
-                {{lang 'products.reviews.hide'}}
-            </span>
-            <span class="toggleLink-text toggleLink-text--off">
-                {{lang 'products.reviews.show'}}
-            </span>
-        </a>
+        {{#if theme_settings.show_product_reviews_tabs '!==' true}}
+            <a class="toggleLink is-open" data-collapsible href="#productReviews-content">
+                <span class="toggleLink-text toggleLink-text--on">
+                    {{lang 'products.reviews.hide'}}
+                </span>
+                <span class="toggleLink-text toggleLink-text--off">
+                    {{lang 'products.reviews.show'}}
+                </span>
+            </a>
+        {{/if}}
     </h4>
     <div class="toggle-content is-open" id="productReviews-content" aria-hidden="false">
         <ul class="productReviews-list" id="productReviews-list">

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -23,9 +23,9 @@ product:
             {{> components/products/videos product.videos}}
         {{/if}}
 
-        {{#if settings.show_product_reviews}}
+        {{#all settings.show_product_reviews (if theme_settings.show_product_reviews_tabs '!==' true)}}
             {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
-        {{/if}}
+        {{/all}}
 
         {{> components/products/tabs}}
 


### PR DESCRIPTION
#### What?

Adds an option to display customer reviews in the details tabs area on product pages.

This PR builds off #1273 by addressing the issues in #1281 that required a revert for the original commit.

#### Tickets / Documentation

- #1273 
- #1281 

#### Screenshots

**False, Full Width, top of product page - tab region**
<img width="1552" alt="false 01 full top" src="https://user-images.githubusercontent.com/5056945/41751806-37f344d6-7578-11e8-9395-8aa026e90b18.png">
**False, Full Width, collapsed (default)**
<img width="1552" alt="false 02 full bottom" src="https://user-images.githubusercontent.com/5056945/41751808-380bf7ce-7578-11e8-8619-f183256bc2a6.png">
**False, Desktop, expanded**
<img width="1552" alt="false 03 desktop" src="https://user-images.githubusercontent.com/5056945/41751809-3820861c-7578-11e8-9414-e8dab894e2b4.png">
**False, Tablet, expanded**
<img width="1152" alt="false 04 tablet" src="https://user-images.githubusercontent.com/5056945/41751810-3838a68e-7578-11e8-9430-9f32f9b7181d.png">
**False, Mobile, expanded**
<img width="512" alt="false 05 mobile" src="https://user-images.githubusercontent.com/5056945/41751811-384f116c-7578-11e8-8071-2be213cf5e90.png">
**True, Full Width**
<img width="1552" alt="true 01 full" src="https://user-images.githubusercontent.com/5056945/41751812-386800e6-7578-11e8-82e2-06b87355ebdc.png">
**True, Desktop**
<img width="1272" alt="true 02 desktop" src="https://user-images.githubusercontent.com/5056945/41751813-38817198-7578-11e8-8261-6e6d9868232c.png">
**True, Tablet**
<img width="859" alt="true 03 tablet" src="https://user-images.githubusercontent.com/5056945/41751814-3896f5ea-7578-11e8-930d-111226ef2049.png">
**True, Mobile**
<img width="512" alt="true 04 mobile" src="https://user-images.githubusercontent.com/5056945/41751815-38ad4cb4-7578-11e8-8361-84d305dec600.png">
**Theme Editor**
<img width="1552" alt="screen shot 2018-06-21 at 5 44 44 pm" src="https://user-images.githubusercontent.com/5056945/41752203-d022db5c-757a-11e8-991d-80fd0302c643.png">
