### PR TITLE
STRF-3591 add return instructions in return-saved.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Draft
 - Update @babel/polyfill to 7.4.4 [#1521](https://github.com/bigcommerce/cornerstone/pull/1521)
 - Add maxlength to text options [#1531](https://github.com/bigcommerce/cornerstone/pull/1531)
+- Add return instructions in return-saved.html [#1525](https://github.com/bigcommerce/cornerstone/pull/1525)
 
 ## 3.5.1 (2019-06-24)
 - Fix conditional logic in share.html [#1522](https://github.com/bigcommerce/cornerstone/pull/1522)

--- a/lang/en.json
+++ b/lang/en.json
@@ -391,6 +391,7 @@
         },
         "returns": {
             "heading": "Returns",
+            "instructions": "Return Instructions",
             "error_no_qty": "Please select one or more items to return.",
             "none": "You haven't placed any returns with us. When you do, they will appear on this page.",
             "new_return": "New Return",

--- a/templates/pages/account/return-saved.html
+++ b/templates/pages/account/return-saved.html
@@ -1,12 +1,16 @@
 {{#partial "page"}}
 <div class="account">
     {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
-    <h2 class="page-heading">{{lang 'account.returns.heading' }}</h2>
+    <h2 class="page-heading">{{lang 'account.returns.heading'}}</h2>
     {{> components/account/navigation account_page='returns'}}
     <div class="account-row">
         <p>
             {{lang 'account.returns.successful'}}
         </p>
+        {{#if return.instructions}}
+            <h3>{{lang 'account.returns.instructions'}}</h3>
+            <p>{{return.instructions}}</p>
+        {{/if}}
     </div>
 </div>
 {{/partial}}


### PR DESCRIPTION
#### What?
Previously return instructions did not appear after submitting a return request and one would need to edit the template file in return-saved.html to display return instructions even if they had configured returns instructions in the control panel.  This pull request is to fix that issue.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [Link 1](https://jira.bigcommerce.com/browse/STRF-3591)

#### Screenshots (if appropriate)

Attach images or add image links here.
![image](https://user-images.githubusercontent.com/50118040/59980212-7108f400-95a7-11e9-833c-a6f54b8085f2.png)
![image](https://user-images.githubusercontent.com/50118040/59980215-76663e80-95a7-11e9-93d7-4582506bb78f.png)

