### PR TITLE
Fix spacing with SweetAlert cancel button on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Fix broken breadcrumb schema markup [#1362](https://github.com/bigcommerce/cornerstone/pull/1362)
 - Add option to disable arrows on the homepage carousel [#1293](https://github.com/bigcommerce/cornerstone/pull/1293)
+- Fix spacing with SweetAlert cancel button on mobile [#1363](https://github.com/bigcommerce/cornerstone/pull/1363)
 
 ## 2.5.0 (2018-09-26)
 - Blueprint for Mapping Custom Templates to JavaScript Modules [#1346](https://github.com/bigcommerce/cornerstone/pull/1346)

--- a/assets/scss/components/vendor/sweetalert2/_sweetalert2.scss
+++ b/assets/scss/components/vendor/sweetalert2/_sweetalert2.scss
@@ -79,10 +79,6 @@
         background-color: $alert-button-cancel-bgColor;
         border-color: $alert-button-cancel-borderColor;
         color: $alert-button-cancel-color;
-
-        @include breakpoint("xsmall") {
-            margin-left: $button-adjacentButton-marginLeft;
-        }
     }
 
     .swal2-cancel:focus,
@@ -96,5 +92,9 @@
         background-color: $alert-button-cancel-bgColorActive;
         border-color: $alert-button-cancel-borderColorActive;
         color: $alert-button-cancel-colorActive;
+    }
+
+    .button + .button {
+        margin-left: $button-adjacentButton-marginLeft;
     }
 }


### PR DESCRIPTION
#### What?

Spacing next to the cancel button on sweetalert2 modal notices was set to 0 on mobile. This PR adds a little breathing room next to the cancel button.

#### Tickets / Documentation

#1352 

#### Screenshots

**BEFORE**
<img width="512" alt="01 before" src="https://user-images.githubusercontent.com/5056945/46108242-69402e80-c192-11e8-8a0a-a9628f4f3ebe.png">

**AFTER**
<img width="512" alt="02 after" src="https://user-images.githubusercontent.com/5056945/46108243-69402e80-c192-11e8-9186-bfb305e52fcf.png">
