### PR TITLE
CHECKOUT-4118 Remove remote_api_scripts from the templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Fix to PDP Product Reviews Link Not Clickable. [#1498](https://github.com/bigcommerce/cornerstone/pull/1498)
 - Update jQuery to 3.4.1 [#1502](https://github.com/bigcommerce/cornerstone/pull/1502)
+- Remove remote_api_scripts to avoid double firing analytics [#1505](https://github.com/bigcommerce/cornerstone/pull/1505)
 
 ## 3.4.3 (2019-05-10)
 - Fix to open Bulk Pricing modal from Quick View. [#1483](https://github.com/bigcommerce/cornerstone/pull/1483)

--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -132,4 +132,3 @@
         {{/each}}
     </tbody>
 </table>
-{{{ remote_api_scripts }}}

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -48,7 +48,6 @@ cart: true
             {{/if}}
         {{else}}
             <h3>{{lang 'cart.checkout.empty_cart'}}</h3>
-            {{{ remote_api_scripts }}}
         {{/if}}
 
     </main>


### PR DESCRIPTION
#### What?

This should avoid double inclusion of some of the analytics code. (eg. facebook pixel)

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/CHECKOUT-4118

#### Screenshots (if appropriate)

Before:
<img width="980" alt="image" src="https://user-images.githubusercontent.com/4542735/58215861-3826f680-7d3f-11e9-8456-fc03078d9a9e.png">

After:
<img width="971" alt="image" src="https://user-images.githubusercontent.com/4542735/58215972-aff52100-7d3f-11e9-9c15-9ed894ce0869.png">

@bigcommerce/storefront-team @lord2800 @megdesko 
