### PR TITLE
URL Utilities: Add optional parameter to display particular or full URL module output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Open correct product page tabs when URL contains a fragment identifier referring to that content [#1304](https://github.com/bigcommerce/cornerstone/pull/1304)
+- URL Utilities: Add optional parameter to display particular or full URL module output [#1311](https://github.com/bigcommerce/cornerstone/pull/1311)
 
 ## 2.2.1 (2018-07-10)
 - Fix wishlist dropdown background color bleeding out of container [#1283](https://github.com/bigcommerce/cornerstone/pull/1283)

--- a/assets/js/theme/common/url-utils.js
+++ b/assets/js/theme/common/url-utils.js
@@ -2,7 +2,24 @@ import $ from 'jquery';
 import Url from 'url';
 
 const urlUtils = {
-    getUrl: () => `${window.location.pathname}${window.location.search}`,
+    getUrl: (object = null) => {
+        const href = Url.parse(window.location.href, true);
+        let url = href.path;
+
+        if (object) {
+            if (object === 'raw') {
+                url = href;
+            } else if (object === 'query') {
+                url = JSON.stringify(href.query);
+            } else if (href[object] !== null) {
+                url = href[object];
+            } else {
+                url = null; // url is null since object was not found but declared
+            }
+        }
+
+        return url;
+    },
 
     goToUrl: (url) => {
         window.history.pushState({}, document.title, url);


### PR DESCRIPTION
#### What?

This allows optional values to be passed along for `Url` module output in `urlUtils.getUrl()`. The default output of this function has not changed. All the properties of `Url` module are now accessible by passing the key name as a value. Passing `'raw'` exposes the entire object while `'query'` exposes the `object.query`. If the value isn't found, then return `null`.

#### Documentation

Parsed URL objects have some or all of the following fields, depending on
whether or not they exist in the URL string. Any parts that are not in the URL
string will not be in the parsed object. Examples are shown for the URL

`'http://localhost:3000/p/a/t/h?query=string&query2=string#hash'`

* `href`: The full URL that was originally parsed. Both the protocol and host are lowercased.

    Example: `'http://localhost:3000/p/a/t/h?query=string&query2=string#hash'`

* `protocol`: The request protocol, lowercased.

    Example: `'http:'`

* `host`: The full lowercased host portion of the URL, including port
  information.

    Example: `'localhost:3000'`

* `auth`: The authentication information portion of a URL.

    Example: `'null'`, normally `'user:pass'`

* `hostname`: Just the lowercased hostname portion of the host.

    Example: `'localhost'`

* `port`: The port number portion of the host.

    Example: `'3000'`

* `pathname`: The path section of the URL, that comes after the host and
  before the query, including the initial slash if present.

    Example: `'/p/a/t/h'`

* `search`: The 'query string' portion of the URL, including the leading
  question mark.

    Example: `'?query=string&query2=string'`

* `path`: Concatenation of `pathname` and `search`.

    Example: `'/p/a/t/h?query=string&query2=string'`

* `query`: a querystring-parsed object.

    Example: `'{"query":"string","query2":"string"}`

* `hash`: The 'fragment' portion of the URL including the pound-sign.

    Example: `'#hash'`

###

> getUrl {
> &nbsp; &nbsp; protocol: 'http:',
> &nbsp; &nbsp; slashes: 'true',
> &nbsp; &nbsp; auth: 'null',
> &nbsp; &nbsp; host: 'localhost:3000',
> &nbsp; &nbsp; port: '3000',
> &nbsp; &nbsp; hostname: 'localhost',
> &nbsp; &nbsp; hash: '#hash',
> &nbsp; &nbsp; search: '?query=string&query2=string',
> &nbsp; &nbsp; query: '{"query":"string","query2":"string"}',
> &nbsp; &nbsp; pathname: '/p/a/t/h',
> &nbsp; &nbsp; path: '/p/a/t/h?query=string&query2=string',
> &nbsp; &nbsp; href: 'http://localhost:3000/p/a/t/h?query=string&query2=string#hash',
> }

#### Screenshots

<img width="1552" alt="screen shot 2018-07-11 at 10 17 43 pm" src="https://user-images.githubusercontent.com/5056945/42613935-499414c8-8558-11e8-9987-3f162920bfb3.png">

