### PR TITLE
Fix bug where image is not clickable in product card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Prevent heading from displaying when no price ranges are available [#1545](https://github.com/bigcommerce/cornerstone/pull/1545)
 - Utilize srcset for responsive images [#1507](https://github.com/bigcommerce/cornerstone/pull/1507)
 - Clean up conditional logic in a couple component templates [#1547](https://github.com/bigcommerce/cornerstone/pull/1547)
+- Remove "demo" product conditional logic [#1551](https://github.com/bigcommerce/cornerstone/pull/1551)
 
 ## 3.5.1 (2019-06-24)
 - Fix conditional logic in share.html [#1522](https://github.com/bigcommerce/cornerstone/pull/1522)

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -16,7 +16,7 @@
                 </div>
             {{/if}}
         {{/or}}
-        {{#if demo}}<a href="{{url}}" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}}>{{/if}}
+        <a href="{{url}}" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}}>
             <div class="card-img-container">
                 {{> components/common/responsive-img
                     image=image
@@ -26,19 +26,17 @@
                     default_image=theme_settings.default_image_product
                 }}
             </div>
-        {{#if demo}}</a>{{/if}}
+        </a>
 
         <figcaption class="card-figcaption">
             <div class="card-figcaption-body">
                 {{#unless hide_product_quick_view}}
                     {{#if theme_settings.show_product_quick_view}}
-                        {{#unless demo}}
-                            {{#if settings.data_tag_enabled}}
-                                <a class="button button--small card-figcaption-button quickview" data-event-type="product-click" data-product-id="{{id}}">{{lang 'products.quick_view'}}</a>
-                            {{else}}
-                                <a class="button button--small card-figcaption-button quickview" data-product-id="{{id}}">{{lang 'products.quick_view'}}</a>
-                            {{/if}}
-                        {{/unless}}
+                        {{#if settings.data_tag_enabled}}
+                            <a class="button button--small card-figcaption-button quickview" data-event-type="product-click" data-product-id="{{id}}">{{lang 'products.quick_view'}}</a>
+                        {{else}}
+                            <a class="button button--small card-figcaption-button quickview" data-product-id="{{id}}">{{lang 'products.quick_view'}}</a>
+                        {{/if}}
                     {{/if}}
                 {{/unless}}
                 {{#if show_compare}}
@@ -77,11 +75,7 @@
             <p class="card-text" data-test-info-type="brandName">{{brand.name}}</p>
         {{/if}}
         <h4 class="card-title">
-            {{#if demo}}
-                {{name}}
-            {{else}}
-                <a href="{{url}}" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}}>{{name}}</a>
-            {{/if}}
+            <a href="{{url}}" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}}>{{name}}</a>
         </h4>
 
         <div class="card-text" data-test-info-type="price">


### PR DESCRIPTION
Removing unneeded `demo` conditional logic which is no longer used. Fixes a bug which was preventing product card images from being clicked.