### PR TITLE
To set proper align Product thumbnail image slider arrows

### DIFF
--- a/assets/scss/components/vendor/slick/_slick.scss
+++ b/assets/scss/components/vendor/slick/_slick.scss
@@ -22,7 +22,7 @@
     z-index: 1;
     border: 1px solid $slick-arrow-borderColor;
     height: remCalc(61px);
-    margin-top: -(remCalc(30px));
+    margin-top: -(remCalc(15px));
     padding: remCalc(10px);
     width: remCalc(40px);
 


### PR DESCRIPTION
#### What?
If a product has more then 5 images. It will create slider but there is an issue about align of the slider arrows. 

#### Screenshots (if appropriate)
**Before:** 
![image](https://user-images.githubusercontent.com/21297354/49629710-da148a00-fa10-11e8-8900-7178f23c04f9.png)

**After:**
![image](https://user-images.githubusercontent.com/21297354/49629734-003a2a00-fa11-11e8-9a9a-fb3676352a36.png)


