### PR TITLE
Fix mobile banner text displaying with underline on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Explicitly disable autocomplete in password entry input fields. [#1465](https://github.com/bigcommerce/cornerstone/pull/1465)
+- Fix mobile banner text displaying with underline on mobile. [#1448](https://github.com/bigcommerce/cornerstone/pull/1448)
 
 ## 3.3.0 (2019-03-18)
 - Add option to hide breadcrumbs and page title. [#1444](https://github.com/bigcommerce/cornerstone/pull/1444)

--- a/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
+++ b/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
@@ -36,6 +36,10 @@
         display: none;
     }
 
+    a {
+        text-decoration: none;
+    }
+
     .slick-next,
     .slick-prev {
         top: 50%;


### PR DESCRIPTION
#### What?

Hero carousel text is displaying with an underline on small screen sizes.

#### Tickets / Documentation

#1303 

#### Screenshots

**BEFORE**
<img width="832" alt="1 before" src="https://user-images.githubusercontent.com/5056945/52827580-40093780-307a-11e9-860d-f7db0efb0bfd.png">

**AFTER**
<img width="832" alt="2 after" src="https://user-images.githubusercontent.com/5056945/52827581-40a1ce00-307a-11e9-9ad8-390f9c6008c2.png">
