### PR TITLE
Fix to open Bulk Pricing modal from Quick View.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fix to open Bulk Pricing modal from Quick View. [#1483](https://github.com/bigcommerce/cornerstone/pull/1483)
 
 ## 3.4.2 (2019-04-30)
 - Remove deprecated "snippet" locations [#1479](https://github.com/bigcommerce/cornerstone/pull/1479)

--- a/assets/js/theme/product.js
+++ b/assets/js/theme/product.js
@@ -13,6 +13,7 @@ export default class Product extends PageManager {
         super(context);
         this.url = window.location.href;
         this.$reviewLink = $('[data-reveal-id="modal-review-form"]');
+        this.$bulkPricingLink = $('[data-reveal-id="modal-bulk-pricing"]');
     }
 
     onReady() {
@@ -50,11 +51,18 @@ export default class Product extends PageManager {
         });
 
         this.productReviewHandler();
+        this.bulkPricingHandler();
     }
 
     productReviewHandler() {
         if (this.url.indexOf('#write_review') !== -1) {
             this.$reviewLink.trigger('click');
+        }
+    }
+
+    bulkPricingHandler() {
+        if (this.url.indexOf('#bulk_pricing') !== -1) {
+            this.$bulkPricingLink.trigger('click');
         }
     }
 }

--- a/templates/components/products/bulk-discount-rates.html
+++ b/templates/components/products/bulk-discount-rates.html
@@ -1,12 +1,12 @@
 {{#if bulk_discount_rates.length}}
     {{#if product}}<dt class="productView-info-name">{{lang 'products.bulk_pricing.title'}}</dt>{{/if}}
     <dd class="productView-info-value">
-        <a href="{{url}}"
-           {{#unless is_ajax }}data-reveal-id="bulkPricingModal{{#if id}}-{{id}}-{{$index}}{{/if}}"{{/unless}}>
+        <a href="{{product.url}}#bulk_pricing"
+           {{#unless is_ajax }}data-reveal-id="modal-bulk-pricing"{{/unless}}>
             {{lang 'products.bulk_pricing.view'}}
         </a>
     </dd>
-    <div id="bulkPricingModal{{#if id}}-{{id}}-{{$index}}{{/if}}" class="modal modal--small" data-reveal>
+    <div id="modal-bulk-pricing" class="modal modal--small" data-reveal>
         <div class="modal-header">
             <h2 class="modal-header-title">{{lang 'products.bulk_pricing.modal_title'}}</h2>
             <a href="#" class="modal-close" aria-label="Close"><span aria-hidden="true">&#215;</span></a>


### PR DESCRIPTION
#### What?

Currently, the Bulk Pricing link doesn't work from a Quick View modal. Clicking on the "Buy in bulk and save" link effectively closes the Quick View modal.

This PR replicates the behavior for Write a Review from Quick View. Now, clicking on the "Buy in bulk and save" link from Quick View will open the Product page and immediately open the Bulk Pricing modal.

#### Screenshots (if appropriate)

Before:
![before](https://user-images.githubusercontent.com/1546172/56528085-814b1700-6503-11e9-8017-13e6574e4f88.gif)

After:
![after](https://user-images.githubusercontent.com/1546172/56528093-84460780-6503-11e9-809a-607fab19ac62.gif)

