### PR TITLE
Require Webpack config only when used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Require Webpack config only when used (reduce time to be ready for receiving messages from stencil-cli). [#1334](https://github.com/bigcommerce/cornerstone/pull/1334)
 
 ## 2.3.2 (2018-08-17)
 - Fix zoom behavior for small images in gallery (turn off zoom if image is too small). [#1325](https://github.com/bigcommerce/cornerstone/pull/1325)

--- a/stencil.conf.js
+++ b/stencil.conf.js
@@ -1,6 +1,4 @@
 var webpack = require('webpack');
-var devConfig = require('./webpack.dev.js');
-var prodConfig = require('./webpack.prod.js');
 
 /**
  * Watch options for the core watcher
@@ -26,6 +24,8 @@ var watchOptions = {
  * Watch any custom files and trigger a rebuild
  */
 function development() {
+    var devConfig = require('./webpack.dev.js');
+
     // Rebuild the bundle once at bootup
     webpack(devConfig).watch({}, err => {
         if (err) {
@@ -40,6 +40,8 @@ function development() {
  * Hook into the `stencil bundle` command and build your files before they are packaged as a .zip
  */
 function production() {
+    var prodConfig = require('./webpack.prod.js');
+
     webpack(prodConfig).run(err => {
         if (err) {
             console.error(err.message, err.details);


### PR DESCRIPTION
#### What?

Detailed description has been written and discussed at issue https://github.com/bigcommerce/stencil-cli/issues/379

This change helps to prevent that issue to happen, because the time to be [ready for receiving messages from `stencil-cli`](https://github.com/bigcommerce/cornerstone/blob/2.3.2/stencil.conf.js#L54-L67) is dramatically reduced.

#### Tickets / Documentation

- [bigcommerce/stencil-cli GitHub issue 379](https://github.com/bigcommerce/stencil-cli/issues/379)
