### PR TITLE
Fix for the fix for review tabs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fix for review tabs not appearing. [#1322](https://github.com/bigcommerce/cornerstone/pull/1322)
 
 ## 2.3.0 (2018-08-02)
 - Open correct product page tabs when URL contains a fragment identifier referring to that content [#1304](https://github.com/bigcommerce/cornerstone/pull/1304)

--- a/templates/components/products/description-tabs.html
+++ b/templates/components/products/description-tabs.html
@@ -7,7 +7,7 @@
             <a class="tab-title" href="#tab-warranty">{{lang 'products.warranty'}}</a>
         </li>
     {{/if}}
-    {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs reviews.total}}
+    {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs product.reviews.total}}
         <li class="tab">
             <a class="tab-title productView-reviewTabLink" href="#tab-reviews">{{lang 'products.reviews.header' total=product.reviews.total}}</a>
         </li>


### PR DESCRIPTION
#### What?

A fix for the fix (#1318) for review tabs.

The issue that arose is that when "Product reviews in tabs" is enabled that tab simply doesn't show up.

If a product has no reviews the tab still won't show up.

What probably happened with the screenshots in #1318 is that they were done through Edit Theme Files, which wasn't reflected/copied over for the code in that PR.

#### Tickets / Documentation

- #1318

#### Screenshots

##### Before

![before](https://user-images.githubusercontent.com/1546172/43614634-0eaa03be-9669-11e8-9da2-3ddbe0276bba.png)

##### After

![after](https://user-images.githubusercontent.com/1546172/43614638-13083af2-9669-11e8-809a-50d888b8f6f8.png)