### PR TITLE
Remove ‘aria-hidden’ attribute from main menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - deleted whitespaces in if statments(content.html) [#1560](https://github.com/bigcommerce/cornerstone/pull/1560)
+- Remove aria-hidden attribute from main menu [#1563](https://github.com/bigcommerce/cornerstone/pull/1563)
 
 ## 4.0.0 (2019-08-05)
 - Update @babel/polyfill to 7.4.4 [#1521](https://github.com/bigcommerce/cornerstone/pull/1521)

--- a/assets/js/theme/global/mobile-menu-toggle.js
+++ b/assets/js/theme/global/mobile-menu-toggle.js
@@ -92,9 +92,7 @@ export class MobileMenuToggle {
             .addClass('is-open')
             .attr('aria-expanded', true);
 
-        this.$menu
-            .addClass('is-open')
-            .attr('aria-hidden', false);
+        this.$menu.addClass('is-open');
 
         this.$header.addClass('is-open');
         this.$scrollView.scrollTop(0);
@@ -109,9 +107,7 @@ export class MobileMenuToggle {
             .removeClass('is-open')
             .attr('aria-expanded', false);
 
-        this.$menu
-            .removeClass('is-open')
-            .attr('aria-hidden', true);
+        this.$menu.removeClass('is-open');
 
         this.$header.removeClass('is-open');
 


### PR DESCRIPTION
#### What?

Currently, the aria-hidden attribute is being added to the main menu (id="menu") with a value of true. This breaks screen-reader capabilities as it hides the entire menu from the accessibility tree.

Additionally, this attribute is unneeded and redundant in this instance because the menu is being hidden with CSS (display: none). This also goes against MDN best practices for the attribute (see link below). Having the menu hidden with CSS is sufficient for hiding it from the accessibility tree.

This Pull Request removes the code that toggles the aria-hidden attribute on the menu (and sets it to true on page load).



#### Tickets / Documentation

- [Open Issue #1558 ](https://github.com/bigcommerce/cornerstone/issues/1558)
- [MDN Best Practices for Aria-hidden](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute#Best_practices)

#### Screenshots 

##### Current code for menu element on page load
![current](https://user-images.githubusercontent.com/47044676/63062866-494f5180-beaf-11e9-92ef-6f5cd1796bb7.png)

##### Updated code for menu element on page load
![updated](https://user-images.githubusercontent.com/47044676/63062865-48b6bb00-beaf-11e9-9dae-50c1a7df5bf3.png)
