### PR TITLE
Amp page error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft 
 - Fix encoding issues on Account Signup Form ("&#039;" characters showing in country name)[#1341] (https://github.com/bigcommerce/cornerstone/pull/1341)
 - Require Webpack config only when used (reduce time to be ready for receiving messages from stencil-cli). [#1334](https://github.com/bigcommerce/cornerstone/pull/1334)
+- Fixed amp page error related to store logo [#1323](https://github.com/bigcommerce/cornerstone/pull/1323)
 
 ## 2.3.2 (2018-08-17)
 - Fix zoom behavior for small images in gallery (turn off zoom if image is too small). [#1325](https://github.com/bigcommerce/cornerstone/pull/1325)

--- a/templates/components/amp/common/store-logo.html
+++ b/templates/components/amp/common/store-logo.html
@@ -7,8 +7,12 @@
             {{else}}
                 width="{{first (split theme_settings.logo_size 'x')}}"
                 height="{{last (split theme_settings.logo_size 'x')}}"
+                {{#if (last (split theme_settings.logo_size 'x')) 'gtnum' (first (split theme_settings.logo_size 'x')) }}
+                    sizes="(max-width: 360px) 100vw, 1vw"
+                {{else}}
+                    sizes="(max-width: 360px) 100vw, 10vw"
+                {{/if}}
                 layout="responsive"
-                sizes="(min-height: {{last (split theme_settings.logo_size 'x')}}%)"
             {{/if}}
             alt="{{settings.store_logo.title}}">
         </amp-img>


### PR DESCRIPTION
#### What?
AMP store logo didn't show up. This pr should fix that issue by setting "sizes"n attribute correctly.

#### Tickets / Documentation

- [AMP docs](https://www.ampproject.org/docs/design/responsive/art_direction)

#### Screenshots 
##### Before:
<img width="1600" alt="screen shot 2018-08-02 at 9 31 23 pm" src="https://user-images.githubusercontent.com/41761536/43624563-12398034-969d-11e8-95af-586f65ce9f5b.png">

##### After
<img width="405" alt="screen shot 2018-08-06 at 11 31 11 am" src="https://user-images.githubusercontent.com/41761536/43735159-d04e86d6-996e-11e8-9ebe-f05af28b7048.png">

<img width="406" alt="screen shot 2018-08-06 at 11 31 52 am" src="https://user-images.githubusercontent.com/41761536/43735165-d5220e4e-996e-11e8-82d4-88faf36952e2.png">

<img width="406" alt="screen shot 2018-08-06 at 11 32 21 am" src="https://user-images.githubusercontent.com/41761536/43735174-d9f80b8a-996e-11e8-9282-a799d2bffc3a.png">


