### PR TITLE
show dots only if carousel has more than one slide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Show bulk discounts only if enabled through store settings. [#1310](https://github.com/bigcommerce/cornerstone/pull/1310)
 - Style active section in search results. [#1316](https://github.com/bigcommerce/cornerstone/pull/1316)
 - Fix blog_post import statement in app.js [#1301](https://github.com/bigcommerce/cornerstone/pull/1301)
+- Show carousel dots only when carousel has more than one slide. [#1319](https://github.com/bigcommerce/cornerstone/pull/1319)
 
 ## 2.2.1 (2018-07-10)
 - Fix wishlist dropdown background color bleeding out of container [#1283](https://github.com/bigcommerce/cornerstone/pull/1283)

--- a/assets/js/test-unit/theme/carousel.spec.js
+++ b/assets/js/test-unit/theme/carousel.spec.js
@@ -1,0 +1,57 @@
+import carousel from '../../theme/common/carousel';
+import $ from 'jquery'
+import 'slick-carousel';
+
+describe('carousel', () => {
+    it('should generate carousel WITH dots if carousel has more than one slide', () => {	
+		var multipleSlidesElement = $("<section class='heroCarousel' data-slick='{}'>\
+			<a href=''>\
+		        <div class='heroCarousel-slide  heroCarousel-slide--first'>\
+		            <div class='heroCarousel-image-wrapper' style='height: 42.868654311039485vw'>\
+		                <img class='heroCarousel-image' data-lazy='https://img.jpg?t=1532986020' alt='Our signature fixture that bends to your will' title='Our signature fixture that bends to your will' width='1241' height='532'>\
+		            </div>\
+		            <div class='heroCarousel-content'>\
+		    			<h1 class='heroCarousel-title'>The Task Lamp</h1>\
+		    			<p class='heroCarousel-description'>Our signature fixture that bends to your will</p>\
+		        		<span class='heroCarousel-action button button--primary button--large'>Shop Now</span>\
+					</div>\
+		        </div>\
+		    </a>\
+		    <a href=''>\
+		        <div class='heroCarousel-slide'>\
+		            <div class='heroCarousel-image-wrapper' style='height: 99.75124378109453vw'>\
+		                <img class='heroCarousel-image' data-lazy='https://img.png?t=1532986020'>\
+		            </div>\
+		        </div>\
+		    </a>\
+		</section>")
+
+	    spyOn(jQuery.fn, 'find').and.returnValue(multipleSlidesElement);
+	    var slickSpy = spyOn(multipleSlidesElement, 'slick');
+	    carousel();
+	    expect(slickSpy).toHaveBeenCalledWith({ dots: true });   
+    });
+
+    it('should generate carousel WITHOUT dots if carousel has one slide', () => {	
+		var multipleSlidesElement = $("<section class='heroCarousel' data-slick='{}'>\
+			<a href=''>\
+		        <div class='heroCarousel-slide  heroCarousel-slide--first'>\
+		            <div class='heroCarousel-image-wrapper' style='height: 42.868654311039485vw'>\
+		                <img class='heroCarousel-image' data-lazy='https://img.jpg?t=1532986020' alt='Our signature fixture that bends to your will' title='Our signature fixture that bends to your will' width='1241' height='532'>\
+		            </div>\
+		            <div class='heroCarousel-content'>\
+		    			<h1 class='heroCarousel-title'>The Task Lamp</h1>\
+		    			<p class='heroCarousel-description'>Our signature fixture that bends to your will</p>\
+		        		<span class='heroCarousel-action button button--primary button--large'>Shop Now</span>\
+					</div>\
+		        </div>\
+		    </a>\
+		</section>")
+
+	    spyOn(jQuery.fn, 'find').and.returnValue(multipleSlidesElement);
+	    var slickSpy = spyOn(multipleSlidesElement, 'slick');
+	    carousel();
+	    expect(slickSpy).toHaveBeenCalledWith({ dots: false });   
+    });
+});
+

--- a/assets/js/theme/common/carousel.js
+++ b/assets/js/theme/common/carousel.js
@@ -3,9 +3,9 @@ import 'slick-carousel';
 
 export default function () {
     const $carousel = $('[data-slick]');
-
     if ($carousel.length) {
-        $carousel.slick();
+        const multipleSlides = $carousel[0].childElementCount > 1;
+        $carousel.slick({ dots: multipleSlides });
     }
 
     // Alternative image styling for IE, which doesn't support objectfit

--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -1,6 +1,5 @@
 <section class="heroCarousel"
     data-slick='{
-        "dots": true,
         "mobileFirst": true,
         "slidesToShow": 1,
         "slidesToScroll": 1,


### PR DESCRIPTION
#### What?
Currently the carousel on the homepage having "dots" even if the carousel has only one slide. This PR is fixing this issue and dots will appear only if there are multiple slides.

#### Tickets / Documentation
- [Slick Docs](http://kenwheeler.github.io/slick/)

#### Screenshots 
##### before
![screen shot 2018-07-31 at 11 27 29 am](https://user-images.githubusercontent.com/41761536/43479389-27da879c-94b5-11e8-9de2-c4da77330896.png)

##### after
![screen shot 2018-07-31 at 11 29 01 am](https://user-images.githubusercontent.com/41761536/43479416-3da5e15c-94b5-11e8-925c-21c4178459a4.png)

![screen shot 2018-07-31 at 12 02 10 pm](https://user-images.githubusercontent.com/41761536/43480999-9d55b2cc-94b9-11e8-96d1-6bee48f88bba.png)


