### PR TITLE
fix(catalog): MERC-3743 Fix zoom behavior for small images in gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fix zoom behavior for small images in gallery (turn off zoom if image is too small). [#1325](https://github.com/bigcommerce/cornerstone/pull/1325)
 
 ## 2.3.1 (2018-08-03)
 - Fix for review tabs not appearing. [#1322](https://github.com/bigcommerce/cornerstone/pull/1322)

--- a/assets/js/theme/product/image-gallery.js
+++ b/assets/js/theme/product/image-gallery.js
@@ -41,7 +41,6 @@ export default class ImageGallery {
 
     selectNewImage(e) {
         e.preventDefault();
-
         const $target = $(e.currentTarget);
         const imgObj = {
             mainImageUrl: $target.attr('data-image-gallery-new-image-url'),
@@ -67,8 +66,22 @@ export default class ImageGallery {
         });
     }
 
+    checkImage() {
+        const containerHeight = $('.productView-image').height();
+        const containerWidth = $('.productView-image').width();
+        const height = this.easyzoom.data('easyZoom').$zoom.context.height;
+        const width = this.easyzoom.data('easyZoom').$zoom.context.width;
+        if (height < containerHeight || width < containerWidth) {
+            this.easyzoom.data('easyZoom').hide();
+        }
+    }
+
     setImageZoom() {
-        this.easyzoom = this.$mainImage.easyZoom({ errorNotice: '', loadingNotice: '' });
+        this.easyzoom = this.$mainImage.easyZoom({
+            onShow: () => this.checkImage(),
+            errorNotice: '',
+            loadingNotice: '',
+        });
     }
 
     bindEvents() {


### PR DESCRIPTION
#### What?
Fixed issue with Cornerstone product image zoom functionality. If images were too small (less than 500px), zoomed image would not show properly. 

Solution: Set up a checkImage() function to check image size before easyzoom-flyout. If image is less than image container (~500px), easyzoom-flyout is hidden, else, easyzoom functions normally.


#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [MERC-3743](https://jira.bigcommerce.com/browse/MERC-3743)


#### Images / Gifs

**Previous Zoom Function (bug)**


*Image of bug*
![previous zoom](https://user-images.githubusercontent.com/33278039/43975805-ace82558-9c93-11e8-8671-472b05bc5799.png)

*Gif of bug*
![previouszoom](https://user-images.githubusercontent.com/33278039/43975940-124feda4-9c94-11e8-9df7-27fdf03706a6.gif)


**Current Zoom Function (Fix)**

![zoomfix](https://user-images.githubusercontent.com/33278039/43975891-eaf90448-9c93-11e8-8094-f2a2544ac188.gif)

