### PR TITLE
STRF-5651: Break product card titles on overflow.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Cart switch from quote item hash to id which is immutable [#1387](https://github.com/bigcommerce/cornerstone/pull/1387)
 - Remove extra font only used for textual store logo. [#1375](https://github.com/bigcommerce/cornerstone/pull/1375)
 - shotaK's Add context to the menu collapsible factory target elements [#1382](https://github.com/bigcommerce/cornerstone/pull/1382)
+- Added default rule for product carousel card title to break words on overflow. [#1389](https://github.com/bigcommerce/cornerstone/pull/1389)
 
 ## 2.6.0 (2018-11-05)
 - Add support for Card Management: List, Delete, Edit, Add and Default Payment Method [#1376](https://github.com/bigcommerce/cornerstone/pull/1376)

--- a/assets/scss/components/stencil/productCarousel/_productCarousel.scss
+++ b/assets/scss/components/stencil/productCarousel/_productCarousel.scss
@@ -33,5 +33,9 @@
 
     .card {
         margin-bottom: 0;
+
+        .card-title {
+            overflow-wrap: break-word;
+        }
     }
 }


### PR DESCRIPTION
#### What?

Changes to the New Products carousel in 2.5.2 changed how many products appeared as the view width became narrower and narrower. Specifically, it would always try to honor the number of columns set for the theme. This means that products with long words get less and less space as the view narrows, and particularly long words start overflowing into adjacent columns.

This change forces words to break if they hit the edge of the column.

This has also been verified to *not crash* Mobile Safari, which was the reason for #1371 in the first place.

#### Tickets / Documentation

- [STRF-5651](https://jira.bigcommerce.com/browse/STRF-5651)
- #1371 

#### Screenshots (if appropriate)

##### Before:

![before](https://user-images.githubusercontent.com/1546172/49314838-8bab3c80-f4a0-11e8-8cea-9e11ad544c5e.png)

##### After:

![after](https://user-images.githubusercontent.com/1546172/49314843-906ff080-f4a0-11e8-86a0-f1146ee07190.png)
