### PR TITLE
Update lazysizes to 4.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added "activePage" as a active class in navigation menus and web pages. [#1354](https://github.com/bigcommerce/cornerstone/pull/1354)
 - Added hidden field for checkboxes with a "No" value. [#1355](https://github.com/bigcommerce/cornerstone/pull/1355)
 - Stop lazyloading store logo [#1357](https://github.com/bigcommerce/cornerstone/pull/1357)
+- Update lazysizes plugin to 4.1.2 [#1358](https://github.com/bigcommerce/cornerstone/pull/1358)
 
 ## 2.4.0 (2018-09-14)
 - Fix encoding issues on Account Signup Form ("&#039;" characters showing in country name)[#1341] (https://github.com/bigcommerce/cornerstone/pull/1341)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "jquery": "^3.3.1",
     "jquery-migrate": "^1.4.1",
     "jstree": "vakata/jstree",
-    "lazysizes": "3.0.0",
+    "lazysizes": "4.1.2",
     "lodash": "^4.17.4",
     "nod-validate": "^2.0.12",
     "pace": "hubspot/pace#a03f1f1de62c9cea6c88b2267b8d7a83858b6cb6",


### PR DESCRIPTION
#### What?

This plugin is about 18 months out of date, the latest versions have some valuable fixes especially for iOS.
