### PR TITLE
change css for product productCarousel -> slick-track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Style active section in search results. [#1316](https://github.com/bigcommerce/cornerstone/pull/1316)
 - Fix blog_post import statement in app.js [#1301](https://github.com/bigcommerce/cornerstone/pull/1301)
 - Show carousel dots only when carousel has more than one slide. [#1319](https://github.com/bigcommerce/cornerstone/pull/1319)
+- New products left align. [1321](https://github.com/bigcommerce/cornerstone/pull/1321)
 
 ## 2.2.1 (2018-07-10)
 - Fix wishlist dropdown background color bleeding out of container [#1283](https://github.com/bigcommerce/cornerstone/pull/1283)

--- a/assets/scss/components/stencil/productCarousel/_productCarousel.scss
+++ b/assets/scss/components/stencil/productCarousel/_productCarousel.scss
@@ -33,3 +33,7 @@
         margin-bottom: 0;
     }
 }
+
+.productCarousel .slick-track {
+    width: auto !important;
+}


### PR DESCRIPTION
#### What?
New products are currently not left aligned. This PR will change the css of the product carousel to fix the alignment of the carousel.
It is expected that in the homepage, the featured, new and popular products show up left aligned.

#### Screenshots
##### Before
<img width="1675" alt="screen shot 2018-08-01 at 1 17 37 pm" src="https://user-images.githubusercontent.com/41761536/43546462-8e2e505e-958d-11e8-831a-ccd062fdbb47.png">


##### After
<img width="1673" alt="screen shot 2018-08-01 at 1 17 50 pm" src="https://user-images.githubusercontent.com/41761536/43546476-96980186-958d-11e8-87c9-4b7e2e346431.png">





