### PR TITLE
STRF-4575 Switch from quote item hash to id which is immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Draft
 - Remove unnecessary API call to get cookie notification status [#1380](https://github.com/bigcommerce/cornerstone/pull/1380)
+- Cart switch from quote item hash to id which is immutable [#1387](https://github.com/bigcommerce/cornerstone/pull/1387)
+
 
 ## 2.6.0 (2018-11-05)
 - Add support for Card Management: List, Delete, Edit, Add and Default Payment Method [#1376](https://github.com/bigcommerce/cornerstone/pull/1376)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -380,7 +380,7 @@ export default class ProductDetails {
             if (this.previewModal) {
                 this.previewModal.open();
 
-                this.updateCartContent(this.previewModal, response.data.cart_item.hash);
+                this.updateCartContent(this.previewModal, response.data.cart_item.id);
             } else {
                 this.$overlay.show();
                 // if no modal, redirect to the cart page
@@ -392,14 +392,14 @@ export default class ProductDetails {
     /**
      * Get cart contents
      *
-     * @param {String} cartItemHash
+     * @param {String} cartItemId
      * @param {Function} onComplete
      */
-    getCartContent(cartItemHash, onComplete) {
+    getCartContent(cartItemId, onComplete) {
         const options = {
             template: 'cart/preview',
             params: {
-                suggest: cartItemHash,
+                suggest: cartItemId,
             },
             config: {
                 cart: {
@@ -430,11 +430,11 @@ export default class ProductDetails {
      * Update cart content
      *
      * @param {Modal} modal
-     * @param {String} cartItemHash
+     * @param {String} cartItemId
      * @param {Function} onComplete
      */
-    updateCartContent(modal, cartItemHash, onComplete) {
-        this.getCartContent(cartItemHash, (err, response) => {
+    updateCartContent(modal, cartItemId, onComplete) {
+        this.getCartContent(cartItemId, (err, response) => {
             if (err) {
                 return;
             }


### PR DESCRIPTION
#### What?
For some reason the quote item hash are changing. It is safer to use quote item id since it is immutable.

#### Depends On
https://github.com/bigcommerce/cornerstone/pull/1387

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [STRF-4575](https://jira.bigcommerce.com/browse/STRF-4575)

#### Screenshots (if appropriate)

Attach images 
<img width="1288" alt="screen shot 2018-11-22 at 12 30 43 am" src="https://user-images.githubusercontent.com/319659/48890516-e6340100-eded-11e8-837a-902c39646001.png">
or add image links here.
