### PR TITLE
mattcoy-arcticleaf's patch/product carousel responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Utilize srcset for responsive images [#1507](https://github.com/bigcommerce/cornerstone/pull/1507)
 - Clean up conditional logic in a couple component templates [#1547](https://github.com/bigcommerce/cornerstone/pull/1547)
 - Remove "demo" product conditional logic [#1551](https://github.com/bigcommerce/cornerstone/pull/1551)
+- Add responsive breakpoints to product carousel. [#1458](https://github.com/bigcommerce/cornerstone/pull/1458)
 
 ## 3.5.1 (2019-06-24)
 - Fix conditional logic in share.html [#1522](https://github.com/bigcommerce/cornerstone/pull/1522)

--- a/assets/scss/components/vendor/slick/_slick.scss
+++ b/assets/scss/components/vendor/slick/_slick.scss
@@ -170,3 +170,13 @@
     backface-visibility: hidden; // 2
     perspective: 1000px; // 2
 }
+
+//
+// iOS Safari fix https://github.com/kenwheeler/slick/issues/2834#issuecomment-389590661
+// -----------------------------------------------------------------------------
+div.slick-slider {
+    width: 1px;
+    min-width: 100%;
+    *width: 100%;
+}
+

--- a/templates/components/products/carousel.html
+++ b/templates/components/products/carousel.html
@@ -4,13 +4,29 @@
         "dots": true,
         "infinite": false,
         "mobileFirst": true,
-        "slidesToShow": {{ columns }},
-        "slidesToScroll": 3
+        "slidesToShow": 2,
+        "slidesToScroll": 2,
+        "responsive": [
+            {
+                "breakpoint": 800,
+                "settings": {
+                    "slidesToShow": {{ columns }},
+                    "slidesToScroll": 3
+                }
+            },
+            {
+                "breakpoint": 550,
+                "settings": {
+                    "slidesToShow": 3,
+                    "slidesToScroll": 3
+                }
+            }
+        ]
     }'
 >
     {{#each products}}
     <div class="productCarousel-slide">
-            {{> components/products/card settings=../settings theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
+        {{> components/products/card settings=../settings theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
     </div>
     {{/each}}
 </section>


### PR DESCRIPTION
#### What?

Pulling in @mattcoy-arcticleaf 's product carousel fix from https://github.com/bigcommerce/cornerstone/pull/1458 together with a slick carousel iOS/Safari fix from https://github.com/kenwheeler/slick/issues/2834#issuecomment-389590661.

Fixes styling issues in several spots where slick carousel is used.

#### Screenshots (if appropriate)

See original PR.