### PR TITLE
breadcrumbs last element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 
+- Fixed breadcrumbs for product and category pages [#1403](https://github.com/bigcommerce/cornerstone/pull/1403)
 - Send GA tracking event whenever the last product is removed from the CART[#1409](https://github.com/bigcommerce/cornerstone/pull/1409)
 
 ## 3.0.0 (2018-12-21)

--- a/templates/components/common/breadcrumbs.html
+++ b/templates/components/common/breadcrumbs.html
@@ -1,13 +1,13 @@
 <ul class="breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">
     {{#each breadcrumbs}}
         <li class="breadcrumb {{#if @last}}is-active{{/if}}" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-            {{#if url}}
-                <a href="{{url}}" class="breadcrumb-label" itemprop="item"><span itemprop="name">{{name}}</span></a>
-            {{else}}
+            {{#or @last (if url "==" null)}}
                 <meta itemprop="item" content="{{url}}">
                 <span class="breadcrumb-label" itemprop="name">{{name}}</span>
-            {{/if}}
-            <meta itemprop="position" content="{{@index}}" />
+            {{else}}
+                <a href="{{url}}" class="breadcrumb-label" itemprop="item"><span itemprop="name">{{name}}</span></a>
+            {{/or}}
+            <meta itemprop="position" content="{{add @index 1}}" />
         </li>
     {{/each}}
 </ul>


### PR DESCRIPTION
#### What?
Fixed the position for breadcrumb elements to start with 1. instead of 0.


#### Screenshots (if appropriate)
###### Before
<img width="785" alt="screen shot 2018-12-11 at 3 12 51 pm" src="https://user-images.githubusercontent.com/41761536/49836508-b9716a80-fd57-11e8-98e8-7216eb6a8763.png">

###### After
<img width="806" alt="screen shot 2018-12-19 at 2 05 35 pm" src="https://user-images.githubusercontent.com/41761536/50251003-51de9f00-0397-11e9-904c-74b2fae38939.png">
