### PR TITLE
URL Utilities: Add optional parameter to getUrl() to filter out query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix for ESLint "quotes" and "quote-props" errors. [#1280](https://github.com/bigcommerce/cornerstone/pull/1280)
 - Fix cart link not being clickable on mobile when white space reduced around store logo [#1296](https://github.com/bigcommerce/cornerstone/pull/1296)
 - Replace usage of in-line styles on PDP with classes to meet Google AMP requirements [#1300](https://github.com/bigcommerce/cornerstone/pull/1300)
+- Add optional parameter to getUrl() to filter out query string [#1305](https://github.com/bigcommerce/cornerstone/pull/1305)
 
 ## 2.2.0 (2018-06-22)
 - Fix quantity edit on Simple Product AMP pages. [#1257](https://github.com/bigcommerce/cornerstone/pull/1257)

--- a/assets/js/theme/common/url-utils.js
+++ b/assets/js/theme/common/url-utils.js
@@ -2,7 +2,15 @@ import $ from 'jquery';
 import Url from 'url';
 
 const urlUtils = {
-    getUrl: () => `${window.location.pathname}${window.location.search}`,
+    getUrl: (query = false) => {
+        let search = window.location.search;
+
+        if (query) {
+            search = '';
+        }
+
+        return `${window.location.pathname}${search}`;
+    },
 
     goToUrl: (url) => {
         window.history.pushState({}, document.title, url);


### PR DESCRIPTION
#### What?

This sets an optional parameter to `getUrl()` so that if set `true`, then only `window.location.pathname` is returned.

**Default behavior**: `urlUtils.getUrl();`
**True, optional**: `urlUtils.getUrl(true);`

#### Screenshot (see console)

<img width="1552" alt="screen shot 2018-07-09 at 5 48 34 pm" src="https://user-images.githubusercontent.com/5056945/42483090-59634f54-83a0-11e8-859a-97ef0a6ed9d5.png">

