### PR TITLE
STRF-5012: Change file location of product default image in orders-li…

### DIFF
--- a/templates/components/account/orders-list.html
+++ b/templates/components/account/orders-list.html
@@ -11,7 +11,7 @@
                     <img class="account-product-image lazyload"
                          data-sizes="auto"
                          src="{{cdn 'img/loading.svg'}}"
-                         data-src="{{getImage image 'productthumb_size' (cdn ../theme_settings.default_image_product)}}"
+                         data-src="{{getImage image 'productthumb_size' (cdn ../../theme_settings.default_image_product)}}"
                          alt="{{image.alt}}"
                          title="{{image.alt}}">
                 {{/if}}


### PR DESCRIPTION
…st.html

#### What?

Currently products with no image will spin indefinitely in the account order history section. Changing the file location of theme_settings.default_image_product to go up two directories rather than just one fixes the issue

#### Tickets / Documentation



#### Screenshots (if appropriate)

