### PR TITLE
Fail stencil bundle on Webpack compile errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Resolve add to cart modal mobile isssue. [#1450](https://github.com/bigcommerce/cornerstone/pull/1450)
+- Fail stencil bundle on Webpack compile errors [#1457](https://github.com/bigcommerce/cornerstone/pull/1457)
 
 ## 3.2.1 (2019-02-15)
 - Added package-lock.json. [#1441](https://github.com/bigcommerce/cornerstone/pull/1441)

--- a/stencil.conf.js
+++ b/stencil.conf.js
@@ -27,9 +27,13 @@ function development() {
     var devConfig = require('./webpack.dev.js');
 
     // Rebuild the bundle once at bootup
-    webpack(devConfig).watch({}, err => {
+    webpack(devConfig).watch({}, (err, stats) => {
         if (err) {
             console.error(err.message, err.details);
+        }
+
+        if (stats.hasErrors()) {
+            console.error(stats.toString({ all: false, errors: true, colors: true }));
         }
 
         process.send('reload');
@@ -42,9 +46,15 @@ function development() {
 function production() {
     var prodConfig = require('./webpack.prod.js');
 
-    webpack(prodConfig).run(err => {
+    webpack(prodConfig).run((err, stats) => {
         if (err) {
             console.error(err.message, err.details);
+            process.exit(1);
+            return;
+        }
+
+        if (stats.hasErrors()) {
+            console.error(stats.toString({ all: false, errors: true, colors: true }));
             process.exit(1);
             return;
         }

--- a/stencil.conf.js
+++ b/stencil.conf.js
@@ -36,6 +36,10 @@ function development() {
             console.error(stats.toString({ all: false, errors: true, colors: true }));
         }
 
+        if (stats.hasWarnings()) {
+            console.error(stats.toString({ all: false, warnings: true, colors: true }));
+        }
+
         process.send('reload');
     });
 }
@@ -57,6 +61,10 @@ function production() {
             console.error(stats.toString({ all: false, errors: true, colors: true }));
             process.exit(1);
             return;
+        }
+
+        if (stats.hasWarnings()) {
+            console.error(stats.toString({ all: false, warnings: true, colors: true }));
         }
 
         process.send('done');

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -43,8 +43,8 @@ module.exports = {
     },
     performance: {
         hints: 'warning',
-        maxAssetSize: 1024 * 150,
-        maxEntrypointSize: 1024 * 150,
+        maxAssetSize: 1024 * 300,
+        maxEntrypointSize: 1024 * 300,
     },
     plugins: [
         new CleanPlugin(['assets/dist'], {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -5,4 +5,7 @@ const webpack = require('webpack'),
 module.exports = merge(commonConfig, {
     devtool: 'inline-source-map',
     mode: 'development',
+    performance: {
+        hints: false,
+    },
 });


### PR DESCRIPTION
#### What?

When Webpack compilation fails, `stencil bundle` blindly ignores it.

As a result, the generated theme ZIP file does not contain the `assets/dist` folder (just like in issue https://github.com/bigcommerce/stencil-cli/issues/379)

#### How to reproduce

Step-by-step from fresh Cornerstone, below.

In this example, we will simply add a line of JavaScript code which Babel will fail to understand:

```sh
# 1. Fresh clone of Cornerstone repository
git clone https://github.com/bigcommerce/cornerstone.git
# 2. Make cornerstone the current working directory
cd cornerstone
# 3. Install dependencies
npm ci
# 4. Generate theme ZIP
stencil bundle
# 5. Check that the generated ZIP file contains assets/dist folder
# 6. Append a line of code to "assets/js/app.js"
echo 'console.log(<h1>Hi</h1>); // eslint-disable-line' >> assets/js/app.js
# This is valid JSX code... but babel-loader needs a plugin to understand it
# 7. Generate theme ZIP again
stencil bundle
# 8. Check that the generated ZIP file does not contain assets/dist folder
```

In our real-world scenario, the **Webpack build failed** for other reasons, and we didn't need to shut up ESLint as in this example (the code passed in ESLint checks). Our scenario is more complex to reproduce. It requires other Webpack loaders and configurations.

The aim with this easy-to-reproduce example is to show how a **Webpack build failure is ignored**.

Later we learned that this happens when an exception is thrown from a Webpack loader (comment from sepo-one at https://github.com/webpack/webpack/issues/708).

#### Solution

The callback for Webpack's `run` is `(err, [stats](#stats-object))`

Currently, `err` is considered, but `stats` is ignored.

Problem is that even when there is no `err`, errors may have happened in Webpack compilation, and they are available at the `stats` object. Screenshot below is from Webpack documentation:

![webpack-stats](https://user-images.githubusercontent.com/69181/53121287-a8e92780-3532-11e9-9989-0a7c4e67d8db.png)

This resembles Ajax error handling... there, we have "two layers" of possible errors... one of the Ajax call failing itself... and the other of the Ajax call returning an error code, or even some "error" code/message contained in an HTTP `200` response (terrible practice, but we can find it out there).

Likewise, we have something similar in Webpack's `run`... an `err` for when the overall compile itself fails... and the other (`stats`) of the compiler completing its work and returning an error code/message...

#### Tickets / Documentation

- [Webpack `run` method documentation](https://webpack.js.org/api/node/#run)
- [Webpack `stats` object documentation](https://webpack.js.org/api/node/#stats-object)
- [Webpack options for `stats.toString()` method](https://webpack.js.org/configuration/stats/#stats)

#### Screenshots

Before changes from this PR, `stencil bundle` fails silently:

![before](https://user-images.githubusercontent.com/69181/53121527-2ad95080-3533-11e9-8ea5-6e6ae8b44a98.png)

After changes from this PR, we can see Webpack error message, and the bundle is interrupted:

![after](https://user-images.githubusercontent.com/69181/53121620-54927780-3533-11e9-9f82-b0438a1e59b9.png)
![after2](https://user-images.githubusercontent.com/69181/53121623-56f4d180-3533-11e9-9381-d562f6c27c95.png)

