### PR TITLE
STRF-5934: Lock down webpack version

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
     "lodash-webpack-plugin": "^0.11.2",
     "npx": "^10.2.0",
     "time-grunt": "^1.2.2",
-    "webpack": "^4.27.1",
+    "webpack": "~4.27.1",
     "webpack-bundle-analyzer": "^3.0.3",
-    "webpack-cli": "^3.1.2",
-    "webpack-merge": "^4.1.2"
+    "webpack-cli": "~3.1.2",
+    "webpack-merge": "~4.1.2"
   },
   "scripts": {
     "build": "npx webpack --config webpack.prod.js",


### PR DESCRIPTION
#### What?
* Webpack 4.29.0 appears to have introduced a breaking change from the 5.0 branch.
* Lock down versions to the ones used during development of #1390 
* Fixes #1427 

#### Tickets / Documentation
- [Stack Overflow Question](https://stackoverflow.com/questions/54316059/bigcommerce-stencil-start-uncaught-error-module-parse-failed/54316525#54316525)
- [Github Issue](https://github.com/bigcommerce/cornerstone/issues/1427)

#### Screenshots
Loads fine in CLI now:
<img width="1416" alt="screen shot 2019-01-22 at 4 35 24 pm" src="https://user-images.githubusercontent.com/168657/51574704-cd82ae80-1e63-11e9-943c-30de9ff646f9.png">

