### PR TITLE
Fixed the issue - sending GA event for last product removed from CART.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Draft
 
+- Send GA tracking event whenever the last product is removed from the CART[#1409](https://github.com/bigcommerce/cornerstone/pull/1409)
+
 ## 3.0.0 (2018-12-21)
 - Added defer tag to addThis and defered execution of related script [#1406](https://github.com/bigcommerce/cornerstone/pull/1406)
 - Fixed compare buttons for product list display [#1384](https://github.com/bigcommerce/cornerstone/pull/1384)

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -48,6 +48,7 @@ cart: true
             {{/if}}
         {{else}}
             <h3>{{lang 'cart.checkout.empty_cart'}}</h3>
+            {{{ remote_api_scripts }}}
         {{/if}}
 
         {{{snippet 'cart'}}}


### PR DESCRIPTION
#### What?
When cart has single product and it is removed - product removed event is not sent

#### Tickets / Documentation
https://jira.bigcommerce.com/browse/CP-4054

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/39140274/50189608-dae3d080-02da-11e9-80e9-e38f49ef1619.png)

