### PR TITLE
Resolve add to cart modal mobile isssue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Resolve add to cart modal mobile isssue. [#1450](https://github.com/bigcommerce/cornerstone/pull/1450)
 
 ## 3.2.1 (2019-02-15)
 - Added package-lock.json. [#1441](https://github.com/bigcommerce/cornerstone/pull/1441)

--- a/assets/scss/components/foundation/modal/_modal.scss
+++ b/assets/scss/components/foundation/modal/_modal.scss
@@ -4,13 +4,16 @@
 
 
 .modal {
-    margin: 0 auto;
+    margin: 0;
     max-height: 90%;
     max-width: 95%;
     min-height: 240px;
     outline: none;
     overflow: hidden;
     padding: 0;
+    left: 50%;
+    top: 50% !important;
+    transform: translate(-50%, -50%);
 }
 
 .modal--large {


### PR DESCRIPTION
#### What?

This change brings the add to cart modal to the proper location on mobile.

On mobile screens, the add to cart modal appears off-screen. This issue stems from an [edit made to the modal.scss file](https://github.com/bigcommerce/cornerstone/pull/1390/commits/5347914d46c24b1732a8e44e9270ed94bc295cf2) where the left, top, and transform CSS properties were removed.

To replicate, go to any product on the Cornerstone demo theme, for example, the [Able Brewing System](https://cornerstone-light-demo.mybigcommerce.com/all/able-brewing-system/), resize your window to a width under 551px, and add the product to your cart.

The edit made to the modal.scss file appears to be a fix to center the small modal. This issue can be resolved by setting margin to 0, while keeping the left, top, and transform properties. I have changed the margin to 0 to prevent breaking the small modal with this edit.

#### Tickets / Documentation
N/A

#### Screenshots
##### Before:
![add-to-cart-modal-before](https://user-images.githubusercontent.com/47044676/53057181-1b8ad200-3463-11e9-859c-624500fee8e3.png)

##### After:
![add-to-cart-modal-after](https://user-images.githubusercontent.com/47044676/53057180-1b8ad200-3463-11e9-83e4-c25ba278ed79.png)
