### PR TITLE
Product review modal error message is now accurate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Product review modal error message is now accurate. [#1370](https://github.com/bigcommerce/cornerstone/pull/1370)
 
 ## 2.5.1 (2018-10-10)
 - Fix broken breadcrumb schema markup [#1362](https://github.com/bigcommerce/cornerstone/pull/1362)

--- a/assets/js/theme/product/reviews.js
+++ b/assets/js/theme/product/reviews.js
@@ -65,11 +65,11 @@ export default class {
             errorMessage: this.context.reviewRating,
         }, {
             selector: '[name="revtitle"]',
-            validate: 'min-length:2',
+            validate: 'presence',
             errorMessage: this.context.reviewSubject,
         }, {
             selector: '[name="revtext"]',
-            validate: 'min-length:2',
+            validate: 'presence',
             errorMessage: this.context.reviewComment,
         }, {
             selector: '[name="email"]',


### PR DESCRIPTION
#### What?

The product review modal currently returns an error message that fields are blank during pre-submit form field validation. This happens when the Subject and Comments fields have entries with 1 character. Code-wise, validation only passes when there is an input of minimum length 2.

This PR changes this so that the error message is accurate. If the forms are blank, the error message about form fields being blank will appear. If the forms are not blank, they won't.

#### Screenshots

##### Before

![before](https://user-images.githubusercontent.com/1546172/46837694-3342a300-cd6b-11e8-9c64-fd1036606915.gif)

##### After

![after](https://user-images.githubusercontent.com/1546172/46837699-376ec080-cd6b-11e8-977a-b9d88fd2014c.gif)