### PR TITLE
Add context to the menu collapsible factory target elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix Webpack DefinePlugin configuration. [#1286](https://github.com/bigcommerce/cornerstone/pull/1286)
 - Disable zoom and link for default "No Image" image. [#1291](https://github.com/bigcommerce/cornerstone/pull/1291)
 - Fix for ESLint "quotes" and "quote-props" errors. [#1280](https://github.com/bigcommerce/cornerstone/pull/1280)
+- Add context to the menu collapsible factory target elements
 
 ## 2.2.0 (2018-06-22)
 - Fix quantity edit on Simple Product AMP pages. [#1257](https://github.com/bigcommerce/cornerstone/pull/1257)

--- a/assets/js/theme/common/collapsible.js
+++ b/assets/js/theme/common/collapsible.js
@@ -232,7 +232,7 @@ export default function collapsibleFactory(selector = `[data-${PLUGIN_KEY}]`, ov
             $toggle.data(`${PLUGIN_KEY}Target`) ||
             $toggle.attr('href'));
         const options = _.extend(optionsFromData($toggle), overrideOptions);
-        const collapsible = new Collapsible($toggle, $(targetId), options);
+        const collapsible = new Collapsible($toggle, $(targetId, overrideOptions.$context), options);
 
         $toggle.data(instanceKey, collapsible);
 


### PR DESCRIPTION
#### What?

I've just duplicated a menu in `global.js` and in templates and supplied a proper context:

global.js
```
menu('[data-menu]');
menu('[data-menumobile]');
```
It seemed to work fine, except when I was clicking the first menu items, the second menu items were opening. After some investigation, I've found out that the context was not specified for the targeted menu items. I've added the context to them and it worked fine.

