### PR TITLE
Add link to order status in account menu when viewing order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix encoding issues on Account Signup Form ("&#039;" characters showing in country name)[#1341] (https://github.com/bigcommerce/cornerstone/pull/1341)
 - Require Webpack config only when used (reduce time to be ready for receiving messages from stencil-cli). [#1334](https://github.com/bigcommerce/cornerstone/pull/1334)
 - Fixed amp page error related to store logo [#1323](https://github.com/bigcommerce/cornerstone/pull/1323)
+- Add link to order status in account menu when viewing order [#1343](https://github.com/bigcommerce/cornerstone/pull/1343)
 
 ## 2.3.2 (2018-08-17)
 - Fix zoom behavior for small images in gallery (turn off zoom if image is too small). [#1325](https://github.com/bigcommerce/cornerstone/pull/1325)

--- a/templates/components/account/navigation.html
+++ b/templates/components/account/navigation.html
@@ -1,7 +1,13 @@
 <nav class="navBar navBar--sub navBar--account">
     <ul class="navBar-section">
         {{#if account_page '===' 'orders'}}
-            <li class="navBar-item is-active">{{lang 'account.nav.orders'}}</li>
+            {{#if page_type '===' 'account_order'}}
+                <li class="navBar-item is-active">
+                    <a class="navBar-action" href="{{urls.account.orders.all}}">{{lang 'account.nav.orders'}}</a>
+                </li>
+            {{else}}
+                <li class="navBar-item is-active">{{lang 'account.nav.orders'}}</li>
+            {{/if}}
         {{else}}
             <li class="navBar-item">
                 <a class="navBar-action" href="{{urls.account.orders.all}}">{{lang 'account.nav.orders'}}</a>


### PR DESCRIPTION
#### What?

While viewing an order, the account menu item for "Orders" remains a label. This fix creates a link to allow customers to return easily to the orders status page.

#### Tickets / Documentation

#1330 

#### Screenshots (if appropriate)

**Before**
<img width="1140" alt="1 before" src="https://user-images.githubusercontent.com/5056945/45260208-8228a180-b395-11e8-8a70-24181f28818f.png">

**After**
<img width="1140" alt="2 after" src="https://user-images.githubusercontent.com/5056945/45260209-8228a180-b395-11e8-8480-403424275426.png">
