### PR TITLE
Add optional card type validation for cvv (card managment)

### DIFF
--- a/assets/js/test-unit/theme/common/payment-method.spec.js
+++ b/assets/js/test-unit/theme/common/payment-method.spec.js
@@ -168,6 +168,22 @@ describe('PaymentMethod', () => {
 
                 expect(callback).toHaveBeenCalledWith(true);
             });
+
+            it('should have invalid input cvv for American Express', () => {
+                const callback = jasmine.createSpy();
+                const validator = { add: ({ validate }) => validate(callback, '123') };
+                Validators.setCvvValidation(validator, 'selector', null, 'American Express');
+
+                expect(callback).toHaveBeenCalledWith(false);
+            });
+
+            it('should have valid input cvv for American Express', () => {
+                const callback = jasmine.createSpy();
+                const validator = { add: ({ validate }) => validate(callback, '1234') };
+                Validators.setCvvValidation(validator, 'selector', null, () => 'American Express');
+
+                expect(callback).toHaveBeenCalledWith(true);
+            });
         });
     });
 });

--- a/assets/js/theme/account.js
+++ b/assets/js/theme/account.js
@@ -252,8 +252,9 @@ export default class Account extends PageManager {
         });
 
         // Use credit card number input listener to highlight credit card type
+        let cardType;
         $(`${paymentMethodSelector} input[name="credit_card_number"]`).on('keyup', ({ target }) => {
-            const cardType = creditCardType(target.value);
+            cardType = creditCardType(target.value);
             if (cardType) {
                 $(`${paymentMethodSelector} img[alt="${cardType}"`).siblings().css('opacity', '.2');
             } else {
@@ -265,7 +266,7 @@ export default class Account extends PageManager {
         CCValidators.setCreditCardNumberValidation(paymentMethodValidator, `${paymentMethodSelector} input[name="credit_card_number"]`, this.context.creditCardNumber);
         CCValidators.setExpirationValidation(paymentMethodValidator, `${paymentMethodSelector} input[name="expiration"]`, this.context.expiration);
         CCValidators.setNameOnCardValidation(paymentMethodValidator, `${paymentMethodSelector} input[name="name_on_card"]`, this.context.nameOnCard);
-        CCValidators.setCvvValidation(paymentMethodValidator, `${paymentMethodSelector} input[name="cvv"]`, this.context.cvv);
+        CCValidators.setCvvValidation(paymentMethodValidator, `${paymentMethodSelector} input[name="cvv"]`, this.context.cvv, () => cardType);
 
         // Set of credit card format
         CCFormatters.setCreditCardNumberFormat(`${paymentMethodSelector} input[name="credit_card_number"]`);

--- a/assets/js/theme/common/payment-method.js
+++ b/assets/js/theme/common/payment-method.js
@@ -151,6 +151,7 @@ export const Validators = {
      * Sets up a validation for credit card number
      * @param validator
      * @param field
+     * @param errorMessage
      */
     setCreditCardNumberValidation: (validator, field, errorMessage) => {
         if (field) {
@@ -170,6 +171,7 @@ export const Validators = {
      * Sets up a validation for expiration date
      * @param validator
      * @param field
+     * @param errorMessage
      */
     setExpirationValidation: (validator, field, errorMessage) => {
         if (field) {
@@ -191,6 +193,7 @@ export const Validators = {
      * Sets up a validation for name on card
      * @param validator
      * @param field
+     * @param errorMessage
      */
     setNameOnCardValidation: (validator, field, errorMessage) => {
         if (field) {
@@ -210,13 +213,16 @@ export const Validators = {
      * Sets up a validation for cvv
      * @param validator
      * @param field
+     * @param errorMessage
+     * @param {any} cardType The credit card number type
      */
-    setCvvValidation: (validator, field, errorMessage) => {
+    setCvvValidation: (validator, field, errorMessage, cardType) => {
         if (field) {
             validator.add({
                 selector: field,
                 validate: (cb, val) => {
-                    const result = val.length && creditcards.cvc.isValid(val);
+                    const type = typeof cardType === 'function' ? cardType() : cardType;
+                    const result = val.length && creditcards.cvc.isValid(val, type);
 
                     cb(result);
                 },


### PR DESCRIPTION
#### What?
- Add optional card type to CVV validation helper to enforce strong type validation.

#### Tickets / Documentation

[PAYMENT](https://jira.bigcommerce.com/browse/PAYMENTS-3723)

#### Screenshots (if appropriate)

- Wrong American Express CVV
<img width="481" alt="screen shot 2018-11-16 at 3 29 33 pm" src="https://user-images.githubusercontent.com/2579218/48598056-1e35e100-e9b5-11e8-8256-adfc73317653.png">

- Right American Express CVV
<img width="469" alt="screen shot 2018-11-16 at 3 29 46 pm" src="https://user-images.githubusercontent.com/2579218/48598070-2db52a00-e9b5-11e8-89fd-f121a4abf7d1.png">

- Wrong Visa CVV
<img width="475" alt="screen shot 2018-11-16 at 3 48 00 pm" src="https://user-images.githubusercontent.com/2579218/48598454-0b241080-e9b7-11e8-93e5-eb745d04a012.png">

- Right Visa CVV
<img width="473" alt="screen shot 2018-11-16 at 3 29 14 pm" src="https://user-images.githubusercontent.com/2579218/48598099-4e7d7f80-e9b5-11e8-8bd3-c9e72f10edd5.png">

@bigcommerce/payments @danieldelcore @bc-zoharmuzafi 
