### PR TITLE
STRF-6450 - Updates to Product Page Template for Google Structured Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixes and some additions to our Google Structured Data schema for the product page template.
 
 ## 4.1.1 (2019-09-12)
 - Reset compare products counter after faceted search updates page content [#1571](https://github.com/bigcommerce/cornerstone/pull/1571)

--- a/templates/components/products/price-range.html
+++ b/templates/components/products/price-range.html
@@ -29,8 +29,11 @@
             <abbr title="{{lang 'products.including_tax'}}">{{lang 'products.price_with_tax' tax_label=price.price_range.min.tax_label}}</abbr>
         {{/and}}
         {{#if schema_org}}
-            <meta itemprop="availability" content="{{product.availability}}">
+            <meta itemprop="availability" itemtype="http://schema.org/ItemAvailability"
+                    content="http://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
             <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
+            <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
+            <meta itemprop="url" content="{{product.url}}">
             <div itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
                 <meta itemprop="minPrice" content="{{price_range.min.with_tax.value}}"  />
                 <meta itemprop="price" content="{{price_range.min.with_tax.value}}">
@@ -72,8 +75,11 @@
             <abbr title="{{lang 'products.excluding_tax'}}">{{lang 'products.price_without_tax' tax_label=price.price_range.min.tax_label}}</abbr>
         {{/and}}
         {{#if schema_org}}
-            <meta itemprop="availability" content="{{product.availability}}">
+            <meta itemprop="availability" itemtype="http://schema.org/ItemAvailability"
+                    content="http://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
             <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
+            <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
+            <meta itemprop="url" content="{{product.url}}">
             <div itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
                 <meta itemprop="minPrice" content="{{price.price_range.min.without_tax.value}}"  />
                 <meta itemprop="price" content="{{price.price_range.min.without_tax.value}}">

--- a/templates/components/products/price.html
+++ b/templates/components/products/price.html
@@ -31,6 +31,8 @@ If you are making a change here or in price-range.html, you probably want to mak
             {{#if schema_org}}
                 <meta itemprop="availability" content="{{product.availability}}">
                 <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
+                <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
+                <meta itemprop="url" content="{{product.url}}">
                 <div itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
                     <meta itemprop="price" content="{{price.with_tax.value}}">
                     <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
@@ -67,6 +69,8 @@ If you are making a change here or in price-range.html, you probably want to mak
                 <meta itemprop="availability" itemtype="http://schema.org/ItemAvailability"
                     content="http://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
                 <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
+                <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
+                <meta itemprop="url" content="{{product.url}}">
                 <div itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
                     <meta itemprop="price" content="{{price.without_tax.value}}">
                     <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -62,9 +62,13 @@
             {{product.detail_messages}}
             <dl class="productView-info">
                 <dt class="productView-info-name sku-label"{{#unless product.sku}} style="display: none;"{{/unless}}>{{lang 'products.sku'}}</dt>
-                <dd class="productView-info-value" data-product-sku>{{product.sku}}</dd>
+                <dd class="productView-info-value" data-product-sku{{#if schema}} itemprop="sku"{{/if}}>{{product.sku}}</dd>
                 <dt class="productView-info-name upc-label"{{#unless product.upc}} style="display: none;"{{/unless}}>{{lang 'products.upc'}}</dt>
                 <dd class="productView-info-value" data-product-upc>{{product.upc}}</dd>
+                {{#if schema}}
+                    {{#if product.mpn}}<meta itemprop="mpn" content="{{product.mpn}}" />{{/if}}
+                    {{#if product.gtin}}<meta itemprop="gtin" content="{{product.gtin}}" />{{/if}}
+                {{/if}}
                 {{#if product.condition}}
                     <dt class="productView-info-name">{{lang 'products.condition'}}</dt>
                     <dd class="productView-info-value">{{product.condition}}</dd>
@@ -164,7 +168,7 @@
                 {{!-- Remove the surrounding a-element if there is no main image. --}}
                 {{#if product.main_image}}
                     <a href="{{getImageSrcset product.main_image (cdn theme_settings.default_image_product) 1x=theme_settings.zoom_size}}"
-                        target="_blank">
+                        target="_blank"{{#if schema}} itemprop="image"{{/if}}>
                 {{/if}}
                 {{> components/common/responsive-img
                     image=product.main_image


### PR DESCRIPTION
#### What?
It was found that we are not properly marking up some fields that are available on a product page for Google Structured Data.  This PR fixes some of our markup and adds some additional markup.

The current errors seen on most product pages (which have reviews added to the product) is:
<img width="1865" alt="2019-09-24_1002" src="https://user-images.githubusercontent.com/6527334/65524115-e6d87080-deb2-11e9-89be-d437b57c0bcd.png">

Also found a bug where if a price range is being displayed then the "offer availability" property does not display correctly:
<img width="946" alt="2019-09-24_1009" src="https://user-images.githubusercontent.com/6527334/65524480-7a11a600-deb3-11e9-9fd0-7a034c737f2d.png">

#### Tickets / Documentation
JIRA ticket:
https://jira.bigcommerce.com/browse/STRF-6450

Google Structured Data (Product) information:
https://developers.google.com/search/docs/data-types/product

#### Screenshots (if appropriate)
Screenshot having applied my updated cornerstone bundle to my production store that I used to generate the error images above.  The product is displaying a price range:
<img width="978" alt="2019-09-24_1034" src="https://user-images.githubusercontent.com/6527334/65526549-e346e880-deb6-11e9-8e19-c3cdc49e75ea.png">


Note only 1 warnings is now seen. This remaining warning for `priceValidUntil` is not something we can currently address.