### PR TITLE
Update qty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Require Webpack config only when used (reduce time to be ready for receiving messages from stencil-cli). [#1334](https://github.com/bigcommerce/cornerstone/pull/1334)
 - Fixed amp page error related to store logo [#1323](https://github.com/bigcommerce/cornerstone/pull/1323)
 - Add link to order status in account menu when viewing order [#1343](https://github.com/bigcommerce/cornerstone/pull/1343)
+- Update cart when quantity changed manually (without using the increase and decrease arrows). [#1338](https://github.com/bigcommerce/cornerstone/pull/1338)
 
 ## 2.3.2 (2018-08-17)
 - Fix zoom behavior for small images in gallery (turn off zoom if image is too small). [#1325](https://github.com/bigcommerce/cornerstone/pull/1325)

--- a/assets/js/test-unit/theme/cart.spec.js
+++ b/assets/js/test-unit/theme/cart.spec.js
@@ -1,97 +1,98 @@
 import $ from 'jquery'
 import utils from '@bigcommerce/stencil-utils';
-import Cart from '../../theme/cart.js'
+import Cart from '../../theme/cart.js';
+import * as SweetAlert from 'sweetalert2';
+
+var dataSpy;
+var swalSpy;
+var UpdateSpy;
+var c = new Cart();
+beforeEach(function() {
+	UpdateSpy = spyOn(utils.api.cart, 'itemUpdate');
+
+	dataSpy = function(requestedAction = null) {
+		spyOn(jQuery.fn, 'data').and.callFake(function() {
+		    var param = arguments[0];
+		    switch (param) {
+		    case 'action':
+		    	return requestedAction;
+		    case 'cartItemid':
+		    	return '11111';
+		    case 'quantityMax':
+		    	return 5;
+		    case 'quantityMin':
+		    	return 1;
+		    case 'quantityMinError':
+		    	return 'min error';
+		    case 'quantityMaxError':
+		    	return ' max error';
+		    default:
+		    	return null;
+		    }
+		})
+	};
+});
+
+var $dom = $('<table class="cart" data-cart-quantity="2">\
+    <thead class="cart-header">\
+        <tr>\
+            <th class="cart-header-item" colspan="2">Item</th>\
+            <th class="cart-header-item">Price</th>\
+            <th class="cart-header-item cart-header-quantity">Quantity</th>\
+            <th class="cart-header-item">Total</th>\
+        </tr>\
+    </thead>\
+    <tbody class="cart-list">\
+            <tr class="cart-item" data-item-row="">\
+                <td class="cart-item-block cart-item-figure">\
+                        <img class="cart-item-image lazyautosizes lazyloaded" data-sizes="auto" src="www.example.com" data-src="www.example.com" alt="[Sample] product" title="[Sample] product">\
+                </td>\
+                <td class="cart-item-block cart-item-title">\
+                    <h4 class="cart-item-name"><a href="/fog-linen-chambray-towel-beige-stripe/">[Sample] Fog Linen Chambray Towel - Beige Stripe</a></h4>\
+                        <dl class="definitionList">\
+                                <dt class="definitionList-key">Size:</dt>\
+                                <dd class="definitionList-value">\
+                                        XS\
+                                </dd>\
+                                <dt class="definitionList-key">Color:</dt>\
+                                <dd class="definitionList-value">\
+                                        Silver\
+                                </dd>\
+                        </dl>\
+                        <a href="#" data-item-edit="item-id">Change</a>\
+                </td>\
+                <td class="cart-item-block cart-item-info">\
+                    <span class="cart-item-label">Price</span>\
+                        <span class="cart-item-value ">$49.00</span>\
+                </td>\
+                <td class="cart-item-block cart-item-info cart-item-quantity">\
+                    <label class="form-label cart-item-label" for="qty-item-id">Quantity:</label>\
+                    <div class="form-increment">\
+                        <button class="button button--icon" data-cart-update="" data-cart-itemid="item-id" data-action="dec">\
+                            <span class="is-srOnly">Decrease Quantity:</span>\
+                            <i class="icon" aria-hidden="true"><svg><use xmlns:xlink="www.ccc.com"></use></svg></i>\
+                        </button>\
+                        <input class="form-input form-input--incrementTotal cart-item-qty-input" id="item-id" name="qty-item-id" type="tel" value="2" data-quantity-min="0" data-quantity-max="" data-quantity-min-error="The minimum purchasable quantity is 0" data-quantity-max-error="The maximum purchasable quantity is null" min="1" pattern="[0-9]*" data-cart-itemid="item-id" data-action="manualQtyChange" aria-live="polite">\
+                            <button class="button button--icon" data-cart-update="" data-cart-itemid="item-id" data-action="inc">\
+                                <span class="is-srOnly">Increase Quantity:</span>\
+                                <i class="icon" aria-hidden="true"><svg><use xmlns:xlink="www.ddd.com"></use></svg></i>\
+                            </button>\
+                    </div>\
+                </td>\
+                <td class="cart-item-block cart-item-info">\
+                    <span class="cart-item-label">Total</span>\
+                        <strong class="cart-item-value ">$98.00</strong>\
+                        <a class="cart-remove icon" data-cart-itemid="item-id" href="#" data-confirm-delete="Are you sure you want to delete this item?">\
+                            <svg><use xmlns:xlink="www.eee.com" xlink:href="#icon-close"></use></svg>\
+                        </a>\
+                </td>\
+            </tr>\
+    </tbody>\
+</table>')
+
+c.onReady();
 
 describe('cartUpdate', () => {
-	var dataSpy;
-	var UpdateSpy;
-	var c = new Cart();
-
-	c.onReady();
-
-	beforeEach(function() {
-		UpdateSpy = spyOn(utils.api.cart, 'itemUpdate');
-
-		dataSpy = function(requestedAction = null) {
-			spyOn(jQuery.fn, 'data').and.callFake(function() {
-			    var param = arguments[0];
-			    switch (param) {
-			    case 'action':
-			    	return requestedAction;
-			    case 'cartItemid':
-			    	return '11111';
-			    case 'quantityMax':
-			    	return 5;
-			    case 'quantityMin':
-			    	return 1;
-			    case 'quantityMinError':
-			    	return 'min error';
-			    case 'quantityMaxError':
-			    	return ' max error';
-			    default:
-			    	return null;
-			    }
-			})
-		};
-	});
-
-	var $dom = $('<table class="cart" data-cart-quantity="2">\
-	    <thead class="cart-header">\
-	        <tr>\
-	            <th class="cart-header-item" colspan="2">Item</th>\
-	            <th class="cart-header-item">Price</th>\
-	            <th class="cart-header-item cart-header-quantity">Quantity</th>\
-	            <th class="cart-header-item">Total</th>\
-	        </tr>\
-	    </thead>\
-	    <tbody class="cart-list">\
-	            <tr class="cart-item" data-item-row="">\
-	                <td class="cart-item-block cart-item-figure">\
-	                        <img class="cart-item-image lazyautosizes lazyloaded" data-sizes="auto" src="www.example.com" data-src="www.example.com" alt="[Sample] product" title="[Sample] product">\
-	                </td>\
-	                <td class="cart-item-block cart-item-title">\
-	                    <h4 class="cart-item-name"><a href="/fog-linen-chambray-towel-beige-stripe/">[Sample] Fog Linen Chambray Towel - Beige Stripe</a></h4>\
-	                        <dl class="definitionList">\
-	                                <dt class="definitionList-key">Size:</dt>\
-	                                <dd class="definitionList-value">\
-	                                        XS\
-	                                </dd>\
-	                                <dt class="definitionList-key">Color:</dt>\
-	                                <dd class="definitionList-value">\
-	                                        Silver\
-	                                </dd>\
-	                        </dl>\
-	                        <a href="#" data-item-edit="item-id">Change</a>\
-	                </td>\
-	                <td class="cart-item-block cart-item-info">\
-	                    <span class="cart-item-label">Price</span>\
-	                        <span class="cart-item-value ">$49.00</span>\
-	                </td>\
-	                <td class="cart-item-block cart-item-info cart-item-quantity">\
-	                    <label class="form-label cart-item-label" for="qty-item-id">Quantity:</label>\
-	                    <div class="form-increment">\
-	                        <button class="button button--icon" data-cart-update="" data-cart-itemid="item-id" data-action="dec">\
-	                            <span class="is-srOnly">Decrease Quantity:</span>\
-	                            <i class="icon" aria-hidden="true"><svg><use xmlns:xlink="www.ccc.com"></use></svg></i>\
-	                        </button>\
-	                        <input class="form-input form-input--incrementTotal cart-item-qty-input" id="item-id" name="qty-item-id" type="tel" value="2" data-quantity-min="0" data-quantity-max="" data-quantity-min-error="The minimum purchasable quantity is 0" data-quantity-max-error="The maximum purchasable quantity is null" min="1" pattern="[0-9]*" data-cart-itemid="item-id" data-action="manualQtyChange" aria-live="polite">\
-	                            <button class="button button--icon" data-cart-update="" data-cart-itemid="item-id" data-action="inc">\
-	                                <span class="is-srOnly">Increase Quantity:</span>\
-	                                <i class="icon" aria-hidden="true"><svg><use xmlns:xlink="www.ddd.com"></use></svg></i>\
-	                            </button>\
-	                    </div>\
-	                </td>\
-	                <td class="cart-item-block cart-item-info">\
-	                    <span class="cart-item-label">Total</span>\
-	                        <strong class="cart-item-value ">$98.00</strong>\
-	                        <a class="cart-remove icon" data-cart-itemid="item-id" href="#" data-confirm-delete="Are you sure you want to delete this item?">\
-	                            <svg><use xmlns:xlink="www.eee.com" xlink:href="#icon-close"></use></svg>\
-	                        </a>\
-	                </td>\
-	            </tr>\
-	    </tbody>\
-	</table>')
-
     it('should INCRIMENT qty', () => {	
 		dataSpy
 		dataSpy('inc');
@@ -109,13 +110,15 @@ describe('cartUpdate', () => {
 		
 		expect(UpdateSpy).toHaveBeenCalledWith('11111', 1, jasmine.any(Function));  
 	});
+});
 
+describe('cartUpdateQtyTextChange', () => {
     it('should CHANGE qty completly based on the cart-item-qty-input', () => {	
 		dataSpy
 		dataSpy('manualQtyChange');
 		spyOn(jQuery.fn, 'attr').and.returnValue(5);
 		spyOn(jQuery.fn, 'val').and.returnValue(2);
-		c.cartUpdate($dom);
+		c.cartUpdateQtyTextChange($dom);
 		
 		expect(UpdateSpy).toHaveBeenCalledWith('11111', 5, jasmine.any(Function));  
 	});

--- a/assets/js/test-unit/theme/cart.spec.js
+++ b/assets/js/test-unit/theme/cart.spec.js
@@ -1,0 +1,122 @@
+import $ from 'jquery'
+import utils from '@bigcommerce/stencil-utils';
+import Cart from '../../theme/cart.js'
+
+describe('cartUpdate', () => {
+	var dataSpy;
+	var UpdateSpy;
+	var c = new Cart();
+
+	c.onReady();
+
+	beforeEach(function() {
+		UpdateSpy = spyOn(utils.api.cart, 'itemUpdate');
+
+		dataSpy = function(requestedAction = null) {
+			spyOn(jQuery.fn, 'data').and.callFake(function() {
+			    var param = arguments[0];
+			    switch (param) {
+			    case 'action':
+			    	return requestedAction;
+			    case 'cartItemid':
+			    	return '11111';
+			    case 'quantityMax':
+			    	return 5;
+			    case 'quantityMin':
+			    	return 1;
+			    case 'quantityMinError':
+			    	return 'min error';
+			    case 'quantityMaxError':
+			    	return ' max error';
+			    default:
+			    	return null;
+			    }
+			})
+		};
+	});
+
+	var $dom = $('<table class="cart" data-cart-quantity="2">\
+	    <thead class="cart-header">\
+	        <tr>\
+	            <th class="cart-header-item" colspan="2">Item</th>\
+	            <th class="cart-header-item">Price</th>\
+	            <th class="cart-header-item cart-header-quantity">Quantity</th>\
+	            <th class="cart-header-item">Total</th>\
+	        </tr>\
+	    </thead>\
+	    <tbody class="cart-list">\
+	            <tr class="cart-item" data-item-row="">\
+	                <td class="cart-item-block cart-item-figure">\
+	                        <img class="cart-item-image lazyautosizes lazyloaded" data-sizes="auto" src="www.example.com" data-src="www.example.com" alt="[Sample] product" title="[Sample] product">\
+	                </td>\
+	                <td class="cart-item-block cart-item-title">\
+	                    <h4 class="cart-item-name"><a href="/fog-linen-chambray-towel-beige-stripe/">[Sample] Fog Linen Chambray Towel - Beige Stripe</a></h4>\
+	                        <dl class="definitionList">\
+	                                <dt class="definitionList-key">Size:</dt>\
+	                                <dd class="definitionList-value">\
+	                                        XS\
+	                                </dd>\
+	                                <dt class="definitionList-key">Color:</dt>\
+	                                <dd class="definitionList-value">\
+	                                        Silver\
+	                                </dd>\
+	                        </dl>\
+	                        <a href="#" data-item-edit="item-id">Change</a>\
+	                </td>\
+	                <td class="cart-item-block cart-item-info">\
+	                    <span class="cart-item-label">Price</span>\
+	                        <span class="cart-item-value ">$49.00</span>\
+	                </td>\
+	                <td class="cart-item-block cart-item-info cart-item-quantity">\
+	                    <label class="form-label cart-item-label" for="qty-item-id">Quantity:</label>\
+	                    <div class="form-increment">\
+	                        <button class="button button--icon" data-cart-update="" data-cart-itemid="item-id" data-action="dec">\
+	                            <span class="is-srOnly">Decrease Quantity:</span>\
+	                            <i class="icon" aria-hidden="true"><svg><use xmlns:xlink="www.ccc.com"></use></svg></i>\
+	                        </button>\
+	                        <input class="form-input form-input--incrementTotal cart-item-qty-input" id="item-id" name="qty-item-id" type="tel" value="2" data-quantity-min="0" data-quantity-max="" data-quantity-min-error="The minimum purchasable quantity is 0" data-quantity-max-error="The maximum purchasable quantity is null" min="1" pattern="[0-9]*" data-cart-itemid="item-id" data-action="manualQtyChange" aria-live="polite">\
+	                            <button class="button button--icon" data-cart-update="" data-cart-itemid="item-id" data-action="inc">\
+	                                <span class="is-srOnly">Increase Quantity:</span>\
+	                                <i class="icon" aria-hidden="true"><svg><use xmlns:xlink="www.ddd.com"></use></svg></i>\
+	                            </button>\
+	                    </div>\
+	                </td>\
+	                <td class="cart-item-block cart-item-info">\
+	                    <span class="cart-item-label">Total</span>\
+	                        <strong class="cart-item-value ">$98.00</strong>\
+	                        <a class="cart-remove icon" data-cart-itemid="item-id" href="#" data-confirm-delete="Are you sure you want to delete this item?">\
+	                            <svg><use xmlns:xlink="www.eee.com" xlink:href="#icon-close"></use></svg>\
+	                        </a>\
+	                </td>\
+	            </tr>\
+	    </tbody>\
+	</table>')
+
+    it('should INCRIMENT qty', () => {	
+		dataSpy
+		dataSpy('inc');
+		spyOn(jQuery.fn, 'val').and.returnValue(2);
+		c.cartUpdate($dom);
+		
+		expect(UpdateSpy).toHaveBeenCalledWith('11111', 3, jasmine.any(Function));  
+	});
+
+    it('should DECREMENT qty', () => {	
+		dataSpy
+		dataSpy('dec');
+		spyOn(jQuery.fn, 'val').and.returnValue(2);
+		c.cartUpdate($dom);
+		
+		expect(UpdateSpy).toHaveBeenCalledWith('11111', 1, jasmine.any(Function));  
+	});
+
+    it('should CHANGE qty completly based on the cart-item-qty-input', () => {	
+		dataSpy
+		dataSpy('manualQtyChange');
+		spyOn(jQuery.fn, 'attr').and.returnValue(5);
+		spyOn(jQuery.fn, 'val').and.returnValue(2);
+		c.cartUpdate($dom);
+		
+		expect(UpdateSpy).toHaveBeenCalledWith('11111', 5, jasmine.any(Function));  
+	});
+});

--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -99,7 +99,7 @@
                                 <i class="icon" aria-hidden="true"><svg><use xlink:href="#icon-keyboard-arrow-down" /></svg></i>
                             </button>
                         {{/if}}
-                        <input class="form-input form-input--incrementTotal"
+                        <input class="form-input form-input--incrementTotal cart-item-qty-input"
                                id="qty-{{id}}"
                                name="qty-{{id}}"
                                type="tel"
@@ -110,6 +110,8 @@
                                data-quantity-max-error="{{lang 'products.quantity_max' quantity=max_purchase_quantity}}"
                                min="1"
                                pattern="[0-9]*"
+                               data-cart-itemid="{{id}}"
+                               data-action="manualQtyChange"
                                aria-live="polite"{{#unless can_modify}} disabled{{/unless}}>
                         {{# if can_modify}}
                             <button class="button button--icon" data-cart-update data-cart-itemid="{{id}}" data-action="inc">


### PR DESCRIPTION
#### What?
Currently if user change manually (write a number) the qty of item, the cart is not updated and the only way to update the qty it is using the inc and dec arrows. This change added "focusout" event on the qty field, which allow the user to change manually the number of the qty., and the cart will be updated once focus leaves the field. 

#### Test
<img width="1639" alt="screen shot 2018-09-12 at 4 51 21 pm" src="https://user-images.githubusercontent.com/41761536/45459231-3aaf5780-b6ac-11e8-921d-7e2a6e032ba0.png">
