### PR TITLE
feat(cp): STRF-6025 improve password complexity rules

### DIFF
--- a/assets/js/theme/common/form-utils.js
+++ b/assets/js/theme/common/form-utils.js
@@ -156,16 +156,25 @@ const Validators = {
             {
                 selector: passwordSelector,
                 validate: (cb, val) => {
-                    const result = val.match(new RegExp(requirements.alpha))
+                    const upperLowerNumeric = val.match(new RegExp(requirements.alphaupper))
                         && val.match(new RegExp(requirements.numeric))
-                        && val.length >= requirements.minlength;
+                        && val.match(new RegExp(requirements.alphalower));
+                    const upperLowerSpecial = val.match(new RegExp(requirements.alphaupper))
+                        && val.match(new RegExp(requirements.alphalower))
+                        && val.match(new RegExp(requirements.specialchars));
+                    const upperSpecialNumeric = val.match(new RegExp(requirements.alphaupper))
+                        && val.match(new RegExp(requirements.numeric))
+                        && val.match(new RegExp(requirements.specialchars));
+                    const lowerSpecialNumeric = val.match(new RegExp(requirements.alphalower))
+                        && val.match(new RegExp(requirements.numeric))
+                        && val.match(new RegExp(requirements.specialchars));
 
                     // If optional and nothing entered, it is valid
                     if (isOptional && val.length === 0) {
                         return cb(true);
                     }
 
-                    cb(result);
+                    cb((upperLowerNumeric || upperLowerSpecial || upperSpecialNumeric || lowerSpecialNumeric) && val.length >= requirements.minlength);
                 },
                 errorMessage: requirements.error,
             },


### PR DESCRIPTION
## What?
Improve password complexity for storefront accounts and customers accounts in Control Panel

## Why?
Right now passwords requirements are too weak

## Testing / Proof
Create an account with each combination:
upper lower special
upper lower numeric
lower special numeric
upper special numeric
and make sure it passes validation
Create an account that doesn't reflect either of combinations and verify it fails to create an account with weak password
Verify password is at least 8 characters long
Verify that error message has correct content, i.e. password must be at least 8 chars long and have at least 3 out of 4 special chars ( upper, lower, special chars and numeric).

## How can this change be undone in case of failure?

1. Revert this PR


ping @bigcommerce/cp-dt 

