### PR TITLE
Bump stencil-utils to 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "BigCommerce",
   "license": "MIT",
   "dependencies": {
-    "@bigcommerce/stencil-utils": "^4.0.0",
+    "@bigcommerce/stencil-utils": "^4.0.1",
     "babel-polyfill": "^6.26.0",
     "creditcards": "^3.0.1",
     "easyzoom": "^2.5.0",


### PR DESCRIPTION
#### What?

There's a bug in stencil-utils that will be fixed by https://github.com/bigcommerce/stencil-utils/pull/95

Once it's released as 4.0.1, this PR is for the bump to that version, to address a bug in which the cart quantity update would not work on HTTP storefronts.

ping @Ubersmake 