### PR TITLE
fix(storefront): STRF-5948 Cleanup and XSS fix on Cart page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 
 - Ensure SKU and UPC display correctly for Variants on PDP. [#1431](https://github.com/bigcommerce/cornerstone/pull/1431)
+- Cleanup and XSS fix on Cart page. [#1434](https://github.com/bigcommerce/cornerstone/pull/1434)
 
 ## 3.1.1 (2019-01-23)
 

--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -26,39 +26,22 @@
                         <p>({{release_date}})</p>
                     {{/if}}
 
-                    {{#if configurable_fields}}
-                        <dl class="definitionList">
-                            {{#each configurable_fields}}
-                                <dt class="definitionList-key">{{name}}:</dt>
-                                <dd class="definitionList-value">
-                                    {{#if is_file}}
-                                        <a href="/viewfile.php?prodfield={{../id}}&cartitem={{../../id}}">{{{value}}}</a>
-                                    {{else}}
-                                        {{{value}}}
-                                    {{/if}}
-                                </dd>
-                            {{/each}}
-                        </dl>
-                    {{/if}}
-
                     {{#if options}}
                         <dl class="definitionList">
                             {{#each options}}
                                 <dt class="definitionList-key">{{name}}:</dt>
                                 <dd class="definitionList-value">
                                     {{#if is_file}}
-                                        <a href="/viewfile.php?attributeId={{../id}}&cartitem={{../../id}}">{{{value}}}</a>
+                                        <a href="/viewfile.php?attributeId={{../id}}&cartitem={{../../id}}">{{value}}</a>
                                     {{else}}
-                                        {{{value}}}
+                                        {{value}}
                                     {{/if}}
                                 </dd>
                             {{/each}}
                         </dl>
-                    {{/if}}
 
-                    {{#or options configurable_fields}}
                         <a href="#" data-item-edit="{{id}}">{{lang 'cart.checkout.change'}}</a>
-                    {{/or}}
+                    {{/if}}
 
                     {{#if type '==' 'GiftCertificate'}}
                         <a href="{{edit_url}}">{{lang 'cart.checkout.change'}}</a>

--- a/templates/components/cart/preview.html
+++ b/templates/components/cart/preview.html
@@ -81,19 +81,6 @@
                         {{/or}}
                     </div>
 
-                    {{#each configurable_fields}}
-                        <dl class="productView-info">
-                            <dt class="productView-info-name">
-                                {{name}}
-                            </dt>
-                            {{#if is_file}}
-                                <a href="/viewfile.php?prodfield={{../id}}&cartitem={{../../id}}">{{{value}}}</a>
-                            {{else}}
-                                {{{value}}}
-                            {{/if}}
-                        </dl>
-                    {{/each}}
-
                     {{#each options}}
                         <dl class="productView-info">
                             <dt class="productView-info-name">

--- a/templates/pages/account/add-return.html
+++ b/templates/pages/account/add-return.html
@@ -37,7 +37,7 @@
                                             <dl class="definitionList">
                                                 {{#each options}}
                                                 <dt class="definitionList-label">{{name}}:</dt>
-                                                <dd class="definitionList-description">{{{value}}}</dd>
+                                                <dd class="definitionList-description">{{value}}</dd>
                                                 {{/each}}
                                             </dl>
                                             {{/if}}


### PR DESCRIPTION
#### What?

Certain product options allow for user-submitted input, which in the case of JS can be executed on the Cart page. This value is now escaped properly on the Cart page. This is also addressed on the Returns page.

This also cleans up code related to Configurable Fields, which were removed in https://github.com/bigcommerce/cornerstone/pull/1407.

This does not address Custom Fields, which are entirely determined by the merchant.

#### Tickets / Documentation

- [STRF-5948](https://jira.bigcommerce.com/browse/STRF-5948)