### PR TITLE
fix(storefront): STRF-5282 Unable to add products to cart with 2 or more non-required File Upload options using Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Draft 
-- Fix encoding issues on Account Signup Form ("&#039;" characters showing in country name)[#1341] (https://github.com/bigcommerce/cornerstone/pull/1341)
+## Draft
+- Fix multiple file upload options not working in Safari. [#1337](https://github.com/bigcommerce/cornerstone/pull/1337)
+- Fix encoding issues on Account Signup Form ("&#039;" characters showing in country name)[#1341](https://github.com/bigcommerce/cornerstone/pull/1341)
 - Require Webpack config only when used (reduce time to be ready for receiving messages from stencil-cli). [#1334](https://github.com/bigcommerce/cornerstone/pull/1334)
 - Fixed amp page error related to store logo [#1323](https://github.com/bigcommerce/cornerstone/pull/1323)
 - Add link to order status in account menu when viewing order [#1343](https://github.com/bigcommerce/cornerstone/pull/1343)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -60,20 +60,25 @@ export default class ProductDetails {
     /**
      * https://stackoverflow.com/questions/49672992/ajax-request-fails-when-sending-formdata-including-empty-file-input-in-safari
      * Safari browser with jquery 3.3.1 has an issue uploading empty file parameters. This function removes any empty files from the form params
-     * @param formData: FormData object
+     * @param form: form NodeList
      * @returns FormData object
      */
-    filterEmptyFilesFromForm(formData) {
+    filterEmptyFilesFromForm(form) {
         try {
-            for (const [key, val] of formData) {
-                if (val instanceof File && !val.name && !val.size) {
-                    formData.delete(key);
+            const filteredFormData = new FormData();
+            for (let i = 0; i < form.elements.length; i++) {
+                const element = form.elements[i];
+                if (element.type !== 'file' && element.value && element.name) {
+                    filteredFormData.append(element.name, element.value);
+                }
+                if (element.type === 'file' && element.files[0]) {
+                    filteredFormData.append(element.name, element.files[0], element.files[0].name);
                 }
             }
+            return filteredFormData;
         } catch (e) {
             console.error(e); // eslint-disable-line no-console
         }
-        return formData;
     }
 
     /**
@@ -257,7 +262,7 @@ export default class ProductDetails {
         this.$overlay.show();
 
         // Add item to cart
-        utils.api.cart.itemAdd(this.filterEmptyFilesFromForm(new FormData(form)), (err, response) => {
+        utils.api.cart.itemAdd(this.filterEmptyFilesFromForm(form), (err, response) => {
             const errorMessage = err || response.data.error;
 
             $addToCartBtn


### PR DESCRIPTION
#### What?
Safari only does one iteration in the current`for of` loop. This change will create a new FormData object and append valid entries using a standard for loop instead.

#### Screenshots (if appropriate)
Before:
![before](https://user-images.githubusercontent.com/20911717/44683115-f44ecd00-aa0a-11e8-9d08-46cb14377cf5.gif)

After:
![after](https://user-images.githubusercontent.com/20911717/44683132-fca70800-aa0a-11e8-8efa-06a3379b956d.gif)


