### PR TITLE
STRF-5475 Stop lazyloading store logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add div and id attributes so that contact form steps can be tracked [#1317](https://github.com/bigcommerce/cornerstone/pull/1317)
 - Added "activePage" as a active class in navigation menus and web pages. [#1354](https://github.com/bigcommerce/cornerstone/pull/1354)
 - Added hidden field for checkboxes with a "No" value. [#1355](https://github.com/bigcommerce/cornerstone/pull/1355)
+- Stop lazyloading store logo [#1357](https://github.com/bigcommerce/cornerstone/pull/1357)
 
 ## 2.4.0 (2018-09-14)
 - Fix encoding issues on Account Signup Form ("&#039;" characters showing in country name)[#1341] (https://github.com/bigcommerce/cornerstone/pull/1341)

--- a/templates/components/common/store-logo.html
+++ b/templates/components/common/store-logo.html
@@ -4,7 +4,7 @@
             <img class="header-logo-image-unknown-size" src="{{getImage settings.store_logo.image 'logo_size'}}" alt="{{settings.store_logo.title}}" title="{{settings.store_logo.title}}">
         {{else}}
             <div class="header-logo-image-container">
-                <img class="header-logo-image lazyload" data-sizes="auto" src="{{cdn 'img/loading.svg'}}" data-src="{{getImage settings.store_logo.image 'logo_size'}}" alt="{{settings.store_logo.title}}" title="{{settings.store_logo.title}}">
+                <img class="header-logo-image" src="{{getImage settings.store_logo.image 'logo_size'}}" alt="{{settings.store_logo.title}}" title="{{settings.store_logo.title}}">
             </div>
         {{/if}}
     {{else}}


### PR DESCRIPTION
#### What?

The logo is high priority content and need not be lazyloaded. In fact, it could benefit from preloading.

-Remove lazyload capability on logo image
~-If the logo _is_ an image, preload it~ will do this later

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [STRF-5475](https://jira.bigcommerce.com/browse/STRF-5475)

ping @mattolson @junedkazi @bc-zoharmuzafi 
