### PR TITLE
Fix tall images on PDPs and PLPs

### DIFF
--- a/assets/js/theme/global.js
+++ b/assets/js/theme/global.js
@@ -13,6 +13,7 @@ import maintenanceMode from './global/maintenanceMode';
 import carousel from './common/carousel';
 import loadingProgressBar from './global/loading-progress-bar';
 import svgInjector from './global/svg-injector';
+import objectFitImages from './global/object-fit-polyfill';
 
 export default class Global extends PageManager {
     onReady() {
@@ -28,5 +29,6 @@ export default class Global extends PageManager {
         maintenanceMode(this.context.maintenanceMode);
         loadingProgressBar();
         svgInjector();
+        objectFitImages();
     }
 }

--- a/assets/js/theme/global/object-fit-polyfill.js
+++ b/assets/js/theme/global/object-fit-polyfill.js
@@ -1,0 +1,5 @@
+import objectFitImages from 'object-fit-images';
+
+export default function () {
+    objectFitImages();
+}

--- a/assets/scss/components/citadel/cards/_cards.scss
+++ b/assets/scss/components/citadel/cards/_cards.scss
@@ -51,6 +51,9 @@
     border: 0;
     width: 100%;
     max-height: 100%;
+    object-fit: contain;
+    /* Object-fit polyfill */
+    font-family: 'object-fit: contain;';
 }
 
 .card-title {

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -49,6 +49,9 @@
         @include lazy-loaded-img;
         max-height: 100%;
         width: 100%;
+        object-fit: contain;
+        /* Object-fit polyfill */
+        font-family: 'object-fit: contain;';
     }
 
     @include lazy-loaded-padding('product_size');
@@ -79,6 +82,9 @@
         max-height: 50px;
         max-width: 50px;
         width: 100%;
+        object-fit: contain;
+        /* Object-fit polyfill */
+        font-family: 'object-fit: contain;';
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigcommerce-cornerstone",
-  "version": "4.0.0-rc.2",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -20603,6 +20603,11 @@
         "define-property": "^0.2.5",
         "kind-of": "^3.0.3"
       }
+    },
+    "object-fit-images": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/object-fit-images/-/object-fit-images-3.2.4.tgz",
+      "integrity": "sha512-G+7LzpYfTfqUyrZlfrou/PLLLAPNC52FTy5y1CBywX+1/FkxIloOyQXBmZ3Zxa2AWO+lMF0JTuvqbr7G5e5CWg=="
     },
     "object-keys": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lodash": "^4.17.4",
     "nanobar": "^0.4.2",
     "nod-validate": "^2.0.12",
+    "object-fit-images": "^3.2.4",
     "slick-carousel": "^1.8.1",
     "svg-injector": "^1.1.3",
     "sweetalert2": "^6.11.5"


### PR DESCRIPTION
#### What?

Cornerstone 4.0 introduced a bug in which images which are particularly tall (portrait) are stretched on PDPs and PLPs:

![image](https://user-images.githubusercontent.com/8922457/62970619-88a96f80-bdd5-11e9-8f72-1134047bdd35.png)

This fixes that using `object-fit: contain`.

#### Tickets / Documentation

- [Link 1](http://example.com)

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/8922457/62970655-9bbc3f80-bdd5-11e9-83d9-4c878c29b063.png)
![image](https://user-images.githubusercontent.com/8922457/62970661-9fe85d00-bdd5-11e9-83d4-3deba66362f8.png)

