### PR TITLE
Revisiting 'Display product reviews in tabbed content region of product page'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Open correct product page tabs when URL contains a fragment identifier referring to that content [#1304](https://github.com/bigcommerce/cornerstone/pull/1304)
+- Display product reviews in tabbed content region of product page. [#1302](https://github.com/bigcommerce/cornerstone/pull/1302)
 
 ## 2.2.1 (2018-07-10)
 - Fix wishlist dropdown background color bleeding out of container [#1283](https://github.com/bigcommerce/cornerstone/pull/1283)

--- a/assets/js/theme/product/reviews.js
+++ b/assets/js/theme/product/reviews.js
@@ -32,17 +32,13 @@ export default class {
     }
 
     collapseReviews() {
-        const $reviewTab = $('#tab-reviews');
-
         // We're in paginating state, do not collapse
         if (window.location.hash && window.location.hash.indexOf('#product-reviews') === 0) {
             return;
         }
 
-        // force collapse on page load if product reviews are displayed in tabs
-        if (!$reviewTab) {
-            this.$collapsible.trigger(CollapsibleEvents.click);
-        }
+        // force collapse on page load
+        this.$collapsible.trigger(CollapsibleEvents.click);
     }
 
     /**

--- a/assets/js/theme/product/reviews.js
+++ b/assets/js/theme/product/reviews.js
@@ -32,13 +32,17 @@ export default class {
     }
 
     collapseReviews() {
+        const $reviewTab = $('#tab-reviews');
+
         // We're in paginating state, do not collapse
         if (window.location.hash && window.location.hash.indexOf('#product-reviews') === 0) {
             return;
         }
 
-        // force collapse on page load
-        this.$collapsible.trigger(CollapsibleEvents.click);
+        // force collapse on page load if product reviews are displayed in tabs
+        if (!$reviewTab) {
+            this.$collapsible.trigger(CollapsibleEvents.click);
+        }
     }
 
     /**

--- a/assets/scss/components/foundation/tabs/_tabs.scss
+++ b/assets/scss/components/foundation/tabs/_tabs.scss
@@ -46,26 +46,52 @@
     }
 }
 
+.tab-content {
+    //
+    // State for when tab-content has js generated of calculated content, like carousel
+    //
+    // Purpose: The content being display: none, means any js calculated dimensions
+    // are incorrect as the elements inside the tab-content have no dimensions to grab.
+    // Carousel is a prime example. It needs widths to calculate the layout and slides
+    // -----------------------------------------------------------------------------
+    &.has-jsContent {
+        display: block;
+        height: 0;
+        overflow: hidden;
+        padding: 0;
+        visibility: hidden;
 
-//
-// State for when tab-content has js generated of calculated content, like carousel
-//
-// Purpose: The content being display: none, means any js calculated dimensions
-// are incorrect as the elements inside the tab-content have no dimensions to grab.
-// Carousel is a prime example. It needs widths to calculate the layout and slides
-// -----------------------------------------------------------------------------
+        // scss-lint:disable NestingDepth
+        &.is-active {
+            height: auto;
+            overflow: visible;
+            padding: $tabs-content-padding;
+            visibility: visible;
+        }
+        // scss-lint:enable NestingDepth
+    }
 
-.tab-content.has-jsContent {
-    display: block;
-    height: 0;
-    overflow: hidden;
-    padding: 0;
-    visibility: hidden;
 
-    &.is-active {
-        height: auto;
-        overflow: visible;
-        padding: $tabs-content-padding;
-        visibility: visible;
+    //
+    // Product review displays in tabs
+    //
+    // Purpose: Display product reviews within tabbed content on product pages.
+    // -----------------------------------------------------------------------------
+    .productReview {
+        @include breakpoint("small") {
+            width: grid-calc(6, $total-columns);
+        }
+
+        @include breakpoint("medium") {
+            width: grid-calc(4, $total-columns);
+        }
+
+        @include breakpoint("large") {
+            width: grid-calc(6, $total-columns);
+        }
+    }
+
+    .productReviews {
+        border-top: 0;
     }
 }

--- a/config.json
+++ b/config.json
@@ -68,6 +68,7 @@
     "show_accept_paypal": false,
     "show_accept_visa": false,
     "show_product_details_tabs": true,
+    "show_product_reviews_tabs": false,
     "show_product_weight": true,
     "show_product_dimensions": false,
     "product_list_display_mode": "grid",

--- a/schema.json
+++ b/schema.json
@@ -1168,6 +1168,12 @@
         "id": "show_product_details_tabs"
       },
       {
+         "type": "checkbox",
+         "label": "Product reviews in tabs",
+         "force_reload": true,
+         "id": "show_product_reviews_tabs"
+      },
+      {
         "type": "checkbox",
         "label": "Show product weight",
         "force_reload": true,

--- a/templates/components/products/description-tabs.html
+++ b/templates/components/products/description-tabs.html
@@ -7,6 +7,11 @@
             <a class="tab-title" href="#tab-warranty">{{lang 'products.warranty'}}</a>
         </li>
     {{/if}}
+    {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs}}
+        <li class="tab">
+            <a class="tab-title productView-reviewTabLink" href="#tab-reviews">{{lang 'products.reviews.header' total=product.reviews.total}}</a>
+        </li>
+    {{/all}}
 </ul>
 <div class="tabs-contents">
     <div class="tab-content is-active" id="tab-description">
@@ -18,4 +23,9 @@
            {{{product.warranty}}}
        </div>
    {{/if}}
+   {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs}}
+       <div class="tab-content" id="tab-reviews">
+           {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
+       </div>
+   {{/all}}
 </div>

--- a/templates/components/products/reviews.html
+++ b/templates/components/products/reviews.html
@@ -2,14 +2,16 @@
 <section class="toggle productReviews" id="product-reviews" data-product-reviews>
     <h4 class="toggle-title">
         {{lang 'products.reviews.header' total=reviews.total}}
-        <a class="toggleLink is-open" data-collapsible href="#productReviews-content">
-            <span class="toggleLink-text toggleLink-text--on">
-                {{lang 'products.reviews.hide'}}
-            </span>
-            <span class="toggleLink-text toggleLink-text--off">
-                {{lang 'products.reviews.show'}}
-            </span>
-        </a>
+        {{#if theme_settings.show_product_reviews_tabs '!==' true}}
+            <a class="toggleLink is-open" data-collapsible href="#productReviews-content">
+                <span class="toggleLink-text toggleLink-text--on">
+                    {{lang 'products.reviews.hide'}}
+                </span>
+                <span class="toggleLink-text toggleLink-text--off">
+                    {{lang 'products.reviews.show'}}
+                </span>
+            </a>
+        {{/if}}
     </h4>
     <div class="toggle-content is-open" id="productReviews-content" aria-hidden="false">
         <ul class="productReviews-list" id="productReviews-list">

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -23,9 +23,9 @@ product:
             {{> components/products/videos product.videos}}
         {{/if}}
 
-        {{#if settings.show_product_reviews}}
+        {{#all settings.show_product_reviews (if theme_settings.show_product_reviews_tabs '!==' true)}}
             {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
-        {{/if}}
+        {{/all}}
 
         {{> components/products/tabs}}
 


### PR DESCRIPTION
#### What?

Restores the changes in #1273 with the desired changes in #1281.

Adds an option to display customer reviews in the details tabs area on product pages.

#### Tickets / Documentation

- #1273 
- #1281 

Diff between this PR and the original PR/commit: https://github.com/bigcommerce/cornerstone/compare/b7370c96f044dc9019d36f3dda4483bf572e85c6...d250b521c8b9de929cdeaf5539c87604bcd72b3b

#### Screenshots

Before:
![221](https://user-images.githubusercontent.com/1546172/42401562-00c8ac9e-812b-11e8-889b-2522dc160604.gif)

After, Current Product Review behavior:
![notabs](https://user-images.githubusercontent.com/1546172/42401567-067bf3b2-812b-11e8-9322-1a897cfb0fb6.gif)

After, Product Reviews in tabs:
![tabs](https://user-images.githubusercontent.com/1546172/42401570-0a2e34c0-812b-11e8-93b0-207f18799b17.gif)
