### PR TITLE
fix(storefront): STRF-5101 - Fixes for product pricing JS for Google AMP on both PDP and PLP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix for ESLint "quotes" and "quote-props" errors. [#1280](https://github.com/bigcommerce/cornerstone/pull/1280)
 - Fix cart link not being clickable on mobile when white space reduced around store logo [#1296](https://github.com/bigcommerce/cornerstone/pull/1296)
 - Replace usage of in-line styles on PDP with classes to meet Google AMP requirements [#1300](https://github.com/bigcommerce/cornerstone/pull/1300)
+- Move product details inside G-AMP iFrame to allow JS that alters price for option selections to work and added new pricing styling to google amp category CSS. [#1306](https://github.com/bigcommerce/cornerstone/pull/1306)
 
 ## 2.2.0 (2018-06-22)
 - Fix quantity edit on Simple Product AMP pages. [#1257](https://github.com/bigcommerce/cornerstone/pull/1257)

--- a/templates/components/amp/css/base.html
+++ b/templates/components/amp/css/base.html
@@ -272,3 +272,11 @@ cite {
 .price--discounted {
     text-decoration: line-through;
 }
+
+.price-section--minor {
+    color: color("greys", "light");
+}
+
+.price-section--hidden, .price-label-hidden, .price-now-label-hidden {
+    display: none;
+}

--- a/templates/components/amp/products/product-options.html
+++ b/templates/components/amp/products/product-options.html
@@ -1,23 +1,26 @@
 <div class="productView">
-    <div class="productView-options">
-        <form class="form" method="post" action="{{product.cart_url}}" enctype="multipart/form-data" data-cart-item-add target="_self">
-            <input type="hidden" name="action" value="add">
-            <input type="hidden" name="product_id" value="{{product.id}}"/>
-            {{#each product.customizations}}
-                {{{dynamicComponent 'components/products/customizations'}}}
-            {{/each}}
-            <div data-product-option-change>
-                {{#each product.options}}
-                    {{{dynamicComponent 'components/products/options'}}}
+    <div class="productView-details">
+        {{> components/amp/products/product-view-details}}
+        <div class="productView-options">
+            <form class="form" method="post" action="{{product.cart_url}}" enctype="multipart/form-data" data-cart-item-add target="_self">
+                <input type="hidden" name="action" value="add">
+                <input type="hidden" name="product_id" value="{{product.id}}"/>
+                {{#each product.customizations}}
+                    {{{dynamicComponent 'components/products/customizations'}}}
                 {{/each}}
-            </div>
-            {{#if product.event_date}}
-                {{> components/products/event-date}}
-            {{/if}}
-            {{#if product.can_purchase}}
-                {{> components/products/add-to-cart}}
-            {{/if}}
-            <div class="loadingOverlay"></div>
-        </form>
+                <div data-product-option-change>
+                    {{#each product.options}}
+                        {{{dynamicComponent 'components/products/options'}}}
+                    {{/each}}
+                </div>
+                {{#if product.event_date}}
+                    {{> components/products/event-date}}
+                {{/if}}
+                {{#if product.can_purchase}}
+                    {{> components/products/add-to-cart}}
+                {{/if}}
+                <div class="loadingOverlay"></div>
+            </form>
+        </div>
     </div>
 </div>

--- a/templates/components/amp/products/product-view-details.html
+++ b/templates/components/amp/products/product-view-details.html
@@ -1,112 +1,110 @@
-<section class="productView-details">
-    <div class="productView-product">
-        <h1 class="productView-title" {{#if schema}}itemprop="name"{{/if}}>{{product.title}}</h1>
-        {{#if product.brand }}
-        <h2 class="productView-brand"{{#if schema}} itemprop="brand" itemscope itemtype="http://schema.org/Brand"{{/if}}>
-            <a href="{{product.brand.url}}"{{#if schema}} itemprop="url"{{/if}}><span{{#if schema}} itemprop="name"{{/if}}>{{product.brand.name}}</span></a>
-        </h2>
+<div class="productView-product">
+    <h1 class="productView-title" {{#if schema}}itemprop="name"{{/if}}>{{product.title}}</h1>
+    {{#if product.brand }}
+    <h2 class="productView-brand"{{#if schema}} itemprop="brand" itemscope itemtype="http://schema.org/Brand"{{/if}}>
+        <a href="{{product.brand.url}}"{{#if schema}} itemprop="url"{{/if}}><span{{#if schema}} itemprop="name"{{/if}}>{{product.brand.name}}</span></a>
+    </h2>
+    {{/if}}
+    {{#if product.call_for_price}}
+        <p class="productView-price">
+            <span>{{product.call_for_price}}</span>
+        </p>
+    {{/if}}
+    {{#if product.price}}
+        <div class="productView-price">
+            {{> components/products/price price=product.price schema_org=schema}}
+        </div>
+    {{/if}}
+    {{product.detail_messages}}
+    {{#if settings.show_product_rating}}
+        {{> components/amp/products/ratings rating=product.rating}}
+    {{/if}}
+    <dl class="productView-info">
+        {{#if product.sku}}
+            <dt class="productView-info-name">{{lang 'products.sku'}}</dt>
+            <dd class="productView-info-value" data-product-sku>{{product.sku}}</dd>
         {{/if}}
-        {{#if product.call_for_price}}
-            <p class="productView-price">
-                <span>{{product.call_for_price}}</span>
-            </p>
+        {{#if product.upc}}
+            <dt class="productView-info-name">{{lang 'products.upc'}}</dt>
+            <dd class="productView-info-value" data-product-upc>{{product.upc}}</dd>
         {{/if}}
-        {{#if product.price}}
-            <div class="productView-price">
-                {{> components/products/price price=product.price schema_org=schema}}
-            </div>
+        {{#if product.condition}}
+            <dt class="productView-info-name">{{lang 'products.condition'}}</dt>
+            <dd class="productView-info-value">{{product.condition}}</dd>
         {{/if}}
-        {{product.detail_messages}}
-        {{#if settings.show_product_rating}}
-            {{> components/amp/products/ratings rating=product.rating}}
+        {{#if product.availability}}
+            <dt class="productView-info-name">{{lang 'products.availability'}}</dt>
+            <dd class="productView-info-value">{{product.availability}}</dd>
         {{/if}}
-        <dl class="productView-info">
-            {{#if product.sku}}
-                <dt class="productView-info-name">{{lang 'products.sku'}}</dt>
-                <dd class="productView-info-value" data-product-sku>{{product.sku}}</dd>
-            {{/if}}
-            {{#if product.upc}}
-                <dt class="productView-info-name">{{lang 'products.upc'}}</dt>
-                <dd class="productView-info-value" data-product-upc>{{product.upc}}</dd>
-            {{/if}}
-            {{#if product.condition}}
-                <dt class="productView-info-name">{{lang 'products.condition'}}</dt>
-                <dd class="productView-info-value">{{product.condition}}</dd>
-            {{/if}}
-            {{#if product.availability}}
-                <dt class="productView-info-name">{{lang 'products.availability'}}</dt>
-                <dd class="productView-info-value">{{product.availability}}</dd>
-            {{/if}}
-            {{#if product.weight}}
-                <dt class="productView-info-name">{{lang 'products.weight'}}</dt>
-                <dd class="productView-info-value" data-product-weight>{{product.weight}}</dd>
-            {{/if}}
-            {{#if product.min_purchase_quantity}}
-                <dt class="productView-info-name">{{lang 'products.min_purchase_quantity'}}</dt>
-                <dd class="productView-info-value">{{lang 'products.purchase_units' quantity=product.min_purchase_quantity}}</dd>
-            {{/if}}
-            {{#if product.max_purchase_quantity}}
-                <dt class="productView-info-name">{{lang 'products.max_purchase_quantity'}}</dt>
-                <dd class="productView-info-value">{{lang 'products.purchase_units' quantity=product.max_purchase_quantity}}</dd>
-            {{/if}}
-            {{#if product.gift_wrapping_available}}
-                <dt class="productView-info-name">{{lang 'products.gift_wrapping'}}</dt>
-                <dd class="productView-info-value">{{lang 'products.gift_wrapping_available'}}</dd>
-            {{/if}}
-            {{#if product.shipping}}
-                {{#if product.shipping.calculated}}
+        {{#if product.weight}}
+            <dt class="productView-info-name">{{lang 'products.weight'}}</dt>
+            <dd class="productView-info-value" data-product-weight>{{product.weight}}</dd>
+        {{/if}}
+        {{#if product.min_purchase_quantity}}
+            <dt class="productView-info-name">{{lang 'products.min_purchase_quantity'}}</dt>
+            <dd class="productView-info-value">{{lang 'products.purchase_units' quantity=product.min_purchase_quantity}}</dd>
+        {{/if}}
+        {{#if product.max_purchase_quantity}}
+            <dt class="productView-info-name">{{lang 'products.max_purchase_quantity'}}</dt>
+            <dd class="productView-info-value">{{lang 'products.purchase_units' quantity=product.max_purchase_quantity}}</dd>
+        {{/if}}
+        {{#if product.gift_wrapping_available}}
+            <dt class="productView-info-name">{{lang 'products.gift_wrapping'}}</dt>
+            <dd class="productView-info-value">{{lang 'products.gift_wrapping_available'}}</dd>
+        {{/if}}
+        {{#if product.shipping}}
+            {{#if product.shipping.calculated}}
+                <dt class="productView-info-name">{{lang 'products.shipping'}}</dt>
+                <dd class="productView-info-value">{{lang 'products.shipping_calculated'}}</dd>
+            {{else}}
+                {{#if product.shipping.price.value '===' 0}}
                     <dt class="productView-info-name">{{lang 'products.shipping'}}</dt>
-                    <dd class="productView-info-value">{{lang 'products.shipping_calculated'}}</dd>
+                    <dd class="productView-info-value">{{lang 'products.shipping_free'}}</dd>
                 {{else}}
-                    {{#if product.shipping.price.value '===' 0}}
-                        <dt class="productView-info-name">{{lang 'products.shipping'}}</dt>
-                        <dd class="productView-info-value">{{lang 'products.shipping_free'}}</dd>
-                    {{else}}
-                        <dt class="productView-info-name">{{lang 'products.shipping'}}</dt>
-                        <dd class="productView-info-value">{{lang 'products.shipping_fixed' amount=product.shipping.price.formatted}}</dd>
-                    {{/if}}
+                    <dt class="productView-info-name">{{lang 'products.shipping'}}</dt>
+                    <dd class="productView-info-value">{{lang 'products.shipping_fixed' amount=product.shipping.price.formatted}}</dd>
                 {{/if}}
             {{/if}}
-            {{#if product.bulk_discount_rates.length}}
-                <dt class="productView-info-name">{{lang 'products.bulk_pricing.title'}}</dt>
-                <dd class="productView-info-value">
-                    <a href="{{product.url}}"
-                        {{#unless is_ajax }}data-reveal-id="bulkPricingModal" {{/unless}}>
-                        {{lang 'products.bulk_pricing.view'}}
-                    </a>
-                </dd>
+        {{/if}}
+        {{#if product.bulk_discount_rates.length}}
+            <dt class="productView-info-name">{{lang 'products.bulk_pricing.title'}}</dt>
+            <dd class="productView-info-value">
+                <a href="{{product.url}}"
+                    {{#unless is_ajax }}data-reveal-id="bulkPricingModal" {{/unless}}>
+                    {{lang 'products.bulk_pricing.view'}}
+                </a>
+            </dd>
 
-                <div id="bulkPricingModal" class="modal modal--small" data-reveal>
-                    <div class="modal-header">
-                        <h2 class="modal-header-title">{{lang 'products.bulk_pricing.modal_title'}}</h2>
-                        <a href="#" class="modal-close" aria-label="Close"><span aria-hidden="true">&#215;</span></a>
-                    </div>
-                    <div class="modal-body">
-                        <p>{{lang 'products.bulk_pricing.instructions'}}</p>
-                        <ul>
-                        {{#each product.bulk_discount_rates}}
-                            <li>
-                                {{lang 'products.bulk_pricing.range' min=min max=max}}
-                                {{#if type '===' 'percent'}}
-                                    {{lang 'products.bulk_pricing.percent' discount=discount.formatted}}
-                                {{/if}}
-                                {{#if type '===' 'fixed'}}
-                                    {{lang 'products.bulk_pricing.fixed' discount=discount.formatted}}
-                                {{/if}}
-                                {{#if type '===' 'price'}}
-                                    {{lang 'products.bulk_pricing.price' discount=discount.formatted}}
-                                {{/if}}
-                            </li>
-                        {{/each}}
-                        </ul>
-                    </div>
+            <div id="bulkPricingModal" class="modal modal--small" data-reveal>
+                <div class="modal-header">
+                    <h2 class="modal-header-title">{{lang 'products.bulk_pricing.modal_title'}}</h2>
+                    <a href="#" class="modal-close" aria-label="Close"><span aria-hidden="true">&#215;</span></a>
                 </div>
-            {{/if}}
+                <div class="modal-body">
+                    <p>{{lang 'products.bulk_pricing.instructions'}}</p>
+                    <ul>
+                    {{#each product.bulk_discount_rates}}
+                        <li>
+                            {{lang 'products.bulk_pricing.range' min=min max=max}}
+                            {{#if type '===' 'percent'}}
+                                {{lang 'products.bulk_pricing.percent' discount=discount.formatted}}
+                            {{/if}}
+                            {{#if type '===' 'fixed'}}
+                                {{lang 'products.bulk_pricing.fixed' discount=discount.formatted}}
+                            {{/if}}
+                            {{#if type '===' 'price'}}
+                                {{lang 'products.bulk_pricing.price' discount=discount.formatted}}
+                            {{/if}}
+                        </li>
+                    {{/each}}
+                    </ul>
+                </div>
+            </div>
+        {{/if}}
 
-            {{#each product.custom_fields}}
-                <dt class="productView-info-name">{{name}}:</dt>
-                <dd class="productView-info-value">{{{value}}}</dd>
-            {{/each}}
-        </dl>
-    </div>
-</section>
+        {{#each product.custom_fields}}
+            <dt class="productView-info-name">{{name}}:</dt>
+            <dd class="productView-info-value">{{{value}}}</dd>
+        {{/each}}
+    </dl>
+</div>

--- a/templates/components/amp/products/product-view.html
+++ b/templates/components/amp/products/product-view.html
@@ -8,7 +8,6 @@
         {{/if}}
     {{/each}}
 
-    {{> components/amp/products/product-view-details}}
     <section class="productView-images" data-image-gallery>
         <amp-carousel width="250"
             height="250"


### PR DESCRIPTION
#### What?

- Moved the image on our Google AMP PDP above the product details section and moved the details inside the Google AMP iFrame so they can be adjusted by the product options JS.  This change corrects the pricing JS updates on the PDP when on an amp page. 

- Added the new pricing label hidden css classes to the base styling for google amp pages as it was missing on category pages causing the pricing elements to not hide properly.

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/STRF-5101

#### Screenshots (if appropriate)

The following shows that both PDP and Category are still passing Google Amp's test page:
<img width="1417" alt="2018-07-09_1855" src="https://user-images.githubusercontent.com/6527334/42481983-c0903dd6-83aa-11e8-86ac-9e282e82f58d.png">
<img width="1348" alt="2018-07-09_1855-1" src="https://user-images.githubusercontent.com/6527334/42481987-c336af02-83aa-11e8-9813-b501745ae836.png">

To see the price updating in action visit this page and select different colors of size "small":
http://jasonzamora1531160478-testington.my-integration.zone/amp/1-l-le-parfait-jar/

This image shows the broken styling on the google amp category page:
<img width="1582" alt="2018-07-09_2022" src="https://user-images.githubusercontent.com/6527334/42483984-49c53b3c-83b6-11e8-8d03-b0c2e53566b1.png">

This is the corrected styling with this PR on the same google amp category page:
<img width="1588" alt="2018-07-09_2025" src="https://user-images.githubusercontent.com/6527334/42483999-581eaa92-83b6-11e8-820a-ac49533b7942.png">
