### PR TITLE
Fix Webpack 4 DefinePlugin config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Fix wishlist dropdown background color bleeding out of container [#1283](https://github.com/bigcommerce/cornerstone/pull/1283)
 - Fix indefinite load spinner for products without an image in order history. [#1284](https://github.com/bigcommerce/cornerstone/pull/1284)
+- Fix Webpack DefinePlugin configuration. [#1286](https://github.com/bigcommerce/cornerstone/pull/1286)
 
 ## 2.2.0 (2018-06-22)
 - Fix quantity edit on Simple Product AMP pages. [#1257](https://github.com/bigcommerce/cornerstone/pull/1257)

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -7,7 +7,7 @@ module.exports = merge(commonConfig, {
     devtool: 'source-map',
     plugins: [
         new webpack.DefinePlugin({
-            'process.env.NODE_ENV': 'development',
+            'process.env.NODE_ENV': JSON.stringify('development'),
         }),
     ],
 });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -6,7 +6,7 @@ module.exports = merge(commonConfig, {
     mode: 'production',
     plugins: [
         new webpack.DefinePlugin({
-            'process.env.NODE_ENV': 'production',
+            'process.env.NODE_ENV': JSON.stringify('production'),
         }),
     ],
 });


### PR DESCRIPTION
#### What?

I've found that the usage of `webpack.DefinePlugin` at Cornerstone's Webpack configuration is wrong:

```javascript
new webpack.DefinePlugin({
    'process.env.NODE_ENV': 'development',
}),
```

According to official DefinePlugin documentation, _if the definition value is a string, it will be used as a code fragment_.

The plugin _does a direct text replacement_. The recommended way, broadly used, and also referred in official documentation, is to wrap the string in a `JSON.stringify` call:

```javascript
new webpack.DefinePlugin({
    'process.env.NODE_ENV': JSON.stringify('development'),
}),
```

This way, in code, `process.env.NODE_ENV` will be properly substituted by the string `"development"`, instead of the literal code snippet `development`, which results in a `'development' is not defined` error because `development` is considered an undefined variable.

I've stumbled upon this issue when adding Vue.js and vue-loader as dependencies. When bundling Vue.js, Webpack substitutes `process.env.NODE_ENV`  in Vue.js code. Due to the misconfiguration, Vue.js fails with a `development is not defined` error.

#### Tickets / Documentation

- [Official DefinePlugin documentation](https://webpack.js.org/plugins/define-plugin/#usage)
- [Sample DefinePlugin usage in Vue.js documentation](https://vuejs.org/v2/guide/installation.html#Development-vs-Production-Mode)
- [Another sample of proper DefinePlugin usage](https://thebrainfiles.wearebrain.com/moving-from-webpack-3-to-webpack-4-f8cdacd290f9)

#### Post Scriptum

In fact, this whole `DefinePlugin` usage in Cornerstone config seems obsolete, now that Webpack 4 automatically uses the `mode` configuration value for `process.env.NODE_ENV` replacements.

I have completely removed the whole `DefinePlugin` usage from Webpack config locally, and everything worked. If we were setting other definitions, or if we wanted to override `mode` value in `process.env.NODE_ENV`, then it would make sense to keep using `DefinePlugin`.
