### PR TITLE
feat(storefront): STRF-4418 allow alert text color editing from theme editor and update default alert text color for Bold variation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Allow alert text color editing from theme editor and update default alert text color for Bold variation [#1565](https://github.com/bigcommerce/cornerstone/pull/1565)
 - Add jquery-migrate to Modal test [#1599](https://github.com/bigcommerce/cornerstone/pull/1599)
 - Upgrade core-js to version 3 [#1598](https://github.com/bigcommerce/cornerstone/pull/1598)
 

--- a/config.json
+++ b/config.json
@@ -477,7 +477,7 @@
         "checkRadio-backgroundColor": "#444444",
         "checkRadio-borderColor": "#999999",
         "alert-backgroundColor": "#444444",
-        "alert-color": "#ffffff",
+        "alert-color": "#333333",
         "alert-color-alt": "#444444",
         "storeName-color": "#ffffff",
         "body-bg": "#444444",

--- a/schema.json
+++ b/schema.json
@@ -33,6 +33,11 @@
       },
       {
         "type": "color",
+        "label": "Alert popup text color",
+        "id": "alert-color"
+      },
+      {
+        "type": "color",
         "label": "Horizontal line",
         "id": "container-border-global-color-base"
       },


### PR DESCRIPTION
#### What?

Cornerstone bold uses #ffffff(white) for the alert box text color, this makes it very hard to see. This ticket changes the default Cornerstone bold alert text color to #333333 and makes the text color editable from the theme-editor
#### Tickets / Documentation

- [STRF-4418](https://jira.bigcommerce.com/browse/STRF-4418)

#### Screenshots (if appropriate)
Before:
![boldbefore](https://user-images.githubusercontent.com/20911717/63712114-9eba2580-c802-11e9-8b86-3f5281569564.png)

After:
![boldAfter](https://user-images.githubusercontent.com/20911717/63712124-a37ed980-c802-11e9-945a-95d55292df7d.png)

