### PR TITLE
changed access level for parent context- products list display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed compare buttons for product list display [#1384](https://github.com/bigcommerce/cornerstone/pull/1384)
 - Remove unnecessary API call to get cookie notification status [#1380](https://github.com/bigcommerce/cornerstone/pull/1380)
 - Cart switch from quote item hash to id which is immutable [#1387](https://github.com/bigcommerce/cornerstone/pull/1387)
 - Remove extra font only used for textual store logo. [#1375](https://github.com/bigcommerce/cornerstone/pull/1375)

--- a/templates/components/products/list-item.html
+++ b/templates/components/products/list-item.html
@@ -1,8 +1,8 @@
 {{#if settings.data_tag_enabled}}
     <article class="listItem" data-event-type="{{event}}" data-entity-id="{{id}}" data-position="{{position}}" data-name="{{name}}" data-product-category="{{#each category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}" data-product-brand="{{brand.name}}" data-product-price="{{#if price.with_tax}}{{price.with_tax.value}}{{else}}{{price.without_tax.value}}{{/if}}">
-        {{else}}
-    <article class="listItem" >
-        {{/if}}
+{{else}}
+    <article class="listItem">
+{{/if}}
     <figure class="listItem-figure">
         <img class="listItem-image lazyload" data-sizes="auto" src="{{cdn 'img/loading.svg'}}" data-src="{{getImage image 'productgallery_size' (cdn theme_settings.default_image_product)}}" alt="{{image.alt}}" title="{{image.alt}}">
         {{#unless hide_product_quick_view}}

--- a/templates/components/products/list.html
+++ b/templates/components/products/list.html
@@ -1,11 +1,7 @@
 <ul class="productList">
     {{#each products}}
     <li class="product">
-        {{#if settings.data_tag_enabled}}
-            {{>components/products/list-item   show_compare=../show_compare show_rating=../settings.show_product_rating theme_settings=../theme_settings customer=../customer event=../event position=(add @index 1)}}
-        {{else}}
-            {{>components/products/list-item show_compare=../show_compare show_rating=../settings.show_product_rating theme_settings=../theme_settings customer=../customer}}
-        {{/if}}
+		{{>components/products/list-item show_compare=../show_compare show_rating=../settings.show_product_rating theme_settings=../theme_settings customer=../customer event=../event settings=../settings position=(add @index 1)}}
     </li>
     {{/each}}
 </ul>


### PR DESCRIPTION
#### What?
In Cornerstone v2.6.0 compare buttons are missing from Category pages that use a List view instead of a grid.  This pr change the access level to the parent context when generating the products list display. 


#### Screenshots (if appropriate)
###### Before
<img width="1669" alt="screen shot 2018-11-16 at 3 24 11 pm" src="https://user-images.githubusercontent.com/41761536/48652544-e9298e80-e9b4-11e8-8b7c-1e54d52a3802.png">

###### After
<img width="1678" alt="screen shot 2018-11-16 at 3 24 28 pm" src="https://user-images.githubusercontent.com/41761536/48652565-fd6d8b80-e9b4-11e8-92fb-aedef2be97d8.png">


