### PR TITLE
MERC-5570: Body text color doesn't effect some cart item headings for mobile and tablet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixes body text color not taking effect for cart item headings on mobile / tablet [#1586](https://github.com/bigcommerce/cornerstone/pull/1586)
 
 ## 4.2.1 (2019-10-15)
 - Added missing gift certificate translation

--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -207,7 +207,7 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
 }
 
 .cart-item-label {
-    color: color("greys", "light");
+    color: stencilColor("color-textBase");
     float: left;
     margin-bottom: spacing("quarter");
     text-align: right;


### PR DESCRIPTION
### What?
When viewing the cart page on mobile or tablet, the cart item headings are not respecting the body text configuration value defined by the user.

### Screenshots (if appropriate)

**Before**
![Screen Shot 2019-10-22 at 12 47 32 PM](https://user-images.githubusercontent.com/955777/67326039-decc1a80-f4ca-11e9-90ff-5f6acabb5796.png)
![Screen Shot 2019-10-22 at 12 47 43 PM](https://user-images.githubusercontent.com/955777/67326038-decc1a80-f4ca-11e9-973a-8bbb4f5a9cca.png)
![Screen Shot 2019-10-22 at 12 47 52 PM](https://user-images.githubusercontent.com/955777/67326037-decc1a80-f4ca-11e9-8717-d5fd8f87188a.png)

**After**
![Screen Shot 2019-10-22 at 12 46 24 PM](https://user-images.githubusercontent.com/955777/67326076-e7245580-f4ca-11e9-8ce8-935116129e15.png)
![Screen Shot 2019-10-22 at 12 46 37 PM](https://user-images.githubusercontent.com/955777/67326074-e68bbf00-f4ca-11e9-827c-ea3ff99845d9.png)
![Screen Shot 2019-10-22 at 12 46 48 PM](https://user-images.githubusercontent.com/955777/67326071-e68bbf00-f4ca-11e9-9dfc-d04f55782f87.png)

