### PR TITLE
changed z-index for header to higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed breadcrumbs for product and category pages [#1403](https://github.com/bigcommerce/cornerstone/pull/1403)
 - Send GA tracking event whenever the last product is removed from the CART[#1409](https://github.com/bigcommerce/cornerstone/pull/1409)
 - Fix cart item quantity change rollback [#1418](https://github.com/bigcommerce/cornerstone/pull/1418)
+- Changed z-index to higher for header [#1422](https://github.com/bigcommerce/cornerstone/pull/1422)
 
 ## 3.0.0 (2018-12-21)
 ### Breaking Changes

--- a/assets/scss/layouts/header/_header.scss
+++ b/assets/scss/layouts/header/_header.scss
@@ -21,7 +21,7 @@
     position: fixed;
     top: 0;
     width: 100%;
-    z-index: zIndex("low");
+    z-index: zIndex("higher");
 
     @include breakpoint("medium") {
         border-bottom: container("border");


### PR DESCRIPTION
#### What?
Currently the sale badge floats above menu on mobile. This change should make the header class higher than sale badge and the badge won't floats above menu on mobile.

#### Screenshots (if appropriate)
###### Before
<img width="481" alt="screen shot 2019-01-15 at 2 39 06 pm" src="https://user-images.githubusercontent.com/41761536/51214776-bf68e700-18d3-11e9-9f69-34030103e2af.png">
<img width="486" alt="screen shot 2019-01-15 at 2 39 51 pm" src="https://user-images.githubusercontent.com/41761536/51214777-bf68e700-18d3-11e9-90ba-bb3011bac774.png">

###### After
<img width="94" alt="screen shot 2019-01-15 at 2 41 13 pm" src="https://user-images.githubusercontent.com/41761536/51214790-c7288b80-18d3-11e9-849c-9b526b00f3b2.png">
<img width="463" alt="screen shot 2019-01-15 at 2 41 19 pm" src="https://user-images.githubusercontent.com/41761536/51214791-c7c12200-18d3-11e9-9e32-4bfc259803ff.png">

