### PR TITLE
Fix blog_post import statement in app.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Display product reviews in tabbed content region of product page. [#1302](https://github.com/bigcommerce/cornerstone/pull/1302)
 - Show bulk discounts only if enabled through store settings. [#1310](https://github.com/bigcommerce/cornerstone/pull/1310)
 - Style active section in search results. [#1316](https://github.com/bigcommerce/cornerstone/pull/1316)
+- Fix blog_post import statement in app.js [#1301](https://github.com/bigcommerce/cornerstone/pull/1301)
 
 ## 2.2.1 (2018-07-10)
 - Fix wishlist dropdown background color bleeding out of container [#1283](https://github.com/bigcommerce/cornerstone/pull/1283)

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,7 +26,7 @@ const pageClasses = {
     getnewpassword: getLogin,
     forgotpassword: getLogin,
     blog: () => import('./theme/blog'),
-    blog_post: () => import('./theme/blog'),
+    blog_post: () => import('./theme/blog-post'),
     brand: () => import('./theme/brand'),
     brands: () => import('./theme/brands'),
     cart: () => import('./theme/cart'),


### PR DESCRIPTION
app.js currently includes `blog.js` code on the `blog_post` page class, rather than `blog-post.js` code. This fixes that.