### PR TITLE
MERC-3688: Fix thumbnail image sizes

### DIFF
--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -124,6 +124,8 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
 }
 
 .cart-item-image {
+    max-width: get-width(stencilString('productthumb_size'));
+
     @include lazy-loaded-img;
 
     @include breakpoint("medium") {

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -79,12 +79,12 @@
 
     img {
         @include lazy-loaded-img;
-        max-height: 50px;
-        max-width: 50px;
-        width: 100%;
+        margin: 0;
+        width: get-width(stencilString('productview_thumb_size'));
         object-fit: contain;
         /* Object-fit polyfill */
         font-family: 'object-fit: contain;';
+        position: relative;
     }
 }
 
@@ -101,13 +101,14 @@
 
 .productView-thumbnail-link {
     border: container("border");
-    display: inline-block;
+    display: inline-flex;
     height: 67px;
     max-width: 75px;
     padding: 2px;
     position: relative;
-    text-align: center;
     width: 100%;
+    box-sizing: content-box;
+    justify-content: center;
 
     &:hover,
     &.is-active {

--- a/schema.json
+++ b/schema.json
@@ -1738,7 +1738,7 @@
         ]
       },      {
         "type": "imageDimension",
-        "label": "Thumbnail image in cart",
+        "label": "Thumbnail image in product page",
         "id": "productview_thumb_size",
         "force_reload": true,
         "options": [

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -198,7 +198,7 @@
                     >
                     {{> components/common/responsive-img
                         image=this
-                        fallback_size=../theme_settings.productthumb_size
+                        fallback_size=../theme_settings.productview_thumb_size
                         lazyload=../theme_settings.lazyload_mode
                     }}
                     </a>


### PR DESCRIPTION
#### What?

Fixes issue where thumbnails could not resize

#### Tickets / Documentation

[MERC-3688](https://jira.bigcommerce.com/browse/MERC-3688)

#### Screenshots (if appropriate)

<img width="945" alt="Screen Shot 2019-09-27 at 4 22 30 PM" src="https://user-images.githubusercontent.com/38708175/65807429-38972a00-e143-11e9-986e-aa215cb3fbff.png">
