### PR TITLE
Fix submenu click on mobile navigation

### DIFF
--- a/assets/js/theme/global/mobile-menu-toggle.js
+++ b/assets/js/theme/global/mobile-menu-toggle.js
@@ -61,7 +61,7 @@ export class MobileMenuToggle {
     bindEvents() {
         this.$toggle.on('click', this.onToggleClick);
         this.$header.on(CartPreviewEvents.open, this.onCartPreviewOpen);
-        this.$navList.on('click .navPages-action', this.onSubMenuClick);
+        this.$subMenus.on('click', this.onSubMenuClick);
 
         if (this.mediumMediaQueryList && this.mediumMediaQueryList.addListener) {
             this.mediumMediaQueryList.addListener(this.onMediumMediaQueryMatch);


### PR DESCRIPTION
#### What?

Change the event handler to correctly call `this.onSubMenuClick`. Without this fix, mobile navigation is not showing/hiding siblings correctly.