### PR TITLE
Corrects mini cart display issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Open correct product page tabs when URL contains a fragment identifier referring to that content [#1304](https://github.com/bigcommerce/cornerstone/pull/1304)
 - Display product reviews in tabbed content region of product page. [#1302](https://github.com/bigcommerce/cornerstone/pull/1302)
 - Show bulk discounts only if enabled through store settings. [#1310](https://github.com/bigcommerce/cornerstone/pull/1310)
+- Corrects mini cart display issues [#1298](https://github.com/bigcommerce/cornerstone/pull/1298)
 
 ## 2.2.1 (2018-07-10)
 - Fix wishlist dropdown background color bleeding out of container [#1283](https://github.com/bigcommerce/cornerstone/pull/1283)

--- a/assets/scss/components/stencil/navUser/_navUser.scss
+++ b/assets/scss/components/stencil/navUser/_navUser.scss
@@ -9,6 +9,10 @@
 // 4. Needs to be 100% so its dropdown can take full width in mobile viewport
 // 5. Needs to be lower than logo zIndex, otherwise, logo is not clickable
 // 6. Make the triangle for currency dropdown right aligned
+// 7. Corrects mini cart positioned outside viewport. Since this resets right
+//    position, nudge dropdown away from the side of viewport in mobile viewport.
+// 8. This corrects mini cart dropdown arrow alignment in mobile viewport by
+//    setting the previous styles to medium breakpoint and adjusts for nudge in (7).
 //
 // -----------------------------------------------------------------------------
 
@@ -59,6 +63,12 @@
                 position: absolute;
             }
         }
+    }
+}
+
+.navUser-section {
+    @include breakpoint("medium") {
+        position: relative; // 7
     }
 }
 
@@ -167,17 +177,30 @@
 
         // scss-lint:disable NestingDepth
         &.is-open {
+            top: auto !important; // 7
+            left: auto !important; // 7
+            right: remCalc(5px); // 7
+            @include breakpoint("medium") {
+                right: 0; // 7
+            }
+
             &:before,
             &:after {
                 left: auto;
             }
 
             &:before {
-                right: spacing("half");
+                right: spacing("half") - remCalc(5px); // 8
+                @include breakpoint("medium") {
+                    right: spacing("half"); // 8
+                }
             }
 
             &:after {
-                right: spacing("half") + remCalc(2px);
+                right: spacing("half") - remCalc(3px); // 8
+                @include breakpoint("medium") {
+                    right: spacing("half") + remCalc(2px); // 8
+                }
             }
         }
     }


### PR DESCRIPTION
#### What?

In certain cases, the mini cart dropdown was displaying basically entirely out of the viewport. This corrects that problem. I also noticed an alignment problem with the mini cart css arrow and the cart quantity badge in mobile viewports. This alignment problem was there before the dropdown viewport fix but became more apparent, so this squashes that.

#### Tickets / Documentation

- #1264 

#### GIF/screenshots

**Viewport fix, before (gif)**
![01 before](https://user-images.githubusercontent.com/5056945/42195413-9771c802-7e2d-11e8-8c95-709844f34f53.gif)

**Viewport fix, after (gif)**
![02 after](https://user-images.githubusercontent.com/5056945/42195414-9789c06a-7e2d-11e8-84c8-8b5f9b7c34b9.gif)

**Mobile alignment, before**
<img width="512" alt="03 mobile - before" src="https://user-images.githubusercontent.com/5056945/42195416-979f5100-7e2d-11e8-9272-e2d2b0606a9f.png">

**Mobile alignment, after**
<img width="512" alt="04 mobile - after" src="https://user-images.githubusercontent.com/5056945/42195417-97b46374-7e2d-11e8-92ba-e67546564959.png">
