### PR TITLE
Fix mobile banner text displaying with underline on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Remove deprecated "snippet" locations [#1479](https://github.com/bigcommerce/cornerstone/pull/1479)
 - Fix dropdown cart not showing discounts [#1481](https://github.com/bigcommerce/cornerstone/pull/1481)
+- Fix mobile banner text displaying with underline on mobile. [#1482](https://github.com/bigcommerce/cornerstone/pull/1482)
 
 ## 3.4.1 (2019-04-11)
 - Sanitize faceted search item's title [#1426](https://github.com/bigcommerce/cornerstone/pull/1426)

--- a/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
+++ b/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
@@ -36,6 +36,10 @@
         display: none;
     }
 
+    a {
+        text-decoration: none;
+    }
+
     .slick-next,
     .slick-prev {
         top: 50%;


### PR DESCRIPTION
#### What?

Hero carousel text is displaying with an underline on small screen sizes.

#### Tickets / Documentation

#1303 

#### Screenshots

**BEFORE**
<img width="832" alt="1 before" src="https://user-images.githubusercontent.com/5056945/52827580-40093780-307a-11e9-860d-f7db0efb0bfd.png">

**AFTER**
<img width="832" alt="2 after" src="https://user-images.githubusercontent.com/5056945/52827581-40a1ce00-307a-11e9-9ad8-390f9c6008c2.png">
