### PR TITLE
feat(payments): PAYMENTS-4228 include currency_code field in Account > Payment Methods page

### DIFF
--- a/assets/js/theme/common/payment-method.js
+++ b/assets/js/theme/common/payment-method.js
@@ -38,8 +38,9 @@ export const storeInstrument = ({
     vaultToken,
 }, {
     /* eslint-disable */
-    // Provider Name
+    // Provider Info
     provider_id,
+    currency_code,
 
     // Instrument Details
     credit_card_number,
@@ -98,6 +99,7 @@ export const storeInstrument = ({
             }),
             provider_id,
             default_instrument,
+            currency_code,
         }),
     })
         .done(done)

--- a/templates/pages/account/add-payment-method.html
+++ b/templates/pages/account/add-payment-method.html
@@ -39,6 +39,7 @@
         <form data-payment-method-form class="form">
             <input type="hidden" name="email" value="{{customer.email}}">
             <input type="hidden" name="provider_id" value="{{forms.provider}}">
+            <input type="hidden" name="currency_code" value="{{currency_selector.active_currency_code}}">
 
             <h3 class="paymentMethodForm-heading">{{lang 'account.payment_methods.payment_method'}}</h3>
 

--- a/templates/pages/account/edit-payment-method.html
+++ b/templates/pages/account/edit-payment-method.html
@@ -14,6 +14,7 @@
 
         <form action="{{customer.payment_methods.selected_payment_method.forms.action}}" data-address-form class="form" method="post">
             <input type="hidden" name="bigpay_token" value="{{customer.payment_methods.selected_payment_method.bigpay_token}}">
+            <input type="hidden" name="currency_code" value="{{currency_selector.active_currency_code}}">
 
             <h3 class="paymentMethodForm-heading">{{lang 'account.payment_methods.payment_method'}}</h3>
 


### PR DESCRIPTION
#### What?

Includes `currency_code` field within the Account > Payment Methods section.
We are wanting to send the shopper selected currency code whenever a shopper adds/edits a new payment method.

#### Tickets / Documentation

- [PAYMENTS-4228](https://jira.bigcommerce.com/browse/PAYMENTS-4228)
