### PR TITLE
Reset compare products counter after faceted search updates page content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Reset compare products counter after faceted search updates page content [#1571](https://github.com/bigcommerce/cornerstone/pull/1571)
 
 ## 4.1.0 (2019-08-28)
 - deleted whitespaces in if statments(content.html) [#1560](https://github.com/bigcommerce/cornerstone/pull/1560)

--- a/assets/js/theme/brand.js
+++ b/assets/js/theme/brand.js
@@ -39,6 +39,8 @@ export default class Brand extends CatalogPage {
             $productListingContainer.html(content.productListing);
             $facetedSearchContainer.html(content.sidebar);
 
+            $('body').triggerHandler('compareReset');
+
             $('html, body').animate({
                 scrollTop: 0,
             }, 100);

--- a/assets/js/theme/category.js
+++ b/assets/js/theme/category.js
@@ -39,6 +39,8 @@ export default class Category extends CatalogPage {
             $productListingContainer.html(content.productListing);
             $facetedSearchContainer.html(content.sidebar);
 
+            $('body').triggerHandler('compareReset');
+
             $('html, body').animate({
                 scrollTop: 0,
             }, 100);

--- a/assets/js/theme/global/compare-products.js
+++ b/assets/js/theme/global/compare-products.js
@@ -26,18 +26,18 @@ function updateCounterNav(counter, $link, urlContext) {
 }
 
 export default function (urlContext) {
-    let products;
+    let compareCounter = [];
 
-    const $checked = $('body').find('input[name="products\[\]"]:checked');
     const $compareLink = $('a[data-compare-nav]');
 
-    if ($checked.length !== 0) {
-        products = _.map($checked, element => element.value);
+    $('body').on('compareReset', () => {
+        const $checked = $('body').find('input[name="products\[\]"]:checked');
 
-        updateCounterNav(products, $compareLink, urlContext);
-    }
+        compareCounter = $checked.length ? _.map($checked, element => element.value) : [];
+        updateCounterNav(compareCounter, $compareLink, urlContext);
+    });
 
-    const compareCounter = products || [];
+    $('body').triggerHandler('compareReset');
 
     $('body').on('click', '[data-compare-id]', event => {
         const product = event.currentTarget.value;

--- a/assets/js/theme/search.js
+++ b/assets/js/theme/search.js
@@ -213,6 +213,8 @@ export default class Search extends CatalogPage {
             $searchHeading.html(content.heading);
             $searchCount.html(content.productCount);
 
+            $('body').triggerHandler('compareReset');
+
             $('html, body').animate({
                 scrollTop: 0,
             }, 100);


### PR DESCRIPTION
#### What?

This pull request implements a bug fix.

It requires "**_Product Filtering_**" to be **turned on** for the store.

When we select a faceted search filter, Cornerstone updates the page without reloading. It does an AJAX request and updates the URL using the History API. Some sections of contents are updated, with the HTML contents returned in the AJAX call response.

The problem is when we do this faceted search filter selection when we already have a few products selected for comparison, and the "Compare" link at the top header is appearing and active, with the number of selected products.

After the faceted search dynamic update described above is performed, the "Compare" link becomes out of sync with the updated contents. The "Compare" link keeps showing the same product count, and has the same URL. But... the updated contents contain no product selected for comparison, at all.

At this point, if we select another product for comparison (even the SAME previously selected product), the counter will be increased - although we are selecting the **first** product for comparison, among the filtered results.

This bug is very easy to reproduce, in unchanged Cornerstone theme, as long as we have Product Filtering turned on and some facets and products to play with.

This pull request simply resets the "compare products" counter / array, immediately after the page contents are updated with the faceted search results.

#### Tickets / Documentation

N/A

#### Screenshots (if appropriate)

N/A
