### PR TITLE
Fix cart link not being clickable on mobile when white space reduced around store logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix Webpack DefinePlugin configuration. [#1286](https://github.com/bigcommerce/cornerstone/pull/1286)
 - Disable zoom and link for default "No Image" image. [#1291](https://github.com/bigcommerce/cornerstone/pull/1291)
 - Fix for ESLint "quotes" and "quote-props" errors. [#1280](https://github.com/bigcommerce/cornerstone/pull/1280)
+- Fix cart link not being clickable on mobile when white space reduced around store logo [#1296](https://github.com/bigcommerce/cornerstone/pull/1296)
 
 ## 2.2.0 (2018-06-22)
 - Fix quantity edit on Simple Product AMP pages. [#1257](https://github.com/bigcommerce/cornerstone/pull/1257)

--- a/assets/scss/layouts/header/_header.scss
+++ b/assets/scss/layouts/header/_header.scss
@@ -69,7 +69,7 @@
         padding: $header-logo-paddingVertical 0;
         position: relative;
         text-decoration: none;
-        width: 100%;
+        width: 60%;
         z-index: zIndex("low");
 
         // scss-lint:disable NestingDepth
@@ -78,6 +78,7 @@
             border-bottom: 0;
             display: inline;
             padding: 0;
+            width: 100%;
         }
 
         &:hover {


### PR DESCRIPTION
#### What?

When reducing margin around the store logo parent container `.header-logo`, this can cause an issue on mobile where the logo overlaps the cart link, preventing the ability to click the link. This setting resolves that issue, while also not having any impact on stores that don't reduce the margin around the store logos.

#### Tickets / Documentation

- #1249 
- https://forum.bigcommerce.com/s/question/0D51B00003vvzbmSAA/cart-button-not-working-on-mobile-version-for-cornerstone-light
- https://forum.bigcommerce.com/s/question/0D51B00004P6KUFSA3/cart-clickable-link-doesnt-work-on-mobile-cornerstone-theme

#### Screenshots (if appropriate)

**Before**
<img width="1440" alt="01 - before" src="https://user-images.githubusercontent.com/5056945/42126735-259ec9d4-7c41-11e8-918d-491e5f588206.png">
<img width="1440" alt="02 - before" src="https://user-images.githubusercontent.com/5056945/42126736-25b2bfd4-7c41-11e8-9bec-bf0561a449f4.png">

**After**
<img width="1440" alt="03 - after" src="https://user-images.githubusercontent.com/5056945/42126737-25c7e8d2-7c41-11e8-83a7-8f009d7040f2.png">
