### PR TITLE
Disable loading of cart on non-cart pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Only show cookie privacy notice for EU IP addresses [#1381](https://github.com/bigcommerce/cornerstone/pull/1381)
 - Move Cart Quantity header value to a FE API call [#1379](https://github.com/bigcommerce/cornerstone/pull/1379)
 - Make display of quantity selection box on PDP configurable. [#1398](https://github.com/bigcommerce/cornerstone/pull/1398)
+- Don't load Cart resource on non-Cart pages [#1401](https://github.com/bigcommerce/cornerstone/pull/1401)
 
 ## 2.6.0 (2018-11-05)
 - Add support for Card Management: List, Delete, Edit, Add and Default Payment Method [#1376](https://github.com/bigcommerce/cornerstone/pull/1376)

--- a/config.json
+++ b/config.json
@@ -324,7 +324,7 @@
     "/assets/scss/vendor"
   ],
   "resources": {
-    "cart": true,
+    "cart": false,
     "bulk_discount_rates": false,
     "shop_by_brand": {
       "limit": 10

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -1,3 +1,6 @@
+---
+cart: true
+---
 {{#partial "page"}}
 <div class="page">
 


### PR DESCRIPTION
#### What?

Disable loading the Cart resource unless we're on the cart page.

This was only used for loading the "quantity in cart", but in https://github.com/bigcommerce/cornerstone/pull/1379 we now do this with a frontend API call.

Turning this off will improve performance.

ping @junedkazi - just opening this for your convenience.
