### PR TITLE
Countries with symbols & punctuation in the name are not encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## Draft
+## Draft 
+- Fix encoding issues on Account Signup Form ("&#039;" characters showing in country name)[#1341] (https://github.com/bigcommerce/cornerstone/pull/1341)
 - Require Webpack config only when used (reduce time to be ready for receiving messages from stencil-cli). [#1334](https://github.com/bigcommerce/cornerstone/pull/1334)
 
 ## 2.3.2 (2018-08-17)

--- a/templates/components/common/forms/select.html
+++ b/templates/components/common/forms/select.html
@@ -1,13 +1,15 @@
-<div class="form-field" id="{{id}}" data-validation="{{validation}}" {{#if private_id}}data-type="{{private_id}}"{{/if}} >
+<div class="form-field" id="{{id}}" data-validation="{{validation}}" {{#if private_id}} data-type="{{private_id}}"
+    {{/if}}>
     <label class="form-label" for="{{id}}_select">{{label}}
         {{#if required}}<small>{{lang 'common.required' }}</small>{{/if}}
     </label>
-    <select class="{{class}} form-select" id="{{id}}_select" data-label="{{label}}" aria-required="{{required}}" name="{{name}}"{{#if private_id}}data-field-type="{{private_id}}"{{/if}}>
+    <select class="{{class}} form-select" id="{{id}}_select" data-label="{{label}}" aria-required="{{required}}" name="{{name}}"
+        {{#if private_id}} data-field-type="{{private_id}}" {{/if}}>
         {{#if options}}
-            <option value="">{{chooseprefix}}</option>
-            {{#each options}}
-                <option {{#if selected}} selected {{/if}}value="{{value}}">{{label}}</option>
-            {{/each}}
+        <option value="">{{chooseprefix}}</option>
+        {{#each options}}
+        <option {{#if selected}} selected {{/if}} value="{{value}}">{{{label}}}</option>
+        {{/each}}
         {{/if}}
     </select>
 </div>


### PR DESCRIPTION
This is fixing the country name options entities on the account signup form.
This fix is for Cornerstone / Other themes will need to be updated by 3rd parties such as Pixel Union
https://jira.bigcommerce.com/browse/STRF-5396

Countries with symbols & punctuation in the name are not encoding, for example:
`"Cote d&#039;Ivoire"`

**updated theme file template/components/common/forms/select.html**

**-Line 11 Was:** <option {{#if selected}} selected {{/if}} value="{{value}}">{{label}}</option>
![screen shot 2018-09-05 at 12 49 06 pm](https://user-images.githubusercontent.com/15876529/45111258-2696b380-b10a-11e8-85ea-b38146e2e95d.png)


**-Line 11 Now Is:** <option {{#if selected}} selected {{/if}} value="{{value}}">{{{label}}}</option>
![screen shot 2018-09-05 at 12 47 02 pm](https://user-images.githubusercontent.com/15876529/45115133-990c9100-b114-11e8-9a1a-55323e1dd053.png)



@bigcommerce/storefront-team 
