### PR TITLE
STRF-5521 PDP Product Reviews Link Not Clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+--Fix to PDP Product Reviews Link Not Clickable. [1498](https://github.com/bigcommerce/cornerstone/pull/1498)
 
 ## 3.4.3 (2019-05-10)
 - Fix to open Bulk Pricing modal from Quick View. [#1483](https://github.com/bigcommerce/cornerstone/pull/1483)

--- a/assets/js/theme/product/reviews.js
+++ b/assets/js/theme/product/reviews.js
@@ -24,6 +24,7 @@ export default class {
         const $content = $('#productReviews-content', this.$reviewsContent);
 
         $('.productView-reviewLink').on('click', () => {
+            $('.productView-reviewTabLink').trigger('click');
             if (!$content.hasClass('is-open')) {
                 this.$collapsible.trigger(CollapsibleEvents.click);
             }


### PR DESCRIPTION
#### What?

Previously when config.json had show_product_reviews_tab as true the reviews link when clicked would do nothing.  This fix should make it so that instead the reviews tab is opened and window is directed to it.

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/STRF-5521
