### PR TITLE
MERC-4567 Add a region for page content

### DIFF
--- a/templates/pages/page.html
+++ b/templates/pages/page.html
@@ -20,6 +20,7 @@
         {{#replace '%%Syndicate%%' page.content}}
             {{> components/page/rss_feed}}
         {{else}}
+            {{{region name="page_content"}}}
             <p>{{{page.content}}}</p>
         {{/replace}}
     </div>


### PR DESCRIPTION
#### What?

Add support for placing widgets in the "page" template.

#### Why?

We will support placing widgets in the page template of all the themes going forward by implicitly injecting regions where {{{page.content}}} is placed, but for now, manual placement of "region" will help the project progress.

#### Tickets / Documentation

- [MERC-4567](https://jira.bigcommerce.com/browse/MERC-4567)
