### PR TITLE
Clean up whitespace in layout/base.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Update license year [#1510](https://github.com/bigcommerce/cornerstone/pull/1510)
 - Remove Node 6 from Travis [#1511](https://github.com/bigcommerce/cornerstone/pull/1511)
+- Clean up whitespace in <head> [#1513](https://github.com/bigcommerce/cornerstone/pull/1513)
 
 ## 3.4.4 (2019-05-23)
 - Fix to PDP Product Reviews Link Not Clickable. [#1498](https://github.com/bigcommerce/cornerstone/pull/1498)

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -11,7 +11,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 
         <script>
-            // Change document class from no-js to js so we can detect this in css
+            {{!-- Change document class from no-js to js so we can detect this in css --}}
             document.documentElement.className = document.documentElement.className.replace('no-js', 'js');
         </script>
 
@@ -21,18 +21,18 @@
         {{{head.scripts}}}
         {{{head.rsslinks}}}
 
-        {{inject 'themeSettings' theme_settings}}
-        {{inject 'genericError' (lang 'common.generic_error')}}
-        {{inject 'maintenanceMode' settings.maintenance}}
-        {{inject 'urls' urls}}
-        {{inject 'secureBaseUrl' settings.secure_base_url}}
-        {{inject 'cartId' cart_id}}
-        {{inject 'template' template}}
+        {{~inject 'themeSettings' theme_settings}}
+        {{~inject 'genericError' (lang 'common.generic_error')}}
+        {{~inject 'maintenanceMode' settings.maintenance}}
+        {{~inject 'urls' urls}}
+        {{~inject 'secureBaseUrl' settings.secure_base_url}}
+        {{~inject 'cartId' cart_id}}
+        {{~inject 'template' template}}
     </head>
     <body>
         <svg data-src="{{cdn 'img/icon-sprite.svg'}}" class="icons-svg-sprite"></svg>
 
-        {{#and settings.privacy_cookie settings.is_eu_ip_address}}
+        {{~#and settings.privacy_cookie settings.is_eu_ip_address}}
             {{> components/common/cookie}}
         {{/and}}
 
@@ -43,7 +43,7 @@
         <script>window.__webpack_public_path__ = "{{cdn 'assets/dist/'}}";</script>
         <script src="{{cdn 'assets/dist/theme-bundle.main.js'}}"></script>
         <script>
-            // Exported in app.js
+            {{!-- Exported in app.js --}}
             window.stencilBootstrap("{{page_type}}", {{jsContext}}).load();
         </script>
 


### PR DESCRIPTION
The <head> of the storefront contains a bunch of empty stuff when you llook at it in prod - this removes some of that which makes it a little easier to develop on Cornerstone.

#### Before

![image](https://user-images.githubusercontent.com/8922457/58731597-c42ac500-83b4-11e9-9ec7-5138f5503f9f.png)

#### After

![image](https://user-images.githubusercontent.com/8922457/58731574-b5441280-83b4-11e9-91ad-11e644a89554.png)
