### PR TITLE
taruntds's "Added "activePage" as a active class in navigation menu and web pages"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix carousel dots overlapping thumbnails on Product page. [#1351](https://github.com/bigcommerce/cornerstone/pull/1351)
 - Cornerstone schema updates and organization [#1350](https://github.com/bigcommerce/cornerstone/pull/1350)
 - Add div and id attributes so that contact form steps can be tracked [#1317](https://github.com/bigcommerce/cornerstone/pull/1317)
+- Added "activePage" as a active class in navigation menus and web pages. [#1354](https://github.com/bigcommerce/cornerstone/pull/1354)
 
 ## 2.4.0 (2018-09-14)
 - Fix encoding issues on Account Signup Form ("&#039;" characters showing in country name)[#1341] (https://github.com/bigcommerce/cornerstone/pull/1341)

--- a/assets/scss/components/stencil/navPages/_navPages.scss
+++ b/assets/scss/components/stencil/navPages/_navPages.scss
@@ -209,7 +209,7 @@
         }
     }
 
-    &:hover {
+    &:hover, &.activePage {
         color: stencilColor("navPages-color-hover");
 
         // scss-lint:disable NestingDepth

--- a/templates/components/common/navigation-dropdown.html
+++ b/templates/components/common/navigation-dropdown.html
@@ -6,12 +6,12 @@
         {{#each children}}
             <li class="navPage-subMenu-item-child">
                 {{#if children}}
-                    <a class="navPage-subMenu-action navPages-action navPages-action-depth-max has-subMenu" href="{{url}}" data-collapsible="navPages-{{id}}">
+                    <a class="navPage-subMenu-action navPages-action navPages-action-depth-max has-subMenu{{#if is_active}} activePage{{/if}}" href="{{url}}" data-collapsible="navPages-{{id}}">
                         {{name}} <i class="icon navPages-action-moreIcon" aria-hidden="true"><svg><use xlink:href="#icon-chevron-down" /></svg></i>
                     </a>
                     {{> components/common/navigation-dropdown}}
                 {{else}}
-                    <a class="navPage-subMenu-action navPages-action" href="{{url}}">{{name}}</a>
+                    <a class="navPage-subMenu-action navPages-action{{#if is_active}} activePage{{/if}}" href="{{url}}">{{name}}</a>
                 {{/if}}
             </li>
         {{/each}}

--- a/templates/components/common/navigation-list-alternate.html
+++ b/templates/components/common/navigation-list-alternate.html
@@ -1,8 +1,8 @@
 {{#if children}}
-    <a class="navPages-action navPages-action-depth-max has-subMenu is-root" href="{{url}}" data-collapsible="navPages-{{id}}">
+    <a class="navPages-action navPages-action-depth-max has-subMenu is-root{{#if is_active}} activePage{{/if}}" href="{{url}}" data-collapsible="navPages-{{id}}">
         {{name}} <i class="icon navPages-action-moreIcon" aria-hidden="true"><svg><use xlink:href="#icon-chevron-down" /></svg></i>
     </a>
     {{> components/common/navigation-dropdown}}
 {{else}}
-    <a class="navPages-action" href="{{url}}">{{name}}</a>
+    <a class="navPages-action{{#if is_active}} activePage{{/if}}" href="{{url}}">{{name}}</a>
 {{/if}}

--- a/templates/components/common/navigation-list.html
+++ b/templates/components/common/navigation-list.html
@@ -1,5 +1,5 @@
 {{#if children}}
-<a class="navPages-action has-subMenu" href="{{url}}" data-collapsible="navPages-{{id}}">
+<a class="navPages-action has-subMenu{{#if is_active}} activePage{{/if}}" href="{{url}}" data-collapsible="navPages-{{id}}">
     {{name}} <i class="icon navPages-action-moreIcon" aria-hidden="true"><svg><use xlink:href="#icon-chevron-down" /></svg></i>
 </a>
 <div class="navPage-subMenu" id="navPages-{{id}}" aria-hidden="true" tabindex="-1">
@@ -11,7 +11,7 @@
             <li class="navPage-subMenu-item">
                 {{#if children}}
                     <a
-                        class="navPage-subMenu-action navPages-action has-subMenu"
+                        class="navPage-subMenu-action navPages-action has-subMenu{{#if is_active}} activePage{{/if}}"
                         href="{{url}}"
                         data-collapsible="navPages-{{id}}"
                         data-collapsible-disabled-breakpoint="medium"
@@ -22,17 +22,17 @@
                     <ul class="navPage-childList" id="navPages-{{id}}">
                         {{#each children}}
                         <li class="navPage-childList-item">
-                            <a class="navPage-childList-action navPages-action" href="{{url}}">{{name}}</a>
+                            <a class="navPage-childList-action navPages-action{{#if is_active}} activePage{{/if}}" href="{{url}}">{{name}}</a>
                         </li>
                         {{/each}}
                     </ul>
                 {{else}}
-                    <a class="navPage-subMenu-action navPages-action" href="{{url}}">{{name}}</a>
+                    <a class="navPage-subMenu-action navPages-action{{#if is_active}} activePage{{/if}}" href="{{url}}">{{name}}</a>
                 {{/if}}
             </li>
         {{/each}}
     </ul>
 </div>
 {{else}}
-<a class="navPages-action" href="{{url}}">{{name}}</a>
+<a class="navPages-action{{#if is_active}} activePage{{/if}}" href="{{url}}">{{name}}</a>
 {{/if}}

--- a/templates/components/common/navigation-menu.html
+++ b/templates/components/common/navigation-menu.html
@@ -16,7 +16,7 @@
         {{#unless theme_settings.hide_content_navigation}}
             {{#each pages}}
                  <li class="navPages-item navPages-item-page">
-                     <a class="navPages-action" href="{{url}}">{{name}}</a>
+                     <a class="navPages-action{{#if name '==' ../page.title}} activePage{{/if}}" href="{{url}}">{{name}}</a>
                  </li>
              {{/each}}
         {{/unless}}


### PR DESCRIPTION
#### What?

A new PR for #1335 

> activePage is a active class which will be applied when any page is active. For example. If you visit any category page then this "activePage" class will be activated and that particular category name will be highlighted in different color.

The active page has the same styling as a navigation link on hover.

#### Tickets / Documentation

#1335 

#### Screenshots

##### Category Page (Bath):

Before:
![screen shot 2018-09-21 at 1 15 08 pm](https://user-images.githubusercontent.com/1546172/45904956-898f7800-bda3-11e8-9c4d-cefbcf77c372.png)

After:
![screen shot 2018-09-21 at 1 17 05 pm](https://user-images.githubusercontent.com/1546172/45904961-8c8a6880-bda3-11e8-8e66-b5e4e1e31793.png)

##### Narrow Category Page (Publications):

Before:
![screen shot 2018-09-21 at 1 36 45 pm](https://user-images.githubusercontent.com/1546172/45904976-99a75780-bda3-11e8-9743-0626f7c03e68.png)

After:
![screen shot 2018-09-21 at 1 33 46 pm](https://user-images.githubusercontent.com/1546172/45904986-9d3ade80-bda3-11e8-8366-e8357ccea13b.png)

##### Nested Category Page (Shop All > Bath):

Before:
![screen shot 2018-09-21 at 1 21 35 pm](https://user-images.githubusercontent.com/1546172/45904999-a5931980-bda3-11e8-94a7-228037f85b42.png)

After:
![screen shot 2018-09-21 at 1 22 07 pm](https://user-images.githubusercontent.com/1546172/45905003-a926a080-bda3-11e8-820a-a042b3e8e951.png)

##### Narrow Nested Category Page (Shop All > Bath):

Before:
![screen shot 2018-09-21 at 1 36 37 pm](https://user-images.githubusercontent.com/1546172/45905021-c0658e00-bda3-11e8-8579-c905a4d5e317.png)

After:
![screen shot 2018-09-21 at 1 33 39 pm](https://user-images.githubusercontent.com/1546172/45905025-c491ab80-bda3-11e8-8302-fab27866a954.png)
