### PR TITLE
Show bulk discounts only if enabled through store settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Open correct product page tabs when URL contains a fragment identifier referring to that content [#1304](https://github.com/bigcommerce/cornerstone/pull/1304)
 - Display product reviews in tabbed content region of product page. [#1302](https://github.com/bigcommerce/cornerstone/pull/1302)
+- Show bulk discounts only if enabled through store settings. [#1310](https://github.com/bigcommerce/cornerstone/pull/1310)
 
 ## 2.2.1 (2018-07-10)
 - Fix wishlist dropdown background color bleeding out of container [#1283](https://github.com/bigcommerce/cornerstone/pull/1283)

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -137,9 +137,11 @@
                     {{/if}}
                 {{/if}}
 
-                <div class="productView-info-bulkPricing">
-                    {{> components/products/bulk-discount-rates bulk_discount_rates=product.bulk_discount_rates}}
-                </div>
+                {{#if settings.bulk_discount_enabled}}
+                    <div class="productView-info-bulkPricing">
+                        {{> components/products/bulk-discount-rates bulk_discount_rates=product.bulk_discount_rates}}
+                    </div>
+                {{/if}}
 
                 {{#each product.custom_fields}}
                     <dt class="productView-info-name">{{name}}:</dt>


### PR DESCRIPTION
#### What?

Cornerstone shows bulk discounts available on all products that have rules associated with them, regardless of the "Enable Bulk Discount?" setting in Display Settings in Store Settings > Display.

This is reliant on a change to expose `settings.bulk_discount_enabled` to the Stencil context: https://github.com/bigcommerce/bigcommerce/pull/25352

If Bulk Discounts are enabled, bulk discounts will show on product pages with bulk discount rules associated with them, as they do now.

If Bulk Discounts are disabled, bulk discounts will not show up, even if a product has a bulk discount rule applied to it.

#### Tickets / Documentation

- [STRF-4969](https://jira.bigcommerce.com/browse/STRF-4969)

#### Screenshots

##### Before

Product **Without** bulk discounts:

![beforewithout](https://user-images.githubusercontent.com/1546172/42605426-bd067b52-852c-11e8-9b98-8728e011fa6d.png)

Product **With** bulk discounts, Bulk discounts **Disabled**:

![beforewithdisabled](https://user-images.githubusercontent.com/1546172/42605439-cfc918da-852c-11e8-82b4-eb26d89df619.png)

Product **With** bulk discounts, Bulk discounts **Enabled**:

![beforewithenabled](https://user-images.githubusercontent.com/1546172/42605445-d43c5c42-852c-11e8-8880-4e0304b1e687.png)

##### After

Product **Without** bulk discounts:

![afterwithout](https://user-images.githubusercontent.com/1546172/42605465-e2dfab28-852c-11e8-8ada-c931af6d35e9.png)

Product **With** bulk discounts, Bulk discounts **Disabled**:

![afterwithdisabled](https://user-images.githubusercontent.com/1546172/42605499-14c16e7e-852d-11e8-9aeb-ddc424edea3d.png)

Product **With** bulk discounts, Bulk discounts **Enabled**:

![afterwithenabled](https://user-images.githubusercontent.com/1546172/42605507-1dc98876-852d-11e8-8b06-e4bdcc821f81.png)

#### Warnings

If a theme with this change is somehow applied to a store **without** the Bigcommerce change that exposes `settings.bulk_discount_enabled`, bulk pricing will not appear under any circumstances because the Handlebars `if` is wrapped around that div.