### PR TITLE
Add responsive breakpoints to product carousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Resolve add to cart modal mobile isssue. [#1450](https://github.com/bigcommerce/cornerstone/pull/1450)
+- Add responsive breakpoints to product carousel. [#1458](https://github.com/bigcommerce/cornerstone/pull/1458)
 
 ## 3.2.1 (2019-02-15)
 - Added package-lock.json. [#1441](https://github.com/bigcommerce/cornerstone/pull/1441)

--- a/templates/components/products/carousel.html
+++ b/templates/components/products/carousel.html
@@ -4,13 +4,29 @@
         "dots": true,
         "infinite": false,
         "mobileFirst": true,
-        "slidesToShow": {{ columns }},
-        "slidesToScroll": 3
+        "slidesToShow": 2,
+        "slidesToScroll": 2,
+        "responsive": [
+            {
+                "breakpoint": 800,
+                "settings": {
+                    "slidesToShow": {{ columns }},
+                    "slidesToScroll": 3
+                }
+            },
+            {
+                "breakpoint": 550,
+                "settings": {
+                    "slidesToShow": 3,
+                    "slidesToScroll": 3
+                }
+            }
+        ]
     }'
 >
     {{#each products}}
     <div class="productCarousel-slide">
-            {{> components/products/card settings=../settings theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
+        {{> components/products/card settings=../settings theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
     </div>
     {{/each}}
 </section>


### PR DESCRIPTION
#### What?

The products inside carousels currently get squished together on smaller screens. 

This occurs wherever the product carousel component is called. This includes the New Products carousel on the homepage and the Related Products and Customers Also Viewed carousels on the product page.

To replicate, go to the [Chambray Towel](https://cornerstone-light-demo.mybigcommerce.com/all/chambray-towel/) on the Cornerstone demo theme, decrease the size of your browser window, and notice that the product cards in the Customers Also Viewed carousel do not look so good. See screenshots "Related Products Mobile View - Before" and "Related Products Tablet View - Before" below.

To replicate, go to the [Cornerstone demo theme](https://cornerstone-light-demo.mybigcommerce.com/), decrease the size of your browser window, and notice that the product cards under the New Products heading do not look good.  See screenshots "New Products Mobile View - Before" and "New Products Tablet View - Before" below.

This PR uses the slick responsive setting in the product carousel component to show fewer products on smaller screen sizes, adding 2 breakpoints to adjust the number of slides to show. These breakpoints use the same values that are specified in the screensizes.scss file. The breakpoints in the slick settings had to be set 1px less than the breakpoints due to how slick works. This change sets the number of products to show on mobile screens (under 551px) to 2, the number to show on table screens (under 801px) to 3, and uses the "columns" value on screens larger than 800px. See all "After" screenshots below. This change has no effect on screens over 800px, so I did not post any desktop screenshots.


Note: This PR eliminates an extra indentation before the card component call.


#### Tickets / Documentation
Slick carousel: http://kenwheeler.github.io/slick/

#### Screenshots

##### New Products Mobile View - Before
![new_products_mobile_before](https://user-images.githubusercontent.com/47044676/53132642-26a63680-3525-11e9-9e80-6edc567182a4.png)

##### New Products Mobile View - After
![new_products_mobile_after](https://user-images.githubusercontent.com/47044676/53132643-26a63680-3525-11e9-814c-229923ccc2ba.png)

##### New Products Tablet View - Before
![new_products_tablet_before](https://user-images.githubusercontent.com/47044676/53132641-26a63680-3525-11e9-94f4-d50f79c04c41.png)

##### New Products Tablet View - After
![new_products_tablet_after](https://user-images.githubusercontent.com/47044676/53132640-260da000-3525-11e9-992c-0c0ba462aa4e.png)

##### Related Products Mobile View - Before
![related_products_mobile_before](https://user-images.githubusercontent.com/47044676/53132637-260da000-3525-11e9-8df5-c07cc0667ade.png)

##### Related Products Mobile View - After
![related_products_mobile_after](https://user-images.githubusercontent.com/47044676/53132639-260da000-3525-11e9-9826-95b4b1068c31.png)

##### Related Products Tablet View - Before
![related_products_tablet_before](https://user-images.githubusercontent.com/47044676/53132635-25750980-3525-11e9-831d-534929c6bebb.png)

##### Related Products Tablet View - After
![related_products_tablet_after](https://user-images.githubusercontent.com/47044676/53132638-260da000-3525-11e9-8ba5-c1b48a465bed.png)

