### PR TITLE
MERC-4566 Add option to hide breadcrumbs and page title

### DIFF
--- a/config.json
+++ b/config.json
@@ -44,6 +44,11 @@
     "Firefox ESR"
   ],
   "settings": {
+    "hide_breadcrumbs": false,
+    "hide_page_heading": false,
+    "hide_category_page_heading": false,
+    "hide_blog_page_heading": false,
+    "hide_contact_us_page_heading": false,
     "homepage_new_products_count": 5,
     "homepage_featured_products_count": 4,
     "homepage_top_products_count": 4,

--- a/schema.json
+++ b/schema.json
@@ -358,6 +358,40 @@
       },
       {
         "type": "heading",
+        "content": "Pages"
+      },
+      {
+        "type": "checkbox",
+        "label": "Hide breadcrumbs",
+        "force_reload": true,
+        "id": "hide_breadcrumbs"
+      },
+      {
+        "type": "checkbox",
+        "label": "Hide page heading",
+        "force_reload": true,
+        "id": "hide_page_heading"
+      },
+      {
+        "type": "checkbox",
+        "label": "Hide category page heading",
+        "force_reload": true,
+        "id": "hide_category_page_heading"
+      },
+      {
+        "type": "checkbox",
+        "label": "Hide blog page heading",
+        "force_reload": true,
+        "id": "hide_blog_page_heading"
+      },
+      {
+        "type": "checkbox",
+        "label": "Hide contact us page heading",
+        "force_reload": true,
+        "id": "hide_contact_us_page_heading"
+      },
+      {
+        "type": "heading",
         "content": "Products"
       },
       {

--- a/templates/components/common/breadcrumbs.html
+++ b/templates/components/common/breadcrumbs.html
@@ -1,13 +1,15 @@
 <ul class="breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">
-    {{#each breadcrumbs}}
-        <li class="breadcrumb {{#if @last}}is-active{{/if}}" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-            {{#or @last (if url "==" null)}}
-                <meta itemprop="item" content="{{url}}">
-                <span class="breadcrumb-label" itemprop="name">{{name}}</span>
-            {{else}}
-                <a href="{{url}}" class="breadcrumb-label" itemprop="item"><span itemprop="name">{{name}}</span></a>
-            {{/or}}
-            <meta itemprop="position" content="{{add @index 1}}" />
-        </li>
-    {{/each}}
+    {{#unless theme_settings.hide_breadcrumbs }}
+        {{#each breadcrumbs}}
+            <li class="breadcrumb {{#if @last}}is-active{{/if}}" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+                {{#or @last (if url "==" null)}}
+                    <meta itemprop="item" content="{{url}}">
+                    <span class="breadcrumb-label" itemprop="name">{{name}}</span>
+                {{else}}
+                    <a href="{{url}}" class="breadcrumb-label" itemprop="item"><span itemprop="name">{{name}}</span></a>
+                {{/or}}
+                <meta itemprop="position" content="{{add @index 1}}" />
+            </li>
+        {{/each}}
+    {{/unless}}
 </ul>

--- a/templates/pages/blog.html
+++ b/templates/pages/blog.html
@@ -10,7 +10,9 @@ blog:
 {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
 
 <main class="page">
-    <h1 class="page-heading">{{ blog.name }}</h1>
+    {{#unless theme_settings.hide_blog_page_heading }}
+        <h1 class="page-heading">{{ blog.name }}</h1>
+    {{/unless}}
 
     {{#each blog.posts}}
         {{> components/blog/post post=this}}

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -20,7 +20,9 @@ category:
 {{#if category.image}}
     <img class="lazyload" data-sizes="auto" src="{{cdn 'img/loading.svg'}}" data-src="{{getImage category.image 'zoom_size'}}">
 {{/if}}
-<h1 class="page-heading">{{category.name}}</h1>
+{{#unless theme_settings.hide_category_page_heading }}
+    <h1 class="page-heading">{{category.name}}</h1>
+{{/unless}}
 {{{category.description}}}
 {{{snippet 'categories'}}}
 <div class="page">

--- a/templates/pages/contact-us.html
+++ b/templates/pages/contact-us.html
@@ -3,8 +3,9 @@
 {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
 
 <main class="page">
-
-    <h1 class="page-heading">{{page.title}}</h1>
+    {{#unless theme_settings.hide_contact_us_page_heading }}
+        <h1 class="page-heading">{{page.title}}</h1>
+    {{/unless}}
 
     {{#if page.sub_pages}}
         <nav class="navBar navBar--sub">

--- a/templates/pages/page.html
+++ b/templates/pages/page.html
@@ -3,8 +3,9 @@
 {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
 
 <main class="page">
-
-    <h1 class="page-heading">{{ page.title }}</h1>
+    {{#unless theme_settings.hide_page_heading }}
+        <h1 class="page-heading">{{ page.title }}</h1>
+    {{/unless}}
 
     {{#if page.sub_pages}}
     <nav class="navBar navBar--sub">


### PR DESCRIPTION
#### What?
Add option to hide breadcrumbs, page heading, category heading, contact page heading and blog page heading. 

#### Tickets / Documentation
[MERC-4566](https://jira.bigcommerce.com/browse/MERC-4566)

**Turning off breadcrumbs**
![feb-14-2019 12-31-38](https://user-images.githubusercontent.com/33278039/52815840-8b105400-3054-11e9-8e62-a3297b09e85a.gif)

**Turn off page heading**
![feb-14-2019 12-32-33](https://user-images.githubusercontent.com/33278039/52815999-040fab80-3055-11e9-85e2-f4c05e9ebf47.gif)

**Turn off category page heading**
![feb-14-2019 12-34-04](https://user-images.githubusercontent.com/33278039/52816021-0ffb6d80-3055-11e9-919c-3f572b170245.gif)

**Turn off contact page heading**
![contact](https://user-images.githubusercontent.com/33278039/52816035-1db0f300-3055-11e9-8471-6139b12509c5.gif)

**Turn off blog page heading**
![blog](https://user-images.githubusercontent.com/33278039/52816043-24d80100-3055-11e9-9598-1830b3d50629.gif)

#### Images

![screen shot 2019-02-14 at 4 10 13 pm](https://user-images.githubusercontent.com/33278039/52825791-100a6600-3073-11e9-9972-47a8e466c081.png)
