### PR TITLE
PAYMENTS-4520 Fix incorrect DOM selectors causing the payment method form on the account page from working properly in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix broken conditional statement in share.html [#1533](https://github.com/bigcommerce/cornerstone/pull/1533)
 - Enable Facebook like button to be displayed on product page if enabled [#1530](https://github.com/bigcommerce/cornerstone/pull/1530)
 - Remove nanobar (loading bar) [#1537](https://github.com/bigcommerce/cornerstone/pull/1537)
+- Fix incorrect DOM selectors causing the payment method form on the account page from working properly in Safari [#1541](https://github.com/bigcommerce/cornerstone/pull/1541)
 
 ## 3.5.1 (2019-06-24)
 - Fix conditional logic in share.html [#1522](https://github.com/bigcommerce/cornerstone/pull/1522)

--- a/assets/js/theme/account.js
+++ b/assets/js/theme/account.js
@@ -255,7 +255,7 @@ export default class Account extends PageManager {
         $(`${paymentMethodSelector} input[name="credit_card_number"]`).on('keyup', ({ target }) => {
             cardType = creditCardType(target.value);
             if (cardType) {
-                $(`${paymentMethodSelector} img[alt="${cardType}"`).siblings().css('opacity', '.2');
+                $(`${paymentMethodSelector} img[alt="${cardType}"]`).siblings().css('opacity', '.2');
             } else {
                 $(`${paymentMethodSelector} img`).css('opacity', '1');
             }
@@ -269,7 +269,7 @@ export default class Account extends PageManager {
 
         // Set of credit card format
         CCFormatters.setCreditCardNumberFormat(`${paymentMethodSelector} input[name="credit_card_number"]`);
-        CCFormatters.setExpirationFormat(`${paymentMethodSelector} input[name="expiration"`);
+        CCFormatters.setExpirationFormat(`${paymentMethodSelector} input[name="expiration"]`);
 
         // Billing address validation
         paymentMethodValidator.add(validationModel);


### PR DESCRIPTION
#### What?

Fix incorrect DOM selectors causing the payment method form on the account page from working properly in Safari.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [PAYMENTS-4520](https://jira.bigcommerce.com/browse/PAYMENTS-4520)

@bigcommerce/payments @bigcommerce/storefront-team 
