### PR TITLE
MERC-4196: Fixes issue with Slick slider for mobile safari

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ assets/js/bundle.js
 assets/dist
 *.js.map
 *.zip
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Product review modal error message is now accurate. [#1370](https://github.com/bigcommerce/cornerstone/pull/1370)
+- Fixes issue with Slick slider for mobile safari in iframe [#1371](https://github.com/bigcommerce/cornerstone/pull/1371)
 
 ## 2.5.1 (2018-10-10)
 - Fix broken breadcrumb schema markup [#1362](https://github.com/bigcommerce/cornerstone/pull/1362)

--- a/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
+++ b/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
@@ -18,6 +18,8 @@
 // -----------------------------------------------------------------------------
 
 .heroCarousel {
+    width: 1px;
+    min-width: 100%;
     margin-bottom: (spacing("double") + spacing("single"));
     margin-top: -(spacing("single")); // 3
 

--- a/assets/scss/components/stencil/productCarousel/_productCarousel.scss
+++ b/assets/scss/components/stencil/productCarousel/_productCarousel.scss
@@ -9,6 +9,8 @@
 // -----------------------------------------------------------------------------
 
 .productCarousel { // 1
+    width: 1px;
+    min-width: 100%;
     @include grid-row(
         $behavior: nest
     );

--- a/templates/components/products/carousel.html
+++ b/templates/components/products/carousel.html
@@ -3,31 +3,8 @@
         "dots": true,
         "infinite": false,
         "mobileFirst": true,
-        "slidesToShow": 2,
-        "slidesToScroll": 2,
-        "responsive": [
-            {
-                "breakpoint": 1260,
-                "settings": {
-                    "slidesToScroll": 3,
-                    "slidesToShow": {{ columns }}
-                }
-            },
-            {
-                "breakpoint": 800,
-                "settings": {
-                    "slidesToScroll": 3,
-                    "slidesToShow": 5
-                }
-            },
-            {
-                "breakpoint": 550,
-                "settings": {
-                    "slidesToScroll": 3,
-                    "slidesToShow": 3
-                }
-            }
-        ]
+        "slidesToShow": {{ columns }},
+        "slidesToScroll": 3
     }'
 >
     {{#each products}}


### PR DESCRIPTION
#### What?

Loading Cornerstone inside an iframe on mobile safari will cause your web browser to become unresponsive. 

There look to be multiple issues at play, the first being some css changes as suggested in the linked ticket. I have also tracked down the setting which is causing another issue, it looks like something in this [block of code](https://github.com/kenwheeler/slick/blob/master/slick/slick.js#L595) is breaking on mobile safari in an iframe. 

You can reproduce this issue in isolation using the following codepen example.

Using the iPad emulator in xcode, open safari and navigate to the following page.

- https://codepen.io/pingoo/pen/BRVPxQ

Compare results against desktop web browser.

#### Tickets / Documentation

There is an open issue on Slick, the open source slider we are using.

- [kenwheeler/slick#2834](https://github.com/kenwheeler/slick/issues/2834)

#### Screenshots

Before:
<img width="964" alt="screen shot 2018-10-11 at 8 30 06 pm" src="https://user-images.githubusercontent.com/955777/46846460-a0b6f980-cd94-11e8-8bbb-0c3703002882.png">

After:
<img width="964" alt="screen shot 2018-10-11 at 8 30 44 pm" src="https://user-images.githubusercontent.com/955777/46846473-a90f3480-cd94-11e8-90f2-ddee3f61ab17.png">

