### PR TITLE
Style active section in search results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Open correct product page tabs when URL contains a fragment identifier referring to that content [#1304](https://github.com/bigcommerce/cornerstone/pull/1304)
 - Display product reviews in tabbed content region of product page. [#1302](https://github.com/bigcommerce/cornerstone/pull/1302)
 - Show bulk discounts only if enabled through store settings. [#1310](https://github.com/bigcommerce/cornerstone/pull/1310)
+- Style active section in search results. [#1316](https://github.com/bigcommerce/cornerstone/pull/1316)
 
 ## 2.2.1 (2018-07-10)
 - Fix wishlist dropdown background color bleeding out of container [#1283](https://github.com/bigcommerce/cornerstone/pull/1283)

--- a/assets/js/theme/search.js
+++ b/assets/js/theme/search.js
@@ -42,6 +42,12 @@ export default class Search extends CatalogPage {
         this.$facetedSearchContainer.removeClass('u-hiddenVisually');
         this.$contentResultsContainer.addClass('u-hiddenVisually');
 
+        $('[data-content-results-toggle]').removeClass('navBar-action-color--active');
+        $('[data-content-results-toggle]').addClass('navBar-action');
+
+        $('[data-product-results-toggle]').removeClass('navBar-action');
+        $('[data-product-results-toggle]').addClass('navBar-action-color--active');
+
         urlUtils.goToUrl(url);
     }
 
@@ -53,6 +59,12 @@ export default class Search extends CatalogPage {
         this.$contentResultsContainer.removeClass('u-hiddenVisually');
         this.$productListingContainer.addClass('u-hiddenVisually');
         this.$facetedSearchContainer.addClass('u-hiddenVisually');
+
+        $('[data-product-results-toggle]').removeClass('navBar-action-color--active');
+        $('[data-product-results-toggle]').addClass('navBar-action');
+
+        $('[data-content-results-toggle]').removeClass('navBar-action');
+        $('[data-content-results-toggle]').addClass('navBar-action-color--active');
 
         urlUtils.goToUrl(url);
     }


### PR DESCRIPTION
#### What?

Added an "active" style for search result page sections/tabs.

#### Tickets / Documentation

- #1313 

#### Screenshots

##### Before:
![before](https://user-images.githubusercontent.com/1546172/43158297-3524f76a-8f34-11e8-9610-e8dbc60ce901.gif)

##### After:
![after](https://user-images.githubusercontent.com/1546172/43158307-3b2fe836-8f34-11e8-8b98-e70217bbcc5d.gif)