### PR TITLE
PAYMENTS-3071 Add the schema and config options for paypal smart button configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Stop lazyloading store logo [#1357](https://github.com/bigcommerce/cornerstone/pull/1357)
 - Update lazysizes plugin to 4.1.2 [#1358](https://github.com/bigcommerce/cornerstone/pull/1358)
 - Improve performance of first carousel slide [#1356](https://github.com/bigcommerce/cornerstone/pull/1356)
+- Add support for Paypal smart buttons settings [#1359](https://github.com/bigcommerce/cornerstone/pull/1359)
 
 ## 2.4.0 (2018-09-14)
 - Fix encoding issues on Account Signup Form ("&#039;" characters showing in country name)[#1341] (https://github.com/bigcommerce/cornerstone/pull/1341)

--- a/config.json
+++ b/config.json
@@ -294,7 +294,14 @@
     "pdp-price-label": "",
     "pdp-sale-price-label": "Now:",
     "pdp-non-sale-price-label": "Was:",
-    "pdp-retail-price-label": "MSRP:"
+    "pdp-retail-price-label": "MSRP:",
+    "paymentbuttons-paypal-layout": "horizontal",
+    "paymentbuttons-paypal-color": "gold",
+    "paymentbuttons-paypal-shape": "pill",
+    "paymentbuttons-paypal-size": "small",
+    "paymentbuttons-paypal-label": "checkout",
+    "paymentbuttons-paypal-tagline": true,
+    "paymentbuttons-paypal-fundingicons": false
   },
   "read_only_files": [
     "/assets/scss/components/citadel",

--- a/schema.json
+++ b/schema.json
@@ -2619,5 +2619,127 @@
         "id": "optimizedCheckout-loadingToaster-textColor"
       }
     ]
+  },
+  {
+      "name": "Payment Buttons",
+      "enable": "smartButtons",
+      "settings": [
+          {
+              "type": "select",
+              "label": "Layout",
+              "id": "paymentbuttons-paypal-layout",
+              "force_reload": true,
+              "options": [
+                {
+                  "value": "horizontal",
+                  "label": "Horizontal"
+                },
+                {
+                  "value": "vertical",
+                  "label": "Vertical"
+                }
+              ]
+          },
+          {
+              "type": "select",
+              "label": "Color",
+              "id": "paymentbuttons-paypal-color",
+              "force_reload": true,
+              "options": [
+                {
+                  "value": "gold",
+                  "label": "Gold"
+                },
+                {
+                  "value": "blue",
+                  "label": "Blue"
+                },
+                {
+                  "value": "silver",
+                  "label": "Silver"
+                },
+                {
+                  "value": "black",
+                  "label": "Black"
+                }
+              ]
+          },
+          {
+              "type": "select",
+              "label": "Shape",
+              "id": "paymentbuttons-paypal-shape",
+              "force_reload": true,
+              "options": [
+                {
+                  "value": "pill",
+                  "label": "Pill"
+                },
+                {
+                  "value": "rect",
+                  "label": "Rectangle"
+                }
+              ]
+          },
+          {
+              "type": "select",
+              "label": "Size",
+              "id": "paymentbuttons-paypal-size",
+              "force_reload": true,
+              "options": [
+                {
+                  "value": "small",
+                  "label": "Small"
+                },
+                {
+                  "value": "medium",
+                  "label": "Medium"
+                },
+                {
+                  "value": "large",
+                  "label": "Large"
+                },
+                {
+                  "value": "responsive",
+                  "label": "Responsive"
+                }
+              ]
+          },
+          {
+              "type": "select",
+              "label": "Display Label",
+              "id": "paymentbuttons-paypal-label",
+              "force_reload": true,
+              "options": [
+                {
+                  "value": "checkout",
+                  "label": "Paypal Checkout"
+                },
+                {
+                  "value": "pay",
+                  "label": "Pay with Paypal"
+                },
+                {
+                  "value": "buynow",
+                  "label": "Buy Now"
+                },
+                {
+                  "value": "paypal",
+                  "label": "Paypal"
+                }
+              ]
+          },
+          {
+              "type": "checkbox",
+              "label": "Display the Paypal Tagline",
+              "force_reload": true,
+              "id": "paymentbuttons-paypal-tagline"
+          },
+          {
+              "type": "checkbox",
+              "label": "Display the Funding Icons",
+              "force_reload": true,
+              "id": "paymentbuttons-paypal-fundingicons"
+          }
+      ]
   }
 ]


### PR DESCRIPTION
#### What?

This adds support for customizing the look and feel of the Paypal and Braintree checkout buttons on the cart (and other) pages. Some of the options are mutually exclusive, but there's currently no way to represent that in the schema--those mutually exclusive options will simply fail to render buttons on the page, so it falls on the merchant to discover that their payment buttons don't render and select options that do. This new section is hidden when the merchant does not have Paypal or Braintree enabled as a payment gateway.

#### Tickets / Documentation

- [PAYMENTS-3071](https://jira.bigcommerce.com/browse/PAYMENTS-3071)

#### Screenshots (if appropriate)

<img width="583" alt="screen shot 2018-09-24 at 11 35 39 am" src="https://user-images.githubusercontent.com/715922/45971504-06ae2d80-bfee-11e8-80f3-a079e8495032.png">
