### PR TITLE
STRF-6042 add maxlength to text options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Update @babel/polyfill to 7.4.4 [#1521](https://github.com/bigcommerce/cornerstone/pull/1521)
+- Add maxlength to text options [#1531](https://github.com/bigcommerce/cornerstone/pull/1531)
 
 ## 3.5.1 (2019-06-24)
 - Fix conditional logic in share.html [#1522](https://github.com/bigcommerce/cornerstone/pull/1522)

--- a/templates/components/products/options/input-text.html
+++ b/templates/components/products/options/input-text.html
@@ -7,5 +7,5 @@
         {{/if}}
     </label>
 
-    <input class="form-input form-input--small" type="text" id="attribute_text_{{id}}" name="attribute[{{this.id}}]" value="{{this.prefill}}" {{#if required}}required{{/if}}>
+    <input class="form-input form-input--small" type="text" id="attribute_text_{{id}}" name="attribute[{{this.id}}]" value="{{this.prefill}}" {{#if required}}required{{/if}} {{#if max_length}}maxlength="{{max_length}}"{{/if}}>
 </div>

--- a/templates/components/products/options/textarea.html
+++ b/templates/components/products/options/textarea.html
@@ -7,5 +7,5 @@
         {{/if}}
     </label>
 
-    <textarea class="form-input" id="attribute_textarea_{{id}}" name="attribute[{{id}}]" {{#if required}}required{{/if}}>{{prefill}}</textarea>
+    <textarea class="form-input" id="attribute_textarea_{{id}}" name="attribute[{{id}}]" {{#if required}}required{{/if}} {{#if max_length}}maxlength={{max_length}}{{/if}}>{{prefill}}</textarea>
 </div>


### PR DESCRIPTION
#### What?
Including the maxlength attribute on text input options and multi line text options if a max length value has been defined by the merchant.

#### Tickets / Documentation
https://jira.bigcommerce.com/browse/STRF-6042
