### PR TITLE
Remove "new products" carousel, use same display used for featured products and best sellers

### DIFF
--- a/config.json
+++ b/config.json
@@ -49,7 +49,7 @@
     "hide_category_page_heading": false,
     "hide_blog_page_heading": false,
     "hide_contact_us_page_heading": false,
-    "homepage_new_products_count": 5,
+    "homepage_new_products_count": 4,
     "homepage_featured_products_count": 4,
     "homepage_top_products_count": 4,
     "homepage_show_carousel": true,

--- a/templates/components/products/featured.html
+++ b/templates/components/products/featured.html
@@ -3,7 +3,7 @@
 <ul class="productGrid productGrid--maxCol{{ columns }}" data-product-type="featured" {{#if settings.data_tag_enabled}} data-list-name="Featured Products" {{/if}}>
     {{#each products}}
         <li class="product">
-                {{>components/products/card settings=../settings theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
+            {{>components/products/card settings=../settings theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
         </li>
     {{/each}}
 </ul>

--- a/templates/components/products/new.html
+++ b/templates/components/products/new.html
@@ -1,6 +1,9 @@
 <h2 class="page-heading">{{lang 'products.new' }}</h2>
-{{#if settings.data_tag_enabled}}
-    {{> components/products/carousel products=products list="New Products"}}
-{{else}}
-    {{> components/products/carousel products=products}}
-{{/if}}
+
+<ul class="productGrid productGrid--maxCol{{ columns }}" data-product-type="new" {{#if settings.data_tag_enabled}} data-list-name="New Products" {{/if}}>
+    {{#each products}}
+        <li class="product">
+            {{>components/products/card settings=../settings theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
+        </li>
+    {{/each}}
+</ul>

--- a/templates/components/products/top.html
+++ b/templates/components/products/top.html
@@ -1,9 +1,9 @@
 <h2 class="page-heading">{{lang 'products.top' }}</h2>
 
 <ul class="productGrid productGrid--maxCol{{ columns }}" data-product-type="top_sellers"  {{#if settings.data_tag_enabled}} data-list-name="Most Popular Products" {{/if}}>
-{{#each products}}
-<li class="product">
-    {{>components/products/card settings=../settings theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
-</li>
-{{/each}}
+    {{#each products}}
+        <li class="product">
+            {{>components/products/card settings=../settings theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
+        </li>
+    {{/each}}
 </ul>


### PR DESCRIPTION
#### What?

Standardize "New Products" to use the same display treatment as other homepage panels, to reduce complexity of the home page and fix a few bugs.