### PR TITLE
Fix carousel dots overlapping thumbnails on Product page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Blueprint for Mapping Custom Templates to JavaScript Modules [#1346](https://github.com/bigcommerce/cornerstone/pull/1346)
+- Fix carousel dots overlapping thumbnails on Product page. [#1351](https://github.com/bigcommerce/cornerstone/pull/1351)
 
 ## 2.4.0 (2018-09-14)
 - Fix encoding issues on Account Signup Form ("&#039;" characters showing in country name)[#1341] (https://github.com/bigcommerce/cornerstone/pull/1341)

--- a/assets/scss/components/vendor/slick/_slick.scss
+++ b/assets/scss/components/vendor/slick/_slick.scss
@@ -140,6 +140,13 @@
 
 }
 
+//
+// Stencil override for product detail page thumbnail dots.
+// -----------------------------------------------------------------------------
+.productView .slick-dots  {
+    position: relative;
+}
+
 
 //
 // disabled carousel elements


### PR DESCRIPTION
#### What?

Things get interesting on the product page image thumbnail carousel when there are a lot of images on that product.

Specifically, when there are more than 22 images the carousel navigation dots will overlap with the image thumbnails.

The way margins are set up, with a window wide enough that Cornerstone will no longer expand out, there will be up to 17 navigation dots per row. These numbers are lower on a narrower view. Using Chrome, this is reduced to 11.

This fix is only for making sure navigation dots don't overlap thumbnail images. The fix also increases the space between the thumbnails and the dots. Only navigation dots on the product page are affected. Carousel navigation on other pages, like the home page, is not.

As an aside, navigation with multiple rows will always seem weird, and the only well-designed solution may be a scroll bar with a variable-width handle, which Slick Carousel (which Cornerstone uses) does not implement.

#### Tickets / Documentation

- [STRF-5323](https://jira.bigcommerce.com/browse/STRF-5323)

#### Screenshots

**Product Pages Before:**

![screen shot 2018-09-20 at 2 19 34 pm](https://user-images.githubusercontent.com/1546172/45848247-a021ca80-bce2-11e8-8b2e-028d962af3c6.png)
![screen shot 2018-09-20 at 2 19 39 pm](https://user-images.githubusercontent.com/1546172/45848248-a021ca80-bce2-11e8-98f7-139aaf69b5bd.png)
![screen shot 2018-09-20 at 2 19 43 pm](https://user-images.githubusercontent.com/1546172/45848249-a021ca80-bce2-11e8-8f05-8b16ed0ad0dd.png)

**Product Pages After:**

![screen shot 2018-09-20 at 2 20 28 pm](https://user-images.githubusercontent.com/1546172/45848268-a9129c00-bce2-11e8-8ad6-8a8f0bfc3344.png)
![screen shot 2018-09-20 at 2 20 31 pm](https://user-images.githubusercontent.com/1546172/45848269-a9129c00-bce2-11e8-92f3-9c0f48537173.png)
![screen shot 2018-09-20 at 2 20 34 pm](https://user-images.githubusercontent.com/1546172/45848270-a9129c00-bce2-11e8-9426-0eafea19dfa1.png)

**Narrow Product Page After:**

![screen shot 2018-09-20 at 2 28 23 pm](https://user-images.githubusercontent.com/1546172/45848279-add75000-bce2-11e8-948c-0535618687fd.png)