### PR TITLE
STRF-4612 only show cookie privacy notice for EU IP addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove extra font only used for textual store logo. [#1375](https://github.com/bigcommerce/cornerstone/pull/1375)
 - shotaK's Add context to the menu collapsible factory target elements [#1382](https://github.com/bigcommerce/cornerstone/pull/1382)
 - Added default rule for product carousel card title to break words on overflow. [#1389](https://github.com/bigcommerce/cornerstone/pull/1389)
+- Only show cookie privacy notice for EU IP addresses [#1381](https://github.com/bigcommerce/cornerstone/pull/1381)
 
 ## 2.6.0 (2018-11-05)
 - Add support for Card Management: List, Delete, Edit, Add and Default Payment Method [#1376](https://github.com/bigcommerce/cornerstone/pull/1376)

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -32,9 +32,9 @@
         {{{snippet 'header'}}}
         <svg data-src="{{cdn 'img/icon-sprite.svg'}}" class="icons-svg-sprite"></svg>
 
-        {{#if settings.privacy_cookie}}
+        {{#and settings.privacy_cookie settings.is_eu_ip_address}}
             {{> components/common/cookie}}
-        {{/if}}
+        {{/and}}
 
         {{> components/common/header }}
         {{> components/common/body }}


### PR DESCRIPTION
#### What?

Depends on https://github.com/bigcommerce/bigcommerce/pull/27154 in which we surface a new key in the context indicating if the shopper has an EU IP address.

This will only show the cookie notification for those shoppers, so that you don't bug shoppers when you aren't legally required to.

Leaving this in the theme code allows the behavior to be further customized by a theme developer if desired.