### PR TITLE
Prevent heading from displaying when no price ranges are available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Remove nanobar (loading bar) [#1537](https://github.com/bigcommerce/cornerstone/pull/1537)
 - Fix incorrect DOM selectors causing the payment method form on the account page from working properly in Safari [#1541](https://github.com/bigcommerce/cornerstone/pull/1541)
 - Add Amazon Pay and Google Pay to payment icons in footer [#1542](https://github.com/bigcommerce/cornerstone/pull/1542)
+- Remove head.rsslinks [#1539](https://github.com/bigcommerce/cornerstone/pull/1539)
 - Prevent heading from displaying when no price ranges are available [#1545](https://github.com/bigcommerce/cornerstone/pull/1545)
 
 ## 3.5.1 (2019-06-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Remove nanobar (loading bar) [#1537](https://github.com/bigcommerce/cornerstone/pull/1537)
 - Fix incorrect DOM selectors causing the payment method form on the account page from working properly in Safari [#1541](https://github.com/bigcommerce/cornerstone/pull/1541)
 - Add Amazon Pay and Google Pay to payment icons in footer [#1542](https://github.com/bigcommerce/cornerstone/pull/1542)
+- Prevent heading from displaying when no price ranges are available [#1545](https://github.com/bigcommerce/cornerstone/pull/1545)
 
 ## 3.5.1 (2019-06-24)
 - Fix conditional logic in share.html [#1522](https://github.com/bigcommerce/cornerstone/pull/1522)

--- a/templates/components/category/shop-by-price.html
+++ b/templates/components/category/shop-by-price.html
@@ -1,4 +1,5 @@
 {{#if theme_settings.shop_by_price_visibility}}
+  {{#if shop_by_price}}
     <div class="sidebarBlock">
         <h5 class="sidebarBlock-heading">{{lang 'category.shop_by_price'}}</h5>
         <ul class="navList">
@@ -17,4 +18,5 @@
             {{/any}}
         </ul>
     </div>
+  {{/if}}
 {{/if}}

--- a/templates/components/category/shop-by-price.html
+++ b/templates/components/category/shop-by-price.html
@@ -1,5 +1,4 @@
-{{#if theme_settings.shop_by_price_visibility}}
-  {{#if shop_by_price}}
+{{#and theme_settings.shop_by_price_visibility shop_by_price}}
     <div class="sidebarBlock">
         <h5 class="sidebarBlock-heading">{{lang 'category.shop_by_price'}}</h5>
         <ul class="navList">
@@ -18,5 +17,4 @@
             {{/any}}
         </ul>
     </div>
-  {{/if}}
-{{/if}}
+{{/and}}


### PR DESCRIPTION
#### What?

It is possible for a category to have an insufficient number of items to generate price ranges. If the theme is customized to display the "Shop by Price" sidebar and the category does not generate a price range, only the heading is displayed. This change ensures there are price ranges available before displaying the heading and price ranges. 

#### Tickets / Documentation

N/A

#### Screenshots (if appropriate)

Example of heading displayed with no price ranges.

![image](https://user-images.githubusercontent.com/18220061/61559799-235d9b00-aa30-11e9-94e0-725b86923304.png)
