### PR TITLE
Explicitly disable autocomplete in password entry input fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Explicitly disable autocomplete in password entry input fields. [#1465](https://github.com/bigcommerce/cornerstone/pull/1465)
 
 ## 3.3.0 (2019-03-18)
 - Add option to hide breadcrumbs and page title. [#1444](https://github.com/bigcommerce/cornerstone/pull/1444)

--- a/templates/pages/auth/login.html
+++ b/templates/pages/auth/login.html
@@ -18,7 +18,7 @@
             </div>
             <div class="form-field">
                 <label class="form-label" for="login_pass">{{lang 'login.field_password'}}</label>
-                <input class="form-input" id="login_pass" type="password" name="login_pass">
+                <input class="form-input" id="login_pass" type="password" name="login_pass" autocomplete="off">
             </div>
             <div class="form-actions">
                 <input type="submit" class="button button--primary" value="{{lang 'login.submit_value' }}">

--- a/templates/pages/auth/new-password.html
+++ b/templates/pages/auth/new-password.html
@@ -14,14 +14,14 @@
                     {{lang 'forms.new_password.password' }}
                     <small>{{lang 'common.required' }}</small>
                 </label>
-                <input type="password" class="form-input" name="password" id="password">
+                <input type="password" class="form-input" name="password" id="password" autocomplete="off">
             </div>
             <div class="form-field">
                 <label class="form-label" for="password_confirm">
                     {{lang 'forms.new_password.password2' }}
                     <small>{{lang 'common.required' }}</small>
                 </label>
-                <input type="password" class="form-input" name="password_confirm" id="password_confirm">
+                <input type="password" class="form-input" name="password_confirm" id="password_confirm" autocomplete="off">
             </div>
         </div>
         <div class="form-actions">


### PR DESCRIPTION
#### What?

Disables implicit autocomplete on password entry forms for Sign In and when changing passwords when signed in as a customer.

When the autocomplete attribute is not on the form element, autocomplete is _implicitly_ enabled: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete

The impetus for this change is increased security for PCI compliance. See https://portswigger.net/kb/issues/00500800_password-field-with-autocomplete-enabled.