### PR TITLE
change src for invoice logo image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 2.3.1 (2018-08-03)
 - Fix for review tabs not appearing. [#1322](https://github.com/bigcommerce/cornerstone/pull/1322)
+- Fix invoice store logo. [#1326](https://github.com/bigcommerce/cornerstone/pull/1326)
 
 ## 2.3.0 (2018-08-02)
 - Open correct product page tabs when URL contains a fragment identifier referring to that content [#1304](https://github.com/bigcommerce/cornerstone/pull/1304)

--- a/templates/pages/account/orders/invoice.html
+++ b/templates/pages/account/orders/invoice.html
@@ -6,7 +6,13 @@
     <div class="Invoice">
         <h1>
             {{#if settings.store_logo.image}}
-                <img class="header-logo-image lazyload" data-sizes="auto" src="{{cdn 'img/loading.svg'}}" data-src="{{getImage settings.store_logo.image 'logo_size'}}" alt="{{settings.store_logo.title}}" title="{{settings.store_logo.title}}">
+                {{#if theme_settings.logo_size '===' 'original'}}
+                    <img class="header-logo-image-unknown-size" src="{{getImage settings.store_logo.image 'logo_size'}}" alt="{{settings.store_logo.title}}" title="{{settings.store_logo.title}}">
+                {{else}}
+                    <div class="header-logo-image-container">
+                        <img class="header-logo-image" data-sizes="auto" src="{{getImage settings.store_logo.image 'logo_size'}}" alt="{{settings.store_logo.title}}" title="{{settings.store_logo.title}}">
+                    </div>
+                {{/if}}
             {{else}}
                 <span class="header-logo-text">{{settings.store_logo.title}}</span>
             {{/if}}


### PR DESCRIPTION
#### What?
Logo img in the invoice is missing. This change will add logo img to the invoice

#### Screenshots 
##### Before
<img width="868" alt="screen shot 2018-08-08 at 10 23 24 am" src="https://user-images.githubusercontent.com/41761536/43853495-2d3221d2-9af5-11e8-8af3-6ac554d493e8.png">

##### After
###### Original logo size
![screen shot 2018-08-10 at 5 08 16 pm](https://user-images.githubusercontent.com/41761536/43985945-876bc186-9cc0-11e8-8ab0-14f245afa375.png)

###### Optimized
![screen shot 2018-08-10 at 5 09 02 pm](https://user-images.githubusercontent.com/41761536/43985948-8d574ea8-9cc0-11e8-9c64-a8744a3be0a0.png)

###### Specified Dimensions   
![screen shot 2018-08-10 at 5 10 02 pm](https://user-images.githubusercontent.com/41761536/43985951-915f4a46-9cc0-11e8-8bbb-19aecdc015bc.png)



