### PR TITLE
Update to make Product Reviews Link Clickable

### DIFF
--- a/assets/js/theme/product/reviews.js
+++ b/assets/js/theme/product/reviews.js
@@ -22,7 +22,7 @@ export default class {
      */
     initLinkBind() {
         const $content = $('#productReviews-content', this.$reviewsContent);
-
+        $('.productView-reviewTabLink').trigger('click');
         $('.productView-reviewLink').on('click', () => {
             if (!$content.hasClass('is-open')) {
                 this.$collapsible.trigger(CollapsibleEvents.click);


### PR DESCRIPTION
#### What?

Previously, when show_product_reviews_tabs was set to true in config.json nothing would happen when user clicked the link to product reviewsn.  This line of code should fix that issue.  

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/STRF-5521
