### PR TITLE
Load gift certificate preview in iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Load gift certificate preview in iframe. [#1456](https://github.com/bigcommerce/cornerstone/pull/1456)
 - Resolve add to cart modal mobile isssue. [#1450](https://github.com/bigcommerce/cornerstone/pull/1450)
 
 ## 3.2.1 (2019-02-15)

--- a/assets/js/theme/gift-certificate.js
+++ b/assets/js/theme/gift-certificate.js
@@ -2,7 +2,6 @@ import PageManager from './page-manager';
 import nod from './common/nod';
 import giftCertChecker from './common/gift-certificate-validator';
 import formModel from './common/models/forms';
-import { api } from '@bigcommerce/stencil-utils';
 import { defaultModal } from './global/modal';
 
 export default class GiftCertificate extends PageManager {
@@ -168,16 +167,15 @@ export default class GiftCertificate extends PageManager {
 
             const modal = defaultModal();
             const previewUrl = `${$(event.currentTarget).data('previewUrl')}&${$purchaseForm.serialize()}`;
+            const frameOptions = {
+                height: '350px',
+                width: '560px',
+            };
+
+            const wrappedContent = `<div style="text-align:center;"><iframe src="${previewUrl}" style="border:0;" name="Gift Certificate Preview" scrolling="yes" frameborder="0" marginheight="0px" marginwidth="0px" height="${frameOptions.height}" width="${frameOptions.width}"></iframe></div>`;
 
             modal.open();
-
-            api.getPage(previewUrl, {}, (err, content) => {
-                if (err) {
-                    return modal.updateContent(this.context.previewError);
-                }
-
-                modal.updateContent(content, { wrap: true });
-            });
+            modal.updateContent(wrappedContent, { wrap: true });
         });
     }
 


### PR DESCRIPTION
#### What?

This PR changes the way in which the preview is loaded, calling it inside an iframe.

Currently, the gift certificate preview is injected into the page content using the api.getPage method. This poses 2 issues. 

First, the style tag pulled in from the gift certificate template affects the rest of the page content even after the preview is closed. To replicate this, navigate to the [Cornerstone Gift Certificate Page](https://cornerstone-light-demo.mybigcommerce.com/giftcertificates.php), notice the styling of the elements on the page, such as the page header (Gift Certificates). Enter your information, click the button to preview the gift certificate, close the preview modal, and notice how the page styling has changed. See screenshots "Gift Certificates Page Before Preview" and "Gift Certificates Page After Preview" below.

Second, because the preview is inside the page content, and is not fully self-contained, it inherits some styling from the theme. This means that it is not a true visual representation of how the gift certificate will look when a customer views it in their inbox. To see this for yourself, navigate to the [Cornerstone Gift Certificate Page](https://cornerstone-light-demo.mybigcommerce.com/giftcertificates.php), enter your details, and click the preview button. Compare this result with the actual link that generates this preview, for example, [This dummy gift certificate](https://cornerstone-light-demo.mybigcommerce.com/giftcertificates.php?action=preview&from_name=test&from_email=test%40test.com&to_name=test&to_email=test%40test.com&certificate_amount=123&agree2=on&message=Lorem%20Ipsum%20message%20Lorem%20Ipsum%20message%20Lorem%20Ipsum%20message%20Lorem%20Ipsum%20message%20Lorem%20Ipsum%20message%20Lorem%20Ipsum%20message%20Lorem%20Ipsum%20message%20Lorem%20Ipsum%20message%20Lorem%20Ipsum%20message%20Lorem%20Ipsum%20message%20&certificate_theme=General.html). Notice the slight differences in styling due to the preview in the modal inheriting font-smoothing and a different line height, among other things. See "Current Gift Certificate Preview in modal" and "Gift Certificate Preview Link" screenshots below.

The new preview is self-contained, meaning it appears exactly as it would if you followed the link. This also solves the issue of the styling of other elements on the page being altered since the style tags from the email template are not injected in a way that affects the rest of the page. See "Gift Certificate Preview iframe" screenshot below to see how this looks within the iframe inside the modal. 

Finally, the mobile look is no different from the current, allowing the content to be wider than the screen, and allowing the user to scroll to the side. See "Gift Certificate Preview Mobile" screenshot below for context.

I have tested this change across several browsers and on an iPhone. 

The one issue is since there is no way to make an iframe responsive, a fixed height must be set for the frame. If the content is smaller than the iframe height, there will be extra whitespace below the frame. If the content is larger than the iframe height, it will appear cut off, but will allow for vertical scrolling. I have set the height to 350px for the iframe, so it should be taller than needed in most cases. I am certainly open to suggestions here if anyone has a better method for sizing the iframe.

#### Tickets / Documentation
N/A

#### Screenshots

##### Gift Certificates Page Before Preview:
![gift_certificates_page_before_preview](https://user-images.githubusercontent.com/47044676/53104698-b5df2a00-34e4-11e9-88e3-6b6fa47c894c.png)


##### Gift Certificates Page After Preview:
![gift_certificates_page_after_preview](https://user-images.githubusercontent.com/47044676/53104700-b5df2a00-34e4-11e9-8808-67cd12f87b6d.png)

##### Current Gift Certificate Preview in modal:
![gift_certificate_in_preview_frame](https://user-images.githubusercontent.com/47044676/53104925-140c0d00-34e5-11e9-8aad-25af12ab8e05.png)


##### Gift Certificate Preview Link:
![gift_certificate_link](https://user-images.githubusercontent.com/47044676/53104926-140c0d00-34e5-11e9-8f11-d1da0c0228c6.png)


##### Gift Certificate Preview iframe:
![gift_certificate_in_preview_iframe](https://user-images.githubusercontent.com/47044676/53105474-0efb8d80-34e6-11e9-9e92-daa156274a3d.png)


##### Gift Certificate Preview Mobile:
![gift_certificate_in_preview_iframe_mobile](https://user-images.githubusercontent.com/47044676/53105153-72d18680-34e5-11e9-83ae-a870ef9a919a.png)
