### PR TITLE
Only show review tab when there are reviews.

### DIFF
--- a/templates/components/products/description-tabs.html
+++ b/templates/components/products/description-tabs.html
@@ -7,7 +7,7 @@
             <a class="tab-title" href="#tab-warranty">{{lang 'products.warranty'}}</a>
         </li>
     {{/if}}
-    {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs}}
+    {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs reviews.total}}
         <li class="tab">
             <a class="tab-title productView-reviewTabLink" href="#tab-reviews">{{lang 'products.reviews.header' total=product.reviews.total}}</a>
         </li>


### PR DESCRIPTION
#### What?

A fix for #1302. The product review tab (if enabled) should not be shown if a product has no reviews.

#### Tickets / Documentation

- #1302 

#### Screenshots

##### Before:

<img width="710" alt="before" src="https://user-images.githubusercontent.com/1546172/43423280-d31abb5a-9400-11e8-8cd2-7ce7b66db8fb.png">

##### After:

<img width="710" alt="after" src="https://user-images.githubusercontent.com/1546172/43423288-d7853a76-9400-11e8-8209-20f60ec291f6.png">