### PR TITLE
STRF-7487 fix registerValidation function to always validate on writeReview-form email field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Added missing gift certificate translation
+- Fix registerValidation function to validate on writeReview-form email field [#1585](https://github.com/bigcommerce/cornerstone/pull/1585)
 
 ## 4.2.0 (2019-10-02)
 - Fixes and some additions to our Google Structured Data schema for the product page template [#1577](https://github.com/bigcommerce/cornerstone/pull/1577)

--- a/assets/js/theme/product/reviews.js
+++ b/assets/js/theme/product/reviews.js
@@ -72,7 +72,7 @@ export default class {
             validate: 'presence',
             errorMessage: this.context.reviewComment,
         }, {
-            selector: '[name="email"]',
+            selector: '.writeReview-form [name="email"]',
             validate: (cb, val) => {
                 const result = forms.email(val);
                 cb(result);


### PR DESCRIPTION
#### What?

There was an issue that was affecting Klaviyo in regards to product reviews as they were loading a third party script and the validator was validating against the third party script's email input field instead of the email input field that belonged to the writeReview-form css class.  This pr is to fix that issue so that a third party script can be on the page and a user can still post a review.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [Link 1](https://jira.bigcommerce.com/browse/STRF-7487)


#### Screenshots (if appropriate)

Attach images or add image links here.

![image](https://user-images.githubusercontent.com/50118040/66690278-e9bdba00-ec43-11e9-8d9e-8a7b9f77b97b.png)
