### PR TITLE
Sanitize faceted search item's title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix cart item quantity change rollback [#1418](https://github.com/bigcommerce/cornerstone/pull/1418)
 - Changed z-index to higher for header [#1422](https://github.com/bigcommerce/cornerstone/pull/1422)
 - Removed customer (not address) phone number requirement from Edit Account [#1417](https://github.com/bigcommerce/cornerstone/pull/1417)
+- Sanitize faceted search titles to remove HTML [#1426](https://github.com/bigcommerce/cornerstone/pull/1426)
 
 ## 3.0.0 (2018-12-21)
 ### Breaking Changes

--- a/templates/components/faceted-search/facets/multi.html
+++ b/templates/components/faceted-search/facets/multi.html
@@ -30,7 +30,7 @@
                         class="navList-action navList-action--checkbox {{#if selected }} is-selected {{/if}}"
                         rel="nofollow"
                         data-faceted-search-facet>
-                        {{ title }}
+                        {{ sanitize title }}
                         {{#if ../show_product_counts}}
                             <span>({{ count }})</span>
                         {{/if}}


### PR DESCRIPTION
#### What?

This pull request uses the handlebars helper {{ sanitize }} to remove HTML tags from facets' titles on category pages. 

#### Tickets / Documentation

- [Issue](https://github.com/bigcommerce/cornerstone/issues/1416)