### PR TITLE
MERC-4895: Fix swapping of Star review icon (full/empty) settings

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1915,12 +1915,12 @@
       {
         "type": "color",
         "label": "Star review icon (full)",
-        "id": "icon-ratingEmpty"
+        "id": "icon-ratingFull"
       },
       {
         "type": "color",
         "label": "Star review icon (empty)",
-        "id": "icon-ratingFull"
+        "id": "icon-ratingEmpty"
       },
       {
         "type": "color",


### PR DESCRIPTION
#### What?

The `Star review icon (full)` and `Star review icon (empty)` settings were swapped (such that `Star review icon (full)` was associated with `icon-ratingEmpty`). This corrects that issue. 

#### Tickets / Documentation

[MERC-4895](https://jira.bigcommerce.com/browse/MERC-4895)
