### PR TITLE
feat(customers): CUST-391 allow enter empty phone number when updatin…

### DIFF
--- a/assets/js/theme/account.js
+++ b/assets/js/theme/account.js
@@ -379,15 +379,6 @@ export default class Account extends PageManager {
                 },
                 errorMessage: this.context.lastName,
             },
-            {
-                selector: `${formEditSelector} input[name='account_phone']`,
-                validate: (cb, val) => {
-                    const result = val.length;
-
-                    cb(result);
-                },
-                errorMessage: this.context.phoneNumber,
-            },
         ]);
 
         $editAccountForm.on('submit', event => {

--- a/templates/components/account/edit-account.html
+++ b/templates/components/account/edit-account.html
@@ -28,7 +28,6 @@
             <div class="form-field">
                 <label class="form-label" for="account_phone">
                     {{lang 'account.settings.phone' }}
-                    <small>{{lang 'common.required' }}</small>
                 </label>
                 <input type="text" class="form-input" name="account_phone" id="account_phone" value="{{forms.edit_account.phone}}">
             </div>


### PR DESCRIPTION
#### What?
allow enter empty phone number when updating account settings in storefront
#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [Jira](https://jira.bigcommerce.com/browse/CUST-391)

PR for server side which updates account validation to allow empty phone numbers https://github.com/bigcommerce/bigcommerce/pull/27974

#### Screenshots (if appropriate)

Attach images or add image links here.
![image](https://user-images.githubusercontent.com/4549842/50908408-58aa8000-1432-11e9-86b9-3b76052321db.png)

@bigcommerce/storefront-team @bigcommerce/customers 