### PR TITLE
Open product tabs on load.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Open correct product page tabs when URL contains a fragment identifier referring to that content [#1304](https://github.com/bigcommerce/cornerstone/pull/1304)
 
 ## 2.2.1 (2018-07-10)
 - Fix wishlist dropdown background color bleeding out of container [#1283](https://github.com/bigcommerce/cornerstone/pull/1283)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -17,8 +17,8 @@ export default class ProductDetails {
         this.imageGallery.init();
         this.listenQuantityChange();
         this.initRadioAttributes();
-
         Wishlist.load(this.context);
+        this.getTabRequests();
 
         const $form = $('form[data-cart-item-add]', $scope);
         const $productOptionsElement = $('[data-product-option-change]', $form);
@@ -606,5 +606,24 @@ export default class ProductDetails {
 
             $radio.attr('data-state', $radio.prop('checked'));
         });
+    }
+
+    /**
+     * Check for fragment identifier in URL requesting a specific tab
+     */
+    getTabRequests() {
+        if (window.location.hash && window.location.hash.indexOf('#tab-') === 0) {
+            const $activeTab = $('.tabs').has(`[href='${window.location.hash}']`);
+            const $tabContent = $(`${window.location.hash}`);
+
+            $activeTab.find('.tab')
+                .removeClass('is-active')
+                .has(`[href='${window.location.hash}']`)
+                .addClass('is-active');
+
+            $tabContent.addClass('is-active')
+                .siblings()
+                .removeClass('is-active');
+        }
     }
 }

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -616,14 +616,16 @@ export default class ProductDetails {
             const $activeTab = $('.tabs').has(`[href='${window.location.hash}']`);
             const $tabContent = $(`${window.location.hash}`);
 
-            $activeTab.find('.tab')
-                .removeClass('is-active')
-                .has(`[href='${window.location.hash}']`)
-                .addClass('is-active');
+            if ($activeTab.length > 0) {
+                $activeTab.find('.tab')
+                    .removeClass('is-active')
+                    .has(`[href='${window.location.hash}']`)
+                    .addClass('is-active');
 
-            $tabContent.addClass('is-active')
-                .siblings()
-                .removeClass('is-active');
+                $tabContent.addClass('is-active')
+                    .siblings()
+                    .removeClass('is-active');
+            }
         }
     }
 }


### PR DESCRIPTION
#### What?

#1220 but with an additional guard for non-existent tab names.

This only works on page load. Because the hash isn't technically an HTML anchor, browsers have no idea what "anchor" to view and will end up doing nothing.

Additionally, the guard for non-existent tab names might not be necessary. As far as the code is concerned the JS will attempt to operate on nothing. But `$activeTab.length > 0` definitely makes sure it doesn't run.

#### Tickets / Documentation

- PR: #1220 
- Issue: #1136 

#### Screenshots

Tab:
![tab](https://user-images.githubusercontent.com/1546172/42464566-4a76087a-835e-11e8-81d3-a2fed3896fe4.gif)

Definitely Not a Tab:
![notatab](https://user-images.githubusercontent.com/1546172/42464570-4d792f48-835e-11e8-90be-888157b5d378.gif)
