### PR TITLE
fixed update product qty by typing the new qty in the cart page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Explicitly disable autocomplete in password entry input fields. [#1465](https://github.com/bigcommerce/cornerstone/pull/1465)
+- Fixed update product qty by typing the new qty in the cart page (not with the arrows). [#1469](https://github.com/bigcommerce/cornerstone/pull/1469)
 
 ## 3.3.0 (2019-03-18)
 - Add option to hide breadcrumbs and page title. [#1444](https://github.com/bigcommerce/cornerstone/pull/1444)

--- a/assets/js/test-unit/theme/cart.spec.js
+++ b/assets/js/test-unit/theme/cart.spec.js
@@ -114,8 +114,7 @@ describe('cartUpdateQtyTextChange', () => {
     it('should CHANGE qty completly based on the cart-item-qty-input', () => {	
 		dataSpy
 		dataSpy('manualQtyChange');
-		spyOn(jQuery.fn, 'attr').and.returnValue(5);
-		spyOn(jQuery.fn, 'val').and.returnValue(2);
+		spyOn(jQuery.fn, 'val').and.returnValue(5, 2);
 		c.cartUpdateQtyTextChange($dom);
 		
 		expect(UpdateSpy).toHaveBeenCalledWith('11111', 5, jasmine.any(Function));  

--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -67,11 +67,12 @@ export default class Cart extends PageManager {
         const oldQty = preVal !== null ? preVal : minQty;
         const minError = $el.data('quantityMinError');
         const maxError = $el.data('quantityMaxError');
-        const newQty = parseInt(Number($el.attr('value')), 10);
+        const newQty = parseInt(Number($el.val()), 10);
         let invalidEntry;
+
         // Does not quality for min/max quantity
         if (!newQty) {
-            invalidEntry = $el.attr('value');
+            invalidEntry = $el.val();
             $el.val(oldQty);
             return swal({
                 text: `${invalidEntry} is not a valid entry`,


### PR DESCRIPTION
#### What?
Update product qty in cart page by typing the new qty (not using the arrow), didn't work and the cart was keeping the old qty after refreshing. This pr fix this functionality.
 
#### Screenshots
<img width="1140" alt="Screen Shot 2019-03-29 at 2 52 41 PM" src="https://user-images.githubusercontent.com/41761536/55264851-0a3b9f00-5233-11e9-9e02-1cf87e5ed64c.png">
<img width="1120" alt="Screen Shot 2019-03-29 at 2 52 50 PM" src="https://user-images.githubusercontent.com/41761536/55264852-0a3b9f00-5233-11e9-8c26-2969ce14c025.png">


