### PR TITLE
Resolve settings scope passed to components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Ensure SKU and UPC display correctly for Variants on PDP. [#1431](https://github.com/bigcommerce/cornerstone/pull/1431)
 
+- Resolve settings scope passed to components. [#1435](https://github.com/bigcommerce/cornerstone/pull/1435)
+
 ## 3.1.1 (2019-01-23)
 
 - Downgrade Webpack to last known good version during development. [#1428](https://github.com/bigcommerce/cornerstone/pull/1428)

--- a/templates/components/products/new.html
+++ b/templates/components/products/new.html
@@ -1,6 +1,6 @@
 <h2 class="page-heading">{{lang 'products.new' }}</h2>
 {{#if settings.data_tag_enabled}}
-    {{> components/products/carousel settings=../settings products=products list="New Products"}}
+    {{> components/products/carousel products=products list="New Products"}}
 {{else}}
     {{> components/products/carousel products=products}}
 {{/if}}

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -235,7 +235,7 @@
         {{#if theme_settings.show_product_details_tabs}}
             {{> components/products/description-tabs}}
         {{else}}
-            {{> components/products/description  settings=../settings}}
+            {{> components/products/description}}
         {{/if}}
     </article>
 </div>

--- a/templates/components/products/quick-view.html
+++ b/templates/components/products/quick-view.html
@@ -1,3 +1,3 @@
 <div class="modal-body quickView">
-    {{> components/products/product-view settings=../settings schema=false}}
+    {{> components/products/product-view schema=false}}
 </div>

--- a/templates/components/products/tabs.html
+++ b/templates/components/products/tabs.html
@@ -24,7 +24,7 @@
 
 {{#if product.similar_by_views}}
     <div role="tabpanel" aria-hidden="{{#if product.related_products}}true{{else}}false{{/if}}" class="tab-content has-jsContent{{#unless product.related_products}} is-active{{/unless}}" id="tab-similar">
-            {{> components/products/carousel settings=../settings products=product.similar_by_views columns=6 list="Customers Also Viewed"}}
+            {{> components/products/carousel products=product.similar_by_views columns=6 list="Customers Also Viewed"}}
 
     </div>
 {{/if}}

--- a/templates/pages/amp/category.html
+++ b/templates/pages/amp/category.html
@@ -41,7 +41,7 @@ category:
         {{/if}}
     </main>
     {{> components/amp/category/subcategories}}
-    {{> components/amp/common/footer settings=../settings}}
+    {{> components/amp/common/footer}}
     {{#if settings.amp_analytics_id}}
         <amp-analytics type="googleanalytics">
             <script type="application/json">

--- a/templates/pages/amp/product.html
+++ b/templates/pages/amp/product.html
@@ -24,7 +24,7 @@ product:
 {{#partial "page"}}
     {{> components/amp/common/header }}
     <div itemscope itemtype="http://schema.org/Product">
-        {{> components/amp/products/product-view schema=true settings=../settings}}
+        {{> components/amp/products/product-view schema=true}}
     </div>
     {{#if settings.amp_analytics_id}}
         <amp-analytics type="googleanalytics">
@@ -69,6 +69,6 @@ product:
             </script>
         </amp-analytics>
     {{/if}}
-    {{> components/amp/common/footer settings=../settings}}
+    {{> components/amp/common/footer}}
 {{/partial}}
 {{> layout/amp }}

--- a/templates/pages/brand.html
+++ b/templates/pages/brand.html
@@ -29,7 +29,7 @@ brand:
 
     <main class="page-content" id="product-listing-container">
         {{#if brand.products}}
-            {{> components/brand/product-listing settings=../settings}}
+            {{> components/brand/product-listing}}
         {{else}}
             <p>{{lang 'brands.no_products'}}</p>
         {{/if}}

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -42,7 +42,7 @@ category:
 
     <main class="page-content" id="product-listing-container">
         {{#if category.products}}
-            {{> components/category/product-listing settings=../settings}}
+            {{> components/category/product-listing}}
         {{else}}
             <p>{{lang 'categories.no_products'}}</p>
         {{/if}}

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -17,7 +17,7 @@ product:
     {{/each}}
 
     <div itemscope itemtype="http://schema.org/Product">
-        {{> components/products/product-view settings=../settings schema=true  }}
+        {{> components/products/product-view schema=true  }}
 
         {{#if product.videos.list.length}}
             {{> components/products/videos product.videos}}

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -142,7 +142,7 @@ product_results:
         {{/if}}
 
         <div id="product-listing-container" {{#if forms.search.section '!=' 'product'}}class="u-hiddenVisually"{{/if}}>
-            {{> components/search/product-listing settings=../settings}}
+            {{> components/search/product-listing}}
         </div>
     </main>
 </section>


### PR DESCRIPTION
#### What?
These changes correct the scope of the settings object in several files.

In [this commit](https://github.com/bigcommerce/cornerstone/commit/55fc73eeb1edc6e140005ca811f090f06ab35435), the store settings object was improperly scoped using '../' unnecessarily in some instances. This causes defects in the quick view modal and poses risks for future development. Anything that can be toggled in the store settings does not appear in the quick view modal. This includes the product rating, social share links, and add to wish list button.

To replicate, go to the [Cornerstone demo theme](https://cornerstone-light-demo.mybigcommerce.com/), and quick view any product. 

#### Tickets / Documentation

N/A

#### Screenshots

##### Before:
![before](https://user-images.githubusercontent.com/47044676/51778390-3f523680-20b6-11e9-8c9b-3205c3b6cba2.png)

##### After:
![after](https://user-images.githubusercontent.com/47044676/51778389-3f523680-20b6-11e9-8bd8-3e2c98682277.png)
