### PR TITLE
Fix errors in breadcrumb schema markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fix broken breadcrumb schema markup [#1362](https://github.com/bigcommerce/cornerstone/pull/1362)
 
 ## 2.5.0 (2018-09-26)
 - Blueprint for Mapping Custom Templates to JavaScript Modules [#1346](https://github.com/bigcommerce/cornerstone/pull/1346)

--- a/templates/components/common/breadcrumbs.html
+++ b/templates/components/common/breadcrumbs.html
@@ -2,8 +2,9 @@
     {{#each breadcrumbs}}
         <li class="breadcrumb {{#if @last}}is-active{{/if}}" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
             {{#if url}}
-                <a href="{{url}}" class="breadcrumb-label" itemprop="item">{{name}}</a>
+                <a href="{{url}}" class="breadcrumb-label" itemprop="item"><span itemprop="name">{{name}}</span></a>
             {{else}}
+                <meta itemprop="item" content="{{url}}">
                 <span class="breadcrumb-label" itemprop="name">{{name}}</span>
             {{/if}}
             <meta itemprop="position" content="{{@index}}" />


### PR DESCRIPTION
#### What?

In late August, Google updated how they processed breadcrumbs, causing schema markup to begin throwing errors when you run a site through their structured data testing tool.

### _**Notice:**_
**While this PR resolves those errors, it will require `{{url}}` being made available for the last [Breadcrumbs Object](https://stencil.bigcommerce.com/docs/breadcrumbs-object)** I'm not sure what that would take on your guys end, but here's the code that will help cross the finish line once that's made available.

#### Screenshots

**Before**
<img width="995" alt="1 before" src="https://user-images.githubusercontent.com/5056945/46102074-502f8180-c182-11e8-9cee-9b50a15b9844.png">

**With the fix, not quite fully resolved.**
<img width="985" alt="2 almost" src="https://user-images.githubusercontent.com/5056945/46102077-53c30880-c182-11e8-8a02-92162171a639.png">

**With the fix and a URL plugged into the meta tag, fully resolving the errors thrown.**
<img width="985" alt="3 done" src="https://user-images.githubusercontent.com/5056945/46102082-57568f80-c182-11e8-96c5-3721db9da1ec.png">