### PR TITLE
Remove Oswald logo font to reduce number of unique fonts, improve pe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Draft
 - Remove unnecessary API call to get cookie notification status [#1380](https://github.com/bigcommerce/cornerstone/pull/1380)
 - Cart switch from quote item hash to id which is immutable [#1387](https://github.com/bigcommerce/cornerstone/pull/1387)
-
+- Remove extra font only used for textual store logo. [#1375](https://github.com/bigcommerce/cornerstone/pull/1375)
 
 ## 2.6.0 (2018-11-05)
 - Add support for Card Management: List, Delete, Edit, Add and Default Payment Method [#1376](https://github.com/bigcommerce/cornerstone/pull/1376)

--- a/assets/scss/layouts/header/_header.scss
+++ b/assets/scss/layouts/header/_header.scss
@@ -119,8 +119,8 @@
     display: block;
     font-family: $fontFamily-hero;
     font-size: $fontSize-logo-small;   // 1
-    font-weight: stencilFontWeight("logo-font");
-    letter-spacing: remCalc(5px);
+    font-weight: stencilFontWeight("headings-font");
+    letter-spacing: remCalc(2px);
     margin-left: auto;
     margin-right: auto;
     overflow: hidden;
@@ -131,7 +131,6 @@
 
     @include breakpoint("small") {
         font-size: $fontSize-logo-medium;
-        letter-spacing: remCalc(9px);
         padding-bottom: 0;
         padding-top: 0;
     }
@@ -140,7 +139,7 @@
         display: inline;
         font-size: $fontSize-logo-large;
         margin-left: 0;
-        margin-right: -(remCalc(9px)); // 3
+        margin-right: -(remCalc(2px)); // 3
         max-width: none;
         overflow: auto;
         white-space: normal;

--- a/assets/scss/settings/global/typography/_typography.scss
+++ b/assets/scss/settings/global/typography/_typography.scss
@@ -26,7 +26,7 @@ $fontFamily-serif:              null;
 $fontFamily-mono:               null;
 $fontFamily-headings:           stencilFontFamily("headings-font"), Arial, Helvetica, sans-serif;
 
-$fontFamily-hero:               stencilFontFamily("logo-font"), Arial, Helvetica, sans-serif;
+$fontFamily-hero:               stencilFontFamily("headings-font"), Arial, Helvetica, sans-serif;
 
 
 // Font sizes

--- a/config.json
+++ b/config.json
@@ -78,7 +78,6 @@
     "logo-position": "center",
     "logo_size": "250x100",
     "logo_fontSize": 28,
-    "logo-font": "Google_Oswald_300",
     "brand_size": "190x250",
     "gallery_size": "300x300",
     "productgallery_size": "500x659",

--- a/schema.json
+++ b/schema.json
@@ -510,23 +510,6 @@
         ]
       },
       {
-        "type": "font",
-        "label": "Logo font family",
-        "id": "logo-font",
-        "options": [
-          {
-            "group": "Oswald",
-            "label": "Oswald",
-            "value": "Google_Oswald_400"
-          },
-          {
-            "group": "Oswald",
-            "label": "Oswald Light",
-            "value": "Google_Oswald_300"
-          }
-        ]
-      },
-      {
         "type": "select",
         "label": "Logo font size",
         "id": "logo_fontSize",

--- a/templates/components/amp/css/header.html
+++ b/templates/components/amp/css/header.html
@@ -42,10 +42,10 @@
 
 .amp-header-logo-text {
     display: block;
-    font-family: "Oswald", Arial, Helvetica, sans-serif;
+    font-family: "Montserrat", Arial, Helvetica, sans-serif;
     font-size: 20px;
     font-weight: 300;
-    letter-spacing: .35714rem;
+    letter-spacing: .15714rem;
     margin-left: auto;
     margin-right: auto;
     overflow: hidden;

--- a/templates/layout/amp.html
+++ b/templates/layout/amp.html
@@ -10,7 +10,7 @@
         {{{ head.config }}}
         {{#block "head"}} {{/block}}
         <link href="{{ head.favicon }}" rel="shortcut icon">
-        <link href="https://fonts.googleapis.com/css?family=Karla:400|Montserrat:400|Oswald:300" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Karla:400|Montserrat:400" rel="stylesheet">
         {{#block "amp-style"}} {{/block}}
         {{{head.rsslinks}}}
         {{inject 'themeSettings' theme_settings}}


### PR DESCRIPTION
…rformance

#### What?

Most stores will upload a logo image, so having a unique font just for the text logo is a waste of bandwidth in the browser.

Changing logo font to one of the existing fonts to reduce download and lookups of fonts.

#### Tickets / Documentation

- [STRF-4616](https://jira.bigcommerce.com/browse/STRF-4616)

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/8922457/47818168-bcb71680-dd14-11e8-8eba-42bff4cac523.png)

