### PR TITLE
Fixed pagination and search page weirdness.

### DIFF
--- a/assets/js/theme/common/faceted-search.js
+++ b/assets/js/theme/common/faceted-search.js
@@ -85,6 +85,11 @@ class FacetedSearch {
             }
         });
 
+        // Observe DOM events
+        window.onpopstate = () => {
+            $(window).trigger('statechange');
+        };
+
         // Observe user events
         this.onStateChange = this.onStateChange.bind(this);
         this.onToggleClick = this.onToggleClick.bind(this);

--- a/assets/js/theme/common/url-utils.js
+++ b/assets/js/theme/common/url-utils.js
@@ -8,6 +8,10 @@ const urlUtils = {
         $(window).trigger('statechange');
     },
 
+    searchGoToUrl: () => {
+        $(window).trigger('statechange');
+    },
+
     replaceParams: (url, params) => {
         const parsed = Url.parse(url, true);
         let param;

--- a/assets/js/theme/search.js
+++ b/assets/js/theme/search.js
@@ -34,10 +34,6 @@ export default class Search extends CatalogPage {
     }
 
     showProducts() {
-        const url = urlUtils.replaceParams(window.location.href, {
-            section: 'product',
-        });
-
         this.$productListingContainer.removeClass('u-hiddenVisually');
         this.$facetedSearchContainer.removeClass('u-hiddenVisually');
         this.$contentResultsContainer.addClass('u-hiddenVisually');
@@ -48,14 +44,10 @@ export default class Search extends CatalogPage {
         $('[data-product-results-toggle]').removeClass('navBar-action');
         $('[data-product-results-toggle]').addClass('navBar-action-color--active');
 
-        urlUtils.goToUrl(url);
+        urlUtils.searchGoToUrl();
     }
 
     showContent() {
-        const url = urlUtils.replaceParams(window.location.href, {
-            section: 'content',
-        });
-
         this.$contentResultsContainer.removeClass('u-hiddenVisually');
         this.$productListingContainer.addClass('u-hiddenVisually');
         this.$facetedSearchContainer.addClass('u-hiddenVisually');
@@ -66,7 +58,7 @@ export default class Search extends CatalogPage {
         $('[data-content-results-toggle]').removeClass('navBar-action');
         $('[data-content-results-toggle]').addClass('navBar-action-color--active');
 
-        urlUtils.goToUrl(url);
+        urlUtils.searchGoToUrl();
     }
 
     onReady() {


### PR DESCRIPTION
#### What?

All this does is change how the system currently handles history so that you can use the back and forwards buttons native to the browser to navigate paginated pages and the search page.

#### Tickets / Documentation

#1442 search page issue.

#### Replication Steps

Just go to any category/brand/search that has pagination and traverse the pages. Clicking back on your browser will set the url back, but not process another AJAX request to reload said page.

This is probably not the best way to do this, but it fixes the issues regardless.