### PR TITLE
Add option to disable arrows on the homepage carousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Fix broken breadcrumb schema markup [#1362](https://github.com/bigcommerce/cornerstone/pull/1362)
+- Add option to disable arrows on the homepage carousel [#1293](https://github.com/bigcommerce/cornerstone/pull/1293)
 
 ## 2.5.0 (2018-09-26)
 - Blueprint for Mapping Custom Templates to JavaScript Modules [#1346](https://github.com/bigcommerce/cornerstone/pull/1346)

--- a/config.json
+++ b/config.json
@@ -45,6 +45,7 @@
     "homepage_featured_products_count": 4,
     "homepage_top_products_count": 4,
     "homepage_show_carousel": true,
+    "homepage_show_carousel_arrows": true,
     "homepage_stretch_carousel_images": false,
     "homepage_new_products_column_count": 4,
     "homepage_featured_products_column_count": 4,

--- a/schema.json
+++ b/schema.json
@@ -909,6 +909,12 @@
       },
       {
         "type": "checkbox",
+        "label": "Show carousel arrows",
+        "force_reload": true,
+        "id": "homepage_show_carousel_arrows"
+      },
+      {
+        "type": "checkbox",
         "label": "Allow image to stretch on large screens",
         "force_reload": true,
         "id": "homepage_stretch_carousel_images"

--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -1,5 +1,6 @@
 <section class="heroCarousel"
     data-slick='{
+        "arrows": {{arrows}},
         "mobileFirst": true,
         "slidesToShow": 1,
         "slidesToScroll": 1,

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -13,7 +13,7 @@ blog:
 ---
 {{#partial "hero"}}
     {{#if carousel}}
-        {{> components/carousel}}
+        {{> components/carousel arrows=theme_settings.homepage_show_carousel_arrows}}
     {{/if}}
     {{{snippet 'home_content'}}}
 {{/partial}}


### PR DESCRIPTION
#### What?

Currently if you want to hide/disable the arrows on the homepage carousel, you'll need to use either CSS or add JavaScript to the bundle. This PR adds an option to the theme editor.

#### Tickets / Documentation

- https://forum.bigcommerce.com/s/question/0D51B00004StLS3SAN
- https://forum.bigcommerce.com/s/question/0D51B00003u0qGnSAI
- https://forum.bigcommerce.com/s/question/0D51B00003zdWYDSA2

#### Screenshots

**True (Default)**
<img width="1552" alt="01 true default" src="https://user-images.githubusercontent.com/5056945/42065698-436dbde0-7af1-11e8-81c1-f2f9ca88faf1.png">
**False**
<img width="1552" alt="02 false" src="https://user-images.githubusercontent.com/5056945/42065699-43845cbc-7af1-11e8-85ae-f62d1e2fbd9f.png">
**Theme Editor**
<img width="1552" alt="03 theme editor" src="https://user-images.githubusercontent.com/5056945/42065700-439daa1e-7af1-11e8-8032-9e0356130345.png">
