### PR TITLE
STRF-3382 display facebook like button when enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add return instructions in return-saved.html [#1525](https://github.com/bigcommerce/cornerstone/pull/1525)
 - Remove Google Plus [#1526](https://github.com/bigcommerce/cornerstone/pull/1526)
 - Fix broken conditional statement in share.html [#1533](https://github.com/bigcommerce/cornerstone/pull/1533)
+- Enable Facebook like button to be displayed on product page if enabled [#1530](https://github.com/bigcommerce/cornerstone/pull/1530)
 
 ## 3.5.1 (2019-06-24)
 - Fix conditional logic in share.html [#1522](https://github.com/bigcommerce/cornerstone/pull/1522)

--- a/templates/components/common/share.html
+++ b/templates/components/common/share.html
@@ -33,10 +33,6 @@
                             <svg>
                                 <use xlink:href="#icon-pinterest"/>
                             </svg>
-                        {{else if service '===' 'facebook_like'}}
-                            <svg>
-                                <use xlink:href="#icon-facebook_like"/>
-                            </svg>
                         {{/if}}
                     </a>
                 </li>
@@ -52,4 +48,14 @@
             });
         </script>
     </div>
+{{/if}}
+{{#if settings.facebook_like_button.enabled}}
+    <iframe 
+        class="facebook{{#if settings.facebook_like_button.verb '===' 'recommend'}}Recommend{{else}}Like{{/if}}Btn" 
+        style="border:none; overflow:hidden; margin: 0; padding: 0; position:absolute" 
+        src="https://www.facebook.com/plugins/like.php?href={{settings.facebook_like_button.href}}&amp;layout=button_count{{#if settings.facebook_like_button.verb '===' 'recommend'}}&amp;action=recommend{{/if}}&amp;colorscheme=light&amp;height=20" 
+        scrolling="no" 
+        frameborder="0" 
+        allowTransparency="true">
+    </iframe>
 {{/if}}


### PR DESCRIPTION
#### What?

Display like button when it is enabled through control panel.  This pull request is to fix a bug where the facebook like button would not display when enabled.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [Link 1](https://jira.bigcommerce.com/browse/STRF-3382)

#### Screenshots (if appropriate)

Attach images or add image links here.

<img width="1260" alt="Screen Shot 2019-06-26 at 9 54 27 PM" src="https://user-images.githubusercontent.com/50118040/60235577-14cefa00-985d-11e9-8fbd-a911258830a0.png">
