### PR TITLE
Fix cart item quantity change rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Major performance improvements. Reduce Javascript bundle size from 376kb to 286kb. [#1390](https://github.com/bigcommerce/cornerstone/pull/1390)
 - Fixed breadcrumbs for product and category pages [#1403](https://github.com/bigcommerce/cornerstone/pull/1403)
 - Send GA tracking event whenever the last product is removed from the CART[#1409](https://github.com/bigcommerce/cornerstone/pull/1409)
+- Fix cart item quantity change rollback [#1418](https://github.com/bigcommerce/cornerstone/pull/1418)
 
 ## 3.0.0 (2018-12-21)
 ### Breaking Changes

--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -226,7 +226,7 @@ export default class Cart extends PageManager {
         });
 
         // cart qty manually updates
-        $('.cart-item-qty-input', this.$cartContent).on('focus', () => {
+        $('.cart-item-qty-input', this.$cartContent).on('focus', function onQtyFocus() {
             preVal = this.value;
         }).change(event => {
             const $target = $(event.currentTarget);


### PR DESCRIPTION
#### What?

This is a bug fix.

Context: change the quantity of a cart line item by manually editing the quantity input field value.

Currently, when a manual quantity change fails to succeed (for example, because it is greater than the maximum purchasable quantity), the quantity is reverted to **zero** in the input field.

It should rollback to the **previous value**. Not to zero.

This PR fixes this bug.

<hr>

It is quite simple to see what is the problem in the code:
- inside the quantity input `focus` event handler function, **`this`** is used as a reference to the event target element (jQuery binds the event target element to the event handler function context);
- as an **arrow function** is being used for the event handler function, `this` is **not** referencing the event target element, as it should, but the enclosing context (Cart class instance)

Thus, the fix was also quite simple: only a matter of using a normal function. This way, we have the event target element properly bound to the function's `this` context. The `preVal` (previous value) variable is properly populated with the input's value.
