### PR TITLE
Blueprint for Mapping Custom Templates to JavaScript Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Blueprint for Mapping Custom Templates to JavaScript Modules [#1346](https://github.com/bigcommerce/cornerstone/pull/1346)
 
 ## 2.4.0 (2018-09-14)
 - Fix encoding issues on Account Signup Form ("&#039;" characters showing in country name)[#1341] (https://github.com/bigcommerce/cornerstone/pull/1341)

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -50,6 +50,8 @@ const pageClasses = {
     wishlists: () => import('./theme/wishlist'),
 };
 
+const customClasses = {};
+
 /**
  * This function gets added to the global window and then called
  * on page load with the current template loaded and JS Context passed in
@@ -59,6 +61,8 @@ const pageClasses = {
  */
 window.stencilBootstrap = function stencilBootstrap(pageType, contextJSON = null, loadGlobal = true) {
     const context = JSON.parse(contextJSON || '{}');
+    const template = context.template;
+    const templateCheck = Object.keys(customClasses).indexOf(template);
 
     return {
         load() {
@@ -73,6 +77,15 @@ window.stencilBootstrap = function stencilBootstrap(pageType, contextJSON = null
                 if (typeof pageClassImporter === 'function') {
                     const PageClass = (await pageClassImporter()).default;
                     PageClass.load(context);
+                }
+
+                if (templateCheck > -1) {
+                    // Find the appropriate page loader based on template
+                    const customClassImporter = customClasses[template];
+                    if (typeof customClassImporter === 'function') {
+                        const CustomClass = (await customClassImporter()).default;
+                        CustomClass.load(context);
+                    }
                 }
             });
         },

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -25,6 +25,7 @@
         {{inject 'genericError' (lang 'common.generic_error')}}
         {{inject 'maintenanceMode' settings.maintenance}}
         {{inject 'urls' urls}}
+        {{inject 'template' template}}
         {{{snippet 'htmlhead'}}}
     </head>
     <body>


### PR DESCRIPTION
Here's the blueprint for more easily mapping custom templates to javascript modules (#1339) in `app.js`.