### PR TITLE
Add div and id attributes so that contact form steps can be tracked

### DIFF
--- a/templates/components/page/contact-us-form.html
+++ b/templates/components/page/contact-us-form.html
@@ -2,7 +2,7 @@
     {{inject 'contactEmail' (lang 'forms.validate.contact.email_address')}}
     {{inject 'contactQuestion' (lang 'forms.validate.contact.question')}}
     {{#if forms.contact.error}}
-        {{> components/common/alert-error forms.contact.error}}
+    <div id="contact-us-error">{{> components/common/alert-error forms.contact.error}}</div>
     {{/if}}
     <input type="hidden" name="page_id" id="page_id" value="{{forms.contact.page_id}}">
     <div class="form-row form-row--half">

--- a/templates/pages/contact-us.html
+++ b/templates/pages/contact-us.html
@@ -16,9 +16,9 @@
         </nav>
     {{/if}}
 
-    <div class="page-content page-content--centered">
+    <div id="contact-us-page" class="page-content page-content--centered">
         {{#if forms.contact.success}}
-            {{{lang 'forms.contact_us.successful' shopPath=urls.home}}}
+            <div id="contact-us-success">{{{lang 'forms.contact_us.successful' shopPath=urls.home}}}</div>
         {{else}}
             <p>{{{page.content}}}</p>
             {{> components/page/contact-us-form}}


### PR DESCRIPTION
#### What?

This is my first ever submission like this on GitHub. Please tell me if I've got it all wrong.

The contact form is single page, which means it is very hard for people to track form submissions on systems like Google Analytics. There is no success page to track it as a goal.

I've developed a way to hook into the page and detect user activity via JavaScript, this JavaScript can directly send a signal to Analytics so that it can track submissions. 

But my solution, and probably anyone elses requires some minor edits to the theme.

The code needs to detect if certain elements are present. These elements indicate if the page has been submitted, or if the submission had errors (also useful to track). However the theme does not include an easy way to find those elements, and there are not always clean elements to detect.

The edits add id attributes to some div elements and add some div elements with id attributes. This makes it possible to detect if the page is a contact page and if it currently contains a success or error messages. 

With that, people can write JavaScript to detect what is going on in the page. And most importantly, detect if the form was successfully submitted. With Google Analytics, events or fake page views can be sent which can be used to trigger a contact form sent goal.

#### Tickets / Documentation

I raised the issue a while ago. 

https://github.com/bigcommerce/cornerstone/issues/1114

And decided to have a go at making the fix myself.

I could not work out how to raise this change under the issue.

#### Screenshots (if appropriate)

Nothing is visible.
