### PR TITLE
Disable zoom and link for default "No Image" image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix wishlist dropdown background color bleeding out of container [#1283](https://github.com/bigcommerce/cornerstone/pull/1283)
 - Fix indefinite load spinner for products without an image in order history. [#1284](https://github.com/bigcommerce/cornerstone/pull/1284)
 - Fix Webpack DefinePlugin configuration. [#1286](https://github.com/bigcommerce/cornerstone/pull/1286)
+- Disable zoom and link for default "No Image" image. [#1291](https://github.com/bigcommerce/cornerstone/pull/1291)
 
 ## 2.2.0 (2018-06-22)
 - Fix quantity edit on Simple Product AMP pages. [#1257](https://github.com/bigcommerce/cornerstone/pull/1257)

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -152,16 +152,25 @@
     <section class="productView-images" data-image-gallery>
         <figure class="productView-image"
                 data-image-gallery-main
+                {{#if product.main_image}}
                 data-zoom-image="{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}"
+                {{/if}}
                 >
             <div class="productView-img-container">
-                <a href="{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}">
-                    <img class="productView-image--default lazyload"
-                         data-sizes="auto"
-                         src="{{cdn 'img/loading.svg'}}"
-                         data-src="{{getImage product.main_image 'product_size' (cdn theme_settings.default_image_product)}}"
-                         alt="{{product.main_image.alt}}" title="{{product.main_image.alt}}" data-main-image>
-                </a>
+                {{!-- Remove the surrounding a-element if there is no main image. --}}
+                {{#if product.main_image}}
+                    <a href="{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}">
+                {{/if}}
+
+                <img class="productView-image--default lazyload"
+                     data-sizes="auto"
+                     src="{{cdn 'img/loading.svg'}}"
+                     data-src="{{getImage product.main_image 'product_size' (cdn theme_settings.default_image_product)}}"
+                     alt="{{product.main_image.alt}}" title="{{product.main_image.alt}}" data-main-image>
+
+                {{#if product.main_image}}
+                    </a>
+                {{/if}}
             </div>
         </figure>
         <ul class="productView-thumbnails"{{#gt product.images.length 5}} data-slick='{


### PR DESCRIPTION
#### What?

A revert of the revert (#1279) of #1278. There are some slight changes between `product-view.html` in this and #1278, with the goal of this PR to keep as much information on the rendered page as possible.

The vast majority of this description is copied over from #1278.

When a product has no images Cornerstone will display a default "No Image" image.

This image is zoomable, like other product images. And the image technically exists within an <a/> element.

This PR removes that behavior. If a product has no images and thus displays the "No Image" image, the "No Image" image is treated like placeholder text. It does not zoom. It has no `href`.

As a caveat, it is possible for a product to have no image, but for its variants to have images. In this specific case the zoom behavior is removed from both the "No Image" image and any images associated with variants. There is no workaround for this at this time.

Products with images with *some but not all* variants with images were never affected.

Diff for `product-view.html` between this PR and the commit in #1278: [Diff](https://github.com/bigcommerce/cornerstone/compare/2aa17d30cc52a5c30c7315b424eb4df5dba537b3...3b903a582b8858f2901075f74abc6382937f22f5#diff-53b336f69d0af6f9498a97945e1a5f60)

#### Tickets / Documentation

- [STRF-5007](https://jira.bigcommerce.com/browse/STRF-5007)

#### Screenshots (if appropriate)

##### Before

Product Details Page:

![productbefore](https://user-images.githubusercontent.com/1546172/41618050-f2e659fe-73b6-11e8-81e1-224eb3fa302d.gif)

Quick View:

![quickbefore](https://user-images.githubusercontent.com/1546172/41618059-f739fee8-73b6-11e8-9098-6a01ee162aff.gif)

Product Details Page, No Main Image, One Variant with Image:

![220-nomainimage](https://user-images.githubusercontent.com/1546172/42055371-ca857e06-7acb-11e8-8783-d5101c698e1c.gif)

##### After

Product Details Page:

![productafter](https://user-images.githubusercontent.com/1546172/41618063-fe292e7c-73b6-11e8-9da6-db6b17a99f80.gif)

Quick View:

![quickafter](https://user-images.githubusercontent.com/1546172/41618069-0247fb64-73b7-11e8-9aaf-5a0608769f19.gif)

Product Details Page, No Main Image, One Variant with Image:

![pr-nomainimage](https://user-images.githubusercontent.com/1546172/42055387-d8145b46-7acb-11e8-8926-48e10ec8568c.gif)
