### PR TITLE
Changelog for #1290

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix blog_post import statement in app.js [#1301](https://github.com/bigcommerce/cornerstone/pull/1301)
 - Show carousel dots only when carousel has more than one slide. [#1319](https://github.com/bigcommerce/cornerstone/pull/1319)
 - New products left align. [1321](https://github.com/bigcommerce/cornerstone/pull/1321)
+- Fix initial aria attributes for 'Customers Also Viewed' products tab [#1290](https://github.com/bigcommerce/cornerstone/pull/1290)
 
 ## 2.2.1 (2018-07-10)
 - Fix wishlist dropdown background color bleeding out of container [#1283](https://github.com/bigcommerce/cornerstone/pull/1283)

--- a/templates/components/products/tabs.html
+++ b/templates/components/products/tabs.html
@@ -6,7 +6,7 @@
     {{/if}}
     {{#if product.similar_by_views}}
         <li class="tab{{#unless product.related_products}} is-active{{/unless}}" role="presentational">
-            <a class="tab-title" href="#tab-similar" role="tab" tabindex="0" aria-selected="false" controls="tab-similar">{{lang 'products.similar_by_views'}}</a>
+            <a class="tab-title" href="#tab-similar" role="tab" tabindex="0" aria-selected="{{#if product.related_products}}false{{else}}true{{/if}}" controls="tab-similar">{{lang 'products.similar_by_views'}}</a>
         </li>
     {{/if}}
 </ul>
@@ -19,7 +19,7 @@
 {{/if}}
 
 {{#if product.similar_by_views}}
-    <div role="tabpanel" aria-hidden="true" class="tab-content has-jsContent{{#unless product.related_products}} is-active{{/unless}}" id="tab-similar">
+    <div role="tabpanel" aria-hidden="{{#if product.related_products}}true{{else}}false{{/if}}" class="tab-content has-jsContent{{#unless product.related_products}} is-active{{/unless}}" id="tab-similar">
         {{> components/products/carousel products=product.similar_by_views columns=6}}
     </div>
 {{/if}}


### PR DESCRIPTION
#### What?

#1290, but with a changelog entry (and screenshots in a PR).

#### Tickets / Documentation

- #1290

#### Screenshots

Screenshots are identical, but they're here for the record. The real fix is in *when* these attributes are set, which is what was fixed in #1290.

##### Before, Related

![relatedbefore](https://user-images.githubusercontent.com/1546172/43544786-df9f1752-9588-11e8-8a5f-86d8eafc2fbc.png)

##### After, Related

![relatedafter](https://user-images.githubusercontent.com/1546172/43544795-e3d796fa-9588-11e8-8c8c-c1491af61598.png)

##### Before, Viewed

![viewedbefore](https://user-images.githubusercontent.com/1546172/43544801-e8ba735e-9588-11e8-9d1e-377857938784.png)

##### After, Viewed

![viewedafter](https://user-images.githubusercontent.com/1546172/43544805-ecb45fba-9588-11e8-9370-92dfa573629f.png)
