### PR TITLE
fix(storefront): STRF-6540 Fire facebook pixel AddToCart in modal

### DIFF
--- a/templates/components/cart/preview.html
+++ b/templates/components/cart/preview.html
@@ -112,3 +112,4 @@
         </section>
     {{/if}}
 </div>
+{{{ remote_api_scripts }}}


### PR DESCRIPTION
#### What?

Add handlebars for `remote_api_scripts` to the preview.html we use for the add to cart preview, so that the Facebook `AddToCart` pixel will fire from the modal window.

#### Tickets / Documentation

- [BC Jira ticket](https://jira.bigcommerce.com/browse/STRF-6540)

Tested this with a theme I changed & bundled locally.

#### Screenshots (if appropriate)

![Screencast showing pixel firing](https://screencast.com/t/Jy8JGXvI)
