### PR TITLE
fix(storefront): STRF-5084 - Fixed PDP pricing element styling so it works with Google AMP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Disable zoom and link for default "No Image" image. [#1291](https://github.com/bigcommerce/cornerstone/pull/1291)
 - Fix for ESLint "quotes" and "quote-props" errors. [#1280](https://github.com/bigcommerce/cornerstone/pull/1280)
 - Fix cart link not being clickable on mobile when white space reduced around store logo [#1296](https://github.com/bigcommerce/cornerstone/pull/1296)
+- Replace usage of in-line styles on PDP with classes to meet Google AMP requirements [#1300](https://github.com/bigcommerce/cornerstone/pull/1300)
 
 ## 2.2.0 (2018-06-22)
 - Fix quantity edit on Simple Product AMP pages. [#1257](https://github.com/bigcommerce/cornerstone/pull/1257)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -379,13 +379,13 @@ export default class ProductDetails {
      * @param viewModel
      */
     clearPricingNotFound(viewModel) {
-        viewModel.rrpWithTax.$div.hide();
-        viewModel.rrpWithoutTax.$div.hide();
-        viewModel.nonSaleWithTax.$div.hide();
-        viewModel.nonSaleWithoutTax.$div.hide();
-        viewModel.priceSaved.$div.hide();
-        viewModel.priceNowLabel.$span.hide();
-        viewModel.priceLabel.$span.hide();
+        viewModel.rrpWithTax.$div.addClass('price-section--hidden');
+        viewModel.rrpWithoutTax.$div.addClass('price-section--hidden');
+        viewModel.nonSaleWithTax.$div.addClass('price-section--hidden');
+        viewModel.nonSaleWithoutTax.$div.addClass('price-section--hidden');
+        viewModel.priceSaved.$div.addClass('price-section--hidden');
+        viewModel.priceNowLabel.$span.addClass('price-now-label-hidden');
+        viewModel.priceLabel.$span.addClass('price-label-hidden');
     }
 
     /**
@@ -396,41 +396,41 @@ export default class ProductDetails {
         this.clearPricingNotFound(viewModel);
 
         if (price.with_tax) {
-            viewModel.priceLabel.$span.show();
+            viewModel.priceLabel.$span.removeClass('price-label-hidden');
             viewModel.$priceWithTax.html(price.with_tax.formatted);
         }
 
         if (price.without_tax) {
-            viewModel.priceLabel.$span.show();
+            viewModel.priceLabel.$span.removeClass('price-label-hidden');
             viewModel.$priceWithoutTax.html(price.without_tax.formatted);
         }
 
         if (price.rrp_with_tax) {
-            viewModel.rrpWithTax.$div.show();
+            viewModel.rrpWithTax.$div.removeClass('price-section--hidden');
             viewModel.rrpWithTax.$span.html(price.rrp_with_tax.formatted);
         }
 
         if (price.rrp_without_tax) {
-            viewModel.rrpWithoutTax.$div.show();
+            viewModel.rrpWithoutTax.$div.removeClass('price-section--hidden');
             viewModel.rrpWithoutTax.$span.html(price.rrp_without_tax.formatted);
         }
 
         if (price.saved) {
-            viewModel.priceSaved.$div.show();
+            viewModel.priceSaved.$div.removeClass('price-section--hidden');
             viewModel.priceSaved.$span.html(price.saved.formatted);
         }
 
         if (price.non_sale_price_with_tax) {
-            viewModel.priceLabel.$span.hide();
-            viewModel.nonSaleWithTax.$div.show();
-            viewModel.priceNowLabel.$span.show();
+            viewModel.priceLabel.$span.addClass('price-label-hidden');
+            viewModel.nonSaleWithTax.$div.removeClass('price-section--hidden');
+            viewModel.priceNowLabel.$span.removeClass('price-now-label-hidden');
             viewModel.nonSaleWithTax.$span.html(price.non_sale_price_with_tax.formatted);
         }
 
         if (price.non_sale_price_without_tax) {
-            viewModel.priceLabel.$span.hide();
-            viewModel.nonSaleWithoutTax.$div.show();
-            viewModel.priceNowLabel.$span.show();
+            viewModel.priceLabel.$span.addClass('price-label-hidden');
+            viewModel.nonSaleWithoutTax.$div.removeClass('price-section--hidden');
+            viewModel.priceNowLabel.$span.removeClass('price-now-label-hidden');
             viewModel.nonSaleWithoutTax.$span.html(price.non_sale_price_without_tax.formatted);
         }
     }

--- a/assets/scss/components/stencil/price/_price.scss
+++ b/assets/scss/components/stencil/price/_price.scss
@@ -11,3 +11,7 @@
 .price-section--minor {
     color: color("greys", "light");
 }
+
+.price-section--hidden, .price-label-hidden, .price-now-label-hidden {
+    display: none;
+}

--- a/templates/components/products/price-range.html
+++ b/templates/components/products/price-range.html
@@ -5,7 +5,7 @@
     </div>
 {{else}}
     {{#if price.with_tax}}
-        <div class="price-section price-section--withTax rrp-price--withTax" style="display: none;">
+        <div class="price-section price-section--withTax rrp-price--withTax price-section--hidden">
             {{theme_settings.pdp-retail-price-label}}
             <span data-product-rrp-with-tax class="price price--rrp">
                 {{price.rrp_with_tax.formatted}}
@@ -15,7 +15,7 @@
 {{/and}}
 {{#and price.price_range.min.with_tax price.price_range.max.with_tax}}
     {{!-- Never display the "non-sales price" if there is a price range to be shown, but we do want the element on the page --}}
-    <div class="price-section price-section--withTax non-sale-price--withTax" style="display: none;">
+    <div class="price-section price-section--withTax non-sale-price--withTax price-section--hidden">
         {{theme_settings.pdp-non-sale-price-label}}
         <span data-product-non-sale-price-with-tax class="price price--non-sale">
             {{price.non_sale_price_with_tax.formatted}}
@@ -23,7 +23,7 @@
     </div>
     <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
         <span class="price-label">{{theme_settings.pdp-price-label}}</span>
-        <span class="price-now-label" style="display: none;">{{theme_settings.pdp-sale-price-label}}</span>
+        <span class="price-now-label price-now-label-hidden">{{theme_settings.pdp-sale-price-label}}</span>
         <span data-product-price-with-tax class="price price--withTax">{{price.price_range.min.with_tax.formatted}} - {{price.price_range.max.with_tax.formatted}}</span>
         {{#and price.price_range.min.without_tax price.price_range.max.without_tax}}
             <abbr title="{{lang 'products.including_tax'}}">{{lang 'products.price_with_tax' tax_label=price.price_range.min.tax_label}}</abbr>
@@ -48,7 +48,7 @@
     </div>
 {{else}}
     {{#if price.without_tax}}
-        <div class="price-section price-section--withoutTax rrp-price--withoutTax{{#if price.with_tax}} price-section--minor{{/if}}" style="display: none;">
+        <div class="price-section price-section--withoutTax rrp-price--withoutTax price-section--hidden{{#if price.with_tax}} price-section--minor{{/if}}">
             {{theme_settings.pdp-retail-price-label}}
             <span data-product-rrp-price-without-tax class="price price--rrp">
                 {{price.rrp_without_tax.formatted}}
@@ -58,7 +58,7 @@
 {{/and}}
 {{#and price.price_range.min.without_tax price.price_range.max.without_tax}}
     {{!-- Never display the "non-sales price" if there is a price range to be shown, but we do want the element on the page --}}
-    <div class="price-section price-section--withoutTax non-sale-price--withoutTax{{#if price.with_tax}} price-section--minor{{/if}}" style="display: none;">
+    <div class="price-section price-section--withoutTax non-sale-price--withoutTax price-section--hidden{{#if price.with_tax}} price-section--minor{{/if}}">
         {{theme_settings.pdp-non-sale-price-label}}
         <span data-product-non-sale-price-without-tax class="price price--non-sale">
             {{price.non_sale_price_without_tax.formatted}}
@@ -66,7 +66,7 @@
     </div>
     <div class="price-section price-section--withoutTax{{#and price_range.min.with_tax price_range.max.with_tax}} price-section--minor{{/and}}" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
         <span class="price-label">{{theme_settings.pdp-price-label}}</span>
-        <span class="price-now-label" style="display: none;">{{theme_settings.pdp-sale-price-label}}</span>
+        <span class="price-now-label price-now-label-hidden">{{theme_settings.pdp-sale-price-label}}</span>
         <span data-product-price-without-tax class="price price--withoutTax">{{price.price_range.min.without_tax.formatted}} - {{price.price_range.max.without_tax.formatted}}</span>
         {{#and price.price_range.min.with_tax price.price_range.max.with_tax}}
             <abbr title="{{lang 'products.excluding_tax'}}">{{lang 'products.price_without_tax' tax_label=price.price_range.min.tax_label}}</abbr>
@@ -87,7 +87,7 @@
 
 {{!-- Never display the "saving price" element by default if there is a price range on the page to be shown --}}
 {{#if page_type '===' 'product'}}
-     <div class="price-section price-section--saving price" style="display: none;">
+     <div class="price-section price-section--saving price price-section--hidden">
             <span class="price">{{lang 'products.you_save_opening_text'}}</span>
             <span data-product-price-saved class="price price--saving">
                 {{price.saved.formatted}}

--- a/templates/components/products/price.html
+++ b/templates/components/products/price.html
@@ -8,23 +8,23 @@ If you are making a change here or in price-range.html, you probably want to mak
     {{> components/products/price-range price=price schema_org=schema_org}}
 {{else}}
     {{#if price.with_tax}}
-        <div class="price-section price-section--withTax rrp-price--withTax" {{#unless price.rrp_with_tax}}style="display: none;"{{/unless}}>
+        <div class="price-section price-section--withTax rrp-price--withTax{{#unless price.rrp_with_tax}} price-section--hidden{{/unless}}">
             {{theme_settings.pdp-retail-price-label}}
             <span data-product-rrp-with-tax class="price price--rrp">
                 {{price.rrp_with_tax.formatted}}
             </span>
         </div>
-        <div class="price-section price-section--withTax non-sale-price--withTax" {{#unless price.non_sale_price_with_tax}}style="display: none;"{{/unless}}>
+        <div class="price-section price-section--withTax non-sale-price--withTax{{#unless price.non_sale_price_with_tax}} price-section--hidden{{/unless}}">
             {{theme_settings.pdp-non-sale-price-label}}
             <span data-product-non-sale-price-with-tax class="price price--non-sale">
                 {{price.non_sale_price_with_tax.formatted}}
             </span>
         </div>
         <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
-            <span class="price-label" {{#if price.non_sale_price_with_tax}}style="display: none;"{{/if}}>
+            <span class="price-label{{#if price.non_sale_price_with_tax}} price-label-hidden{{/if}}">
                 {{theme_settings.pdp-price-label}}
             </span>
-            <span class="price-now-label" {{#unless price.non_sale_price_with_tax}}style="display: none;"{{/unless}}>
+            <span class="price-now-label{{#unless price.non_sale_price_with_tax}} price-now-label-hidden{{/unless}}">
                 {{theme_settings.pdp-sale-price-label}}
             </span>
             <span data-product-price-with-tax class="price price--withTax">{{price.with_tax.formatted}}</span>
@@ -43,23 +43,23 @@ If you are making a change here or in price-range.html, you probably want to mak
         </div>
     {{/if}}
     {{#if price.without_tax}}
-        <div class="price-section price-section--withoutTax rrp-price--withoutTax{{#if price.with_tax}} price-section--minor{{/if}}" {{#unless price.rrp_without_tax}}style="display: none;"{{/unless}}>
+        <div class="price-section price-section--withoutTax rrp-price--withoutTax{{#unless price.rrp_without_tax}} price-section--hidden{{/unless}}{{#if price.with_tax}} price-section--minor{{/if}}">
             {{theme_settings.pdp-retail-price-label}}
             <span data-product-rrp-price-without-tax class="price price--rrp"> 
                 {{price.rrp_without_tax.formatted}}
             </span>
         </div>
-        <div class="price-section price-section--withoutTax non-sale-price--withoutTax{{#if price.with_tax}} price-section--minor{{/if}}" {{#unless price.non_sale_price_without_tax}}style="display: none;"{{/unless}}>
+        <div class="price-section price-section--withoutTax non-sale-price--withoutTax{{#unless price.non_sale_price_without_tax}} price-section--hidden{{/unless}}{{#if price.with_tax}} price-section--minor{{/if}}">
             {{theme_settings.pdp-non-sale-price-label}}
             <span data-product-non-sale-price-without-tax class="price price--non-sale">
                 {{price.non_sale_price_without_tax.formatted}}
             </span>
         </div>
         <div class="price-section price-section--withoutTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
-            <span class="price-label" {{#if price.non_sale_price_without_tax}}style="display: none;"{{/if}}>
+            <span class="price-label{{#if price.non_sale_price_without_tax}} price-label-hidden{{/if}}">
                 {{theme_settings.pdp-price-label}}
             </span>
-            <span class="price-now-label" {{#unless price.non_sale_price_without_tax}}style="display: none;"{{/unless}}>
+            <span class="price-now-label{{#unless price.non_sale_price_without_tax}} price-now-label-hidden{{/unless}}">
                 {{theme_settings.pdp-sale-price-label}}
             </span>
             <span data-product-price-without-tax class="price price--withoutTax{{#if price.with_tax}} price-section--minor{{/if}}">{{price.without_tax.formatted}}</span>
@@ -79,7 +79,7 @@ If you are making a change here or in price-range.html, you probably want to mak
         </div>
     {{/if}}
     {{#if page_type '===' 'product'}}
-         <div class="price-section price-section--saving price" {{#unless price.saved}}style="display: none;"{{/unless}}>
+         <div class="price-section price-section--saving price{{#unless price.saved}} price-section--hidden{{/unless}}">
                 <span class="price">{{lang 'products.you_save_opening_text'}}</span>
                 <span data-product-price-saved class="price price--saving">
                     {{price.saved.formatted}}


### PR DESCRIPTION
#### What?

Updated PDP element styling for pricing related elements to use classes instead of in-line styling. The in-line styling does not play nicely with Google AMP.

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/STRF-5084

*Google AMP Test on PDP with this Update is Passing*
<img width="1381" alt="2018-07-05_1427" src="https://user-images.githubusercontent.com/6527334/42350563-a5d4bba2-8076-11e8-895b-a5c64d2c5f4c.png">
