### PR TITLE
STRF-5640 - Load cart quantity in FE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - shotaK's Add context to the menu collapsible factory target elements [#1382](https://github.com/bigcommerce/cornerstone/pull/1382)
 - Added default rule for product carousel card title to break words on overflow. [#1389](https://github.com/bigcommerce/cornerstone/pull/1389)
 - Only show cookie privacy notice for EU IP addresses [#1381](https://github.com/bigcommerce/cornerstone/pull/1381)
+- Move Cart Quantity header value to a FE API call [#1379](https://github.com/bigcommerce/cornerstone/pull/1379)
 
 ## 2.6.0 (2018-11-05)
 - Add support for Card Management: List, Delete, Edit, Add and Default Payment Method [#1376](https://github.com/bigcommerce/cornerstone/pull/1376)

--- a/assets/js/theme/global.js
+++ b/assets/js/theme/global.js
@@ -24,11 +24,11 @@ export default class Global extends PageManager {
         window.lazySizesConfig = window.lazySizesConfig || {};
         window.lazySizesConfig.loadMode = 1;
 
+        cartPreview(this.context.secureBaseUrl);
         quickSearch();
         currencySelector();
         foundation($(document));
         quickView(this.context);
-        cartPreview();
         compareProducts(this.context.urls);
         carousel();
         menu();

--- a/assets/js/theme/global/cart-preview.js
+++ b/assets/js/theme/global/cart-preview.js
@@ -8,13 +8,15 @@ export const CartPreviewEvents = {
     open: 'opened.fndtn.dropdown',
 };
 
-export default function () {
+export default function (secureBaseUrl) {
     const loadingClass = 'is-loading';
     const $cart = $('[data-cart-preview]');
     const $cartDropdown = $('#cart-preview-dropdown');
     const $cartLoading = $('<div class="loadingOverlay"></div>');
 
-    $('body').on('cart-quantity-update', (event, quantity) => {
+    const $body = $('body');
+
+    $body.on('cart-quantity-update', (event, quantity) => {
         $('.cart-quantity')
             .text(quantity)
             .toggleClass('countPill--positive', quantity > 0);
@@ -48,5 +50,33 @@ export default function () {
             $cartLoading
                 .hide();
         });
+    });
+
+    let quantity = 0;
+
+    // Get existing quantity from localStorage if found
+    if (utils.tools.storage.localStorageAvailable()) {
+        if (localStorage.getItem('cart-quantity')) {
+            quantity = Number(localStorage.getItem('cart-quantity'));
+            $body.trigger('cart-quantity-update', quantity);
+        }
+    }
+
+    // Get updated cart quantity from the Cart API
+    const cartQtyPromise = new Promise((resolve, reject) => {
+        utils.api.cart.getCartQuantity({ baseUrl: secureBaseUrl }, (err, qty) => {
+            if (err) {
+                reject(err);
+            }
+            resolve(qty);
+        });
+    });
+
+    // If the Cart API gives us a different quantity number, update it
+    cartQtyPromise.then(qty => {
+        $body.trigger('cart-quantity-update', qty);
+        if (utils.tools.storage.localStorageAvailable()) {
+            localStorage.setItem('cart-quantity', qty);
+        }
     });
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "BigCommerce",
   "license": "MIT",
   "dependencies": {
-    "@bigcommerce/stencil-utils": "^2.0.0",
+    "@bigcommerce/stencil-utils": "^4.0.0",
     "babel-polyfill": "^6.26.0",
     "creditcards": "^3.0.1",
     "easyzoom": "^2.5.0",

--- a/templates/components/common/navigation.html
+++ b/templates/components/common/navigation.html
@@ -50,7 +50,7 @@
                 data-dropdown="cart-preview-dropdown"
                 data-options="align:right"
                 href="{{urls.cart}}">
-                <span class="navUser-item-cartLabel">{{lang 'common.cart'}}</span> <span class="countPill{{#if cart.items}} countPill--positive{{/if}} cart-quantity">{{cart.quantity}}</span>
+                <span class="navUser-item-cartLabel">{{lang 'common.cart'}}</span> <span class="countPill cart-quantity"></span>
             </a>
 
             <div class="dropdown-menu" id="cart-preview-dropdown" data-dropdown-content aria-hidden="true"></div>

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -25,6 +25,7 @@
         {{inject 'genericError' (lang 'common.generic_error')}}
         {{inject 'maintenanceMode' settings.maintenance}}
         {{inject 'urls' urls}}
+        {{inject 'secureBaseUrl' settings.secure_base_url}}
         {{inject 'template' template}}
         {{{snippet 'htmlhead'}}}
     </head>


### PR DESCRIPTION
#### What?

This is the first step in improving storefront performance by moving most/all Cart interactions to the frontend.

This change moves all functionality related to calculating the cart quantity in the header to FE API calls, after the initial HTML loads.

In future PRs, we'll be able to actually turn off the loading of Cart details in the HTML in Cornerstone, which will improve performance, especially for large carts. However, this PR does *not* disable Cart data, it simply introduces the FE behavior.

The "last known" cart quantity is cached in `localStorage` so it loads quickly when the page loads and then it's quietly updated if new information is received from the API. There is a graceful fallback if `localStorage` is unavailable in the environment or otherwise fails (e.g. if the 5MB storage limit is already reached for the domain).

#### Tickets / Documentation

- [STRF-5640](https://jira.bigcommerce.com/browse/STRF-5640)
