### PR TITLE
STRF-4612 - Remove unnecessary API call to get cookie notification st…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Remove unnecessary API call to get cookie notification status [#1380](https://github.com/bigcommerce/cornerstone/pull/1380)
 
 ## 2.6.0 (2018-11-05)
 - Add support for Card Management: List, Delete, Edit, Add and Default Payment Method [#1376](https://github.com/bigcommerce/cornerstone/pull/1376)

--- a/assets/js/theme/global/cookieNotification.js
+++ b/assets/js/theme/global/cookieNotification.js
@@ -17,15 +17,18 @@ export default function () {
     });
     */
 
-    utils.hooks.on('cookie-privacy-notification', (event) => {
-        event.preventDefault();
+    const $privacyDialog = $('.cookieMessage');
 
-        const $privacyDialog = $('.cookieMessage');
+    if (document.cookie.indexOf('ACCEPT_COOKIE_USAGE') === -1) {
         $privacyDialog.show();
+    }
 
-        $('body').on('click', '[data-privacy-accept]', () => {
-            utils.hooks.emit('cookie-privacy-accepted');
-            $privacyDialog.hide();
-        });
+    $('body').on('click', '[data-privacy-accept]', () => {
+        const date = new Date();
+        date.setDate(date.getDate() + 365);
+        document.cookie = `ACCEPT_COOKIE_USAGE=1;expires=${date.toGMTString()}; path=/`;
+
+        utils.hooks.emit('cookie-privacy-accepted');
+        $privacyDialog.hide();
     });
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "BigCommerce",
   "license": "MIT",
   "dependencies": {
-    "@bigcommerce/stencil-utils": "^1.1.2",
+    "@bigcommerce/stencil-utils": "^2.0.0",
     "babel-polyfill": "^6.26.0",
     "creditcards": "^3.0.1",
     "easyzoom": "^2.5.0",


### PR DESCRIPTION
…atus

#### What?

You can already infer the status of the cookie setting from the presence of cookie notification text; this property returns false if the setting is disabled. So this API call was unnecessary. It should probably also be deprecated and removed from stencil-utils.

This handlebars check is enough: https://github.com/bigcommerce/cornerstone/blob/master/templates/layout/base.html#L35

#### Tickets / Documentation

- [STRF-4612](https://jira.bigcommerce.com/browse/STRF-4612)

#### Dependencies

Depends on https://github.com/bigcommerce/stencil-utils/pull/87 and a stencil-utils bump

#### Video

http://recordit.co/U3qUIDCHl4
