### PR TITLE
shotaK's Add context to the menu collapsible factory target elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Remove unnecessary API call to get cookie notification status [#1380](https://github.com/bigcommerce/cornerstone/pull/1380)
 - Cart switch from quote item hash to id which is immutable [#1387](https://github.com/bigcommerce/cornerstone/pull/1387)
 - Remove extra font only used for textual store logo. [#1375](https://github.com/bigcommerce/cornerstone/pull/1375)
+- shotaK's Add context to the menu collapsible factory target elements [#1382](https://github.com/bigcommerce/cornerstone/pull/1382)
 
 ## 2.6.0 (2018-11-05)
 - Add support for Card Management: List, Delete, Edit, Add and Default Payment Method [#1376](https://github.com/bigcommerce/cornerstone/pull/1376)

--- a/assets/js/theme/common/collapsible.js
+++ b/assets/js/theme/common/collapsible.js
@@ -232,7 +232,7 @@ export default function collapsibleFactory(selector = `[data-${PLUGIN_KEY}]`, ov
             $toggle.data(`${PLUGIN_KEY}Target`) ||
             $toggle.attr('href'));
         const options = _.extend(optionsFromData($toggle), overrideOptions);
-        const collapsible = new Collapsible($toggle, $(targetId), options);
+        const collapsible = new Collapsible($toggle, $(targetId, overrideOptions.$context), options);
 
         $toggle.data(instanceKey, collapsible);
 


### PR DESCRIPTION
Rebased version of https://github.com/bigcommerce/cornerstone/pull/1299 by shotaK.

> #### What?
> 
> I've just duplicated a menu in `global.js` and in templates and supplied a proper context:
> 
> global.js
> ```
> menu('[data-menu]');
> menu('[data-menumobile]');
> ```
> It seemed to work fine, except when I was clicking the first menu items, the second menu items were opening. After some investigation, I've found out that the context was not specified for the targeted menu items. I've added the context to them and it worked fine.

#### Testing

This has no effect on Cornerstone as it is, but benefits anyone extending Cornerstone.

To test, make the following changes:

Change `/assets/js/theme/global.js` so that `menu()` is defined twice with two different contexts:

```
@@ -31,7 +31,8 @@ export default class Global extends PageManager {
         cartPreview();
         compareProducts(this.context.urls);
         carousel();
-        menu();
+        menu('[data-menu]');
+        menu('[data-menu-duplicate]');
         mobileMenuToggle();
         privacyCookieNotification();
         maintenanceMode(this.context.maintenanceMode);
```

Add something to `/templates/components/common/header.html` so that the second menu can be displayed:

```
@@ -28,4 +28,12 @@
     <div class="navPages-container" id="menu" data-menu>
         {{> components/common/navigation-menu}}
     </div>
+
+    <div style="height:100px">
+        <p>Some Spacing</p>
+    </div>
+
+    <div class="navPages-container" id="menu" data-menu-duplicate>
+        {{> components/common/navigation-menu-2}}
+    </div>
 </header>
```

Add a new file for that new template being referenced, `templates/components/common/navigation-menu-2.html`. Note the `something-else`, an attribute which is being used as a "tell" to verify that things are working as expected.

```
<nav class="navPages">
    <ul class="navPages-list{{#if theme_settings.navigation_design '!==' 'simple'}} navPages-list-depth-max{{/if}}">
        {{#each categories}}
            <li class="navPages-item" something-else>
                {{> components/common/navigation-list}}
            </li>
        {{/each}}    
    </ul>
</nav>
```

##### With fix:
![shotakwith](https://user-images.githubusercontent.com/1546172/49256546-27c33e00-f3e4-11e8-88b9-3e08dbf27afa.gif)

Notice how there are two menu bars, and the "duplicate" is correctly tagged with the `something-else` attribute.

##### Without fix:
![shotakwithout](https://user-images.githubusercontent.com/1546172/49256548-27c33e00-f3e4-11e8-8608-9badd6aa0cc4.gif)

Only the first menu can be accessed here. `something-else` does not appear, and only the first menu is opened and interacted with while inspecting the DOM.

##### And for good measure, Cornerstone 2.6.0 with the fix:
![cornerstonewith](https://user-images.githubusercontent.com/1546172/49256545-27c33e00-f3e4-11e8-977d-87a9f1753989.gif)


