### PR TITLE
Undo New Products left align from 2.3.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Fix zoom behavior for small images in gallery (turn off zoom if image is too small). [#1325](https://github.com/bigcommerce/cornerstone/pull/1325)
+- Undo New Products left align from 2.3.0. [#1328](https://github.com/bigcommerce/cornerstone/pull/1328)
 
 ## 2.3.1 (2018-08-03)
 - Fix for review tabs not appearing. [#1322](https://github.com/bigcommerce/cornerstone/pull/1322)

--- a/assets/scss/components/stencil/productCarousel/_productCarousel.scss
+++ b/assets/scss/components/stencil/productCarousel/_productCarousel.scss
@@ -33,7 +33,3 @@
         margin-bottom: 0;
     }
 }
-
-.productCarousel .slick-track {
-    width: auto !important;
-}


### PR DESCRIPTION
#### What?

Reverting #1321 until we can find a better solution for all cases. New products were left-aligned, but once there were four products the fourth product would be pushed into a new row.

The caveat here is that merchants who are displaying less than four new products on Cornerstone should probably keep the changes to `_productCarousel.scss` in ca0f3cdf9bce4e32cd6fd897440d7debb3095e5d.

#### Tickets / Documentation

- [#1321]

#### Screenshots

##### Before (2.3.1)

###### 3 Products

![before3](https://user-images.githubusercontent.com/1546172/44059592-bc76f402-9f06-11e8-9f19-66d19778301f.png)

###### 5 Products

![before5](https://user-images.githubusercontent.com/1546172/44059593-bc90549c-9f06-11e8-9bf0-dc05bdcbedbb.png)

##### After (or 2.2.1)

###### 3 Products. Note the justification.

![after3](https://user-images.githubusercontent.com/1546172/44059590-bc3c1030-9f06-11e8-82a0-89ec46224c2e.png)

###### 5 Products. Note the carousel.

![after5](https://user-images.githubusercontent.com/1546172/44059591-bc5a5d06-9f06-11e8-8b82-75d4beb62967.png)