### PR TITLE
MERC-3425 - Remove all legacy "snippet" locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Remove deprecated "snippet" locations [#1479](https://github.com/bigcommerce/cornerstone/pull/1479)
 
 ## 3.4.1 (2019-04-11)
 - Sanitize faceted search item's title [#1426](https://github.com/bigcommerce/cornerstone/pull/1426)

--- a/templates/components/amp/products/ratings.html
+++ b/templates/components/amp/products/ratings.html
@@ -9,4 +9,3 @@
         </span>
     {{/if}}
 {{/for}}
-{{{snippet 'product_rating'}}}

--- a/templates/components/common/quick-search.html
+++ b/templates/components/common/quick-search.html
@@ -1,5 +1,4 @@
 <div class="container">
-    {{{ snippet "forms_search"}}}
     <form class="form" action="{{urls.search}}">
         <fieldset class="form-fieldset">
             <div class="form-field">

--- a/templates/components/common/search-box.html
+++ b/templates/components/common/search-box.html
@@ -1,4 +1,3 @@
-{{{ snippet "forms_search"}}}
 <form class="form"  action="{{urls.search}}">
     <fieldset class="form-fieldset">
         <div class="form-field">

--- a/templates/components/products/add-to-cart.html
+++ b/templates/components/products/add-to-cart.html
@@ -44,5 +44,4 @@
         <input id="form-action-addToCart" data-wait-message="{{lang 'products.adding_to_cart'}}" class="button button--primary" type="submit"
             value="{{#if product.pre_order}}{{lang 'products.pre_order'}}{{else}}{{lang 'products.add_to_cart'}}{{/if}}">
     </div>
-     {{{snippet 'product_addtocart'}}}
 {{/or}}

--- a/templates/components/products/description-tabs.html
+++ b/templates/components/products/description-tabs.html
@@ -16,7 +16,6 @@
 <div class="tabs-contents">
     <div class="tab-content is-active" id="tab-description">
         {{{product.description}}}
-        {{{snippet 'product_description'}}}
     </div>
    {{#if product.warranty}}
        <div class="tab-content" id="tab-warranty">

--- a/templates/components/products/description.html
+++ b/templates/components/products/description.html
@@ -1,7 +1,6 @@
 <p class="productView-title">{{lang 'products.description'}}</p>
 <div class="productView-description" {{#if settings.data_tag_enabled}} data-event-type="product" {{/if}}>
     {{{product.description}}}
-    {{{snippet 'product_description'}}}
 </div>
 
 {{#if product.warranty}}

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -228,7 +228,6 @@
             {{/if}}
         </div>
         {{> components/common/share}}
-        {{{snippet 'product_details'}}}
     </section>
 
     <article class="productView-description"{{#if schema}} itemprop="description"{{/if}}>

--- a/templates/components/products/ratings.html
+++ b/templates/components/products/ratings.html
@@ -13,4 +13,3 @@
         </span>
     {{/if}}
 {{/for}}
-{{{snippet 'product_rating'}}}

--- a/templates/components/products/reviews.html
+++ b/templates/components/products/reviews.html
@@ -44,4 +44,3 @@
     </div>
 </section>
 {{/if}}
-{{{snippet 'reviews'}}}

--- a/templates/components/search/advanced-search.html
+++ b/templates/components/search/advanced-search.html
@@ -1,4 +1,3 @@
-{{{snippet 'forms_search'}}}
 <div class="page">
     <div class="page-content page-content--centered">
         <form class="advancedSearch-form toggle-content" action="{{forms.search.action}}" data-advanced-search-form id="advanced-search-content" aria-hidden="true">

--- a/templates/layout/amp.html
+++ b/templates/layout/amp.html
@@ -17,7 +17,6 @@
         {{inject 'genericError' (lang 'common.generic_error')}}
         {{inject 'maintenanceMode' settings.maintenance}}
         {{inject 'urls' urls}}
-        {{{snippet 'htmlhead'}}}
         <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
         <script async custom-element="amp-sidebar" src="https://cdn.ampproject.org/v0/amp-sidebar-0.1.js"></script>
         {{#if settings.amp_analytics_id}}

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -28,10 +28,8 @@
         {{inject 'secureBaseUrl' settings.secure_base_url}}
         {{inject 'cartId' cart_id}}
         {{inject 'template' template}}
-        {{{snippet 'htmlhead'}}}
     </head>
     <body>
-        {{{snippet 'header'}}}
         <svg data-src="{{cdn 'img/icon-sprite.svg'}}" class="icons-svg-sprite"></svg>
 
         {{#and settings.privacy_cookie settings.is_eu_ip_address}}
@@ -50,6 +48,5 @@
         </script>
 
         {{{footer.scripts}}}
-        {{{snippet 'footer'}}}
     </body>
 </html>

--- a/templates/pages/account/orders/all.html
+++ b/templates/pages/account/orders/all.html
@@ -28,7 +28,6 @@ customer:
             {{/if}}
         </section>
     </div>
-    {{{snippet 'account'}}}
 </main>
 
 {{/partial}}

--- a/templates/pages/amp/category.html
+++ b/templates/pages/amp/category.html
@@ -31,7 +31,7 @@ category:
         {{!-- Category descriptions should include valid AMP markup. Read more about what are valid components: https://www.ampproject.org/docs/reference/components
 
             {{{category.description}}}
-            {{{snippet 'categories'}}}  --}}
+        --}}
     </div>
     <main class="page-content" id="product-listing-container">
         {{#if category.products}}

--- a/templates/pages/brand.html
+++ b/templates/pages/brand.html
@@ -21,7 +21,6 @@ brand:
     </div>
 {{/if}}
 <h1 class="page-heading">{{brand.name}}</h1>
-{{{snippet 'brand'}}}
 <div class="page">
     <aside class="page-sidebar" id="faceted-search-container">
         {{> components/brand/sidebar}}

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -51,7 +51,6 @@ cart: true
             {{{ remote_api_scripts }}}
         {{/if}}
 
-        {{{snippet 'cart'}}}
     </main>
 </div>
 {{/partial}}

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -24,7 +24,6 @@ category:
     <h1 class="page-heading">{{category.name}}</h1>
 {{/unless}}
 {{{category.description}}}
-{{{snippet 'categories'}}}
 <div class="page">
     {{#if category.faceted_search_enabled}}
         <aside class="page-sidebar" id="faceted-search-container">

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -15,7 +15,6 @@ blog:
     {{#if carousel}}
         {{> components/carousel arrows=theme_settings.homepage_show_carousel_arrows}}
     {{/if}}
-    {{{snippet 'home_content'}}}
 {{/partial}}
 
 {{#partial "page"}}

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -15,7 +15,6 @@ product_results:
 
 {{#partial "page"}}
 {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
-{{{snippet 'search'}}}
 <section class="nav">
     {{#if forms.search.query}}
         <div id="search-results-heading">


### PR DESCRIPTION
#### What?

Related:

https://github.com/bigcommerce/cornerstone/pull/1193
https://github.com/bigcommerce/cornerstone/pull/1478

This removes legacy "snippet" locations which were intended for CMS functionality which was never built. These have been deprecated in favor of [Widgets](https://developer.bigcommerce.com/api-docs/storefront/widgets/widgets-overview).

This should cause no functional change, and is purely for "cleanup" purposes so that developers are not confused by the presence of these.

ping @bigcommerce/storefront-team @bigcommerce/merc-team 
