### PR TITLE
chore: bumping stencil-cli forward for node 10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - 10
 sudo: required
-dist: trusty
+dist: xenial
 install:
   - bundle install --path vendor/bundle
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 8
+  - 10
 sudo: required
 dist: trusty
 install:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14600,37 +14600,44 @@
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
           "dev": true
         },
         "ansi": {
           "version": "0.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
           "dev": true
         },
         "ansi-regex": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
           "dev": true
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "async-some": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
           "dev": true,
           "requires": {
             "dezalgo": "^1.0.2"
@@ -14638,7 +14645,8 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true,
           "requires": {
             "inherits": "~2.0.0"
@@ -14646,22 +14654,26 @@
         },
         "char-spinner": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-5upnvSR+EHESmDt6sEee02KAAIE=",
           "dev": true
         },
         "chmodr": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BGYrky0PAuxm3qorDqQoEZaOPrk=",
           "dev": true
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true
         },
         "cmd-shim": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -14670,7 +14682,8 @@
         },
         "columnify": {
           "version": "1.5.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "dev": true,
           "requires": {
             "strip-ansi": "^3.0.0",
@@ -14679,7 +14692,8 @@
           "dependencies": {
             "wcwidth": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-AtBZ/3qPx0Hg9rXaHmmytA2uym8=",
               "dev": true,
               "requires": {
                 "defaults": "^1.0.0"
@@ -14687,7 +14701,8 @@
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                   "dev": true,
                   "requires": {
                     "clone": "^1.0.2"
@@ -14695,7 +14710,8 @@
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
                       "dev": true
                     }
                   }
@@ -14706,7 +14722,8 @@
         },
         "config-chain": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-f8OD3g/MhNcRy0Zb0XZXnK1hI0Y=",
           "dev": true,
           "requires": {
             "ini": "^1.3.4",
@@ -14715,14 +14732,16 @@
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
               "dev": true
             }
           }
         },
         "dezalgo": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "dev": true,
           "requires": {
             "asap": "^2.0.0",
@@ -14731,19 +14750,22 @@
           "dependencies": {
             "asap": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-H8HRVk7hFiDfym1nAphQkT+fRnk=",
               "dev": true
             }
           }
         },
         "editor": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
           "dev": true
         },
         "fs-vacuum": {
           "version": "1.2.9",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-T5AZOrjqAokJlbzU6ARlml02ay0=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -14753,7 +14775,8 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-5Jqt3yiPh9Rv+eiC8hahOrxAd4s=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -14764,14 +14787,16 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             }
           }
         },
         "fstream": {
           "version": "1.0.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -14782,7 +14807,8 @@
         },
         "fstream-npm": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-a5F122I5qD2CCeIyQmxJTbspaQw=",
           "dev": true,
           "requires": {
             "fstream-ignore": "^1.0.0",
@@ -14791,7 +14817,8 @@
           "dependencies": {
             "fstream-ignore": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
               "dev": true,
               "requires": {
                 "fstream": "^1.0.0",
@@ -14803,17 +14830,20 @@
         },
         "github-url-from-git": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-KF5rUggZABveEoZ0cEN55P8D4N4=",
           "dev": true
         },
         "github-url-from-username-repo": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo=",
           "dev": true
         },
         "glob": {
           "version": "7.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -14826,34 +14856,40 @@
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
               "dev": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-UUw4dysxvuLgi+3CGgrrOr9UwZ4=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -14862,17 +14898,20 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true
         },
         "init-package-json": {
           "version": "1.9.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tAU9C0Dwz4QqQZZpN8s9wPU06FY=",
           "dev": true,
           "requires": {
             "glob": "^6.0.0",
@@ -14887,7 +14926,8 @@
           "dependencies": {
             "glob": {
               "version": "6.0.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
               "dev": true,
               "requires": {
                 "inflight": "^1.0.4",
@@ -14899,14 +14939,16 @@
               "dependencies": {
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                   "dev": true
                 }
               }
             },
             "promzard": {
               "version": "0.3.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
               "dev": true,
               "requires": {
                 "read": "1"
@@ -14916,12 +14958,14 @@
         },
         "lockfile": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-nTU+z+P1TRULtX+J1RdGk1o5xPU=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.1",
@@ -14930,19 +14974,22 @@
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
               "dev": true
             },
             "yallist": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
               "dev": true
             }
           }
         },
         "minimatch": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.0.0"
@@ -14950,7 +14997,8 @@
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
               "dev": true,
               "requires": {
                 "balanced-match": "^0.4.1",
@@ -14959,12 +15007,14 @@
               "dependencies": {
                 "balanced-match": {
                   "version": "0.4.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                   "dev": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                   "dev": true
                 }
               }
@@ -14973,7 +15023,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -14981,14 +15032,16 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             }
           }
         },
         "node-gyp": {
           "version": "3.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-dHT2OjoFARYd2gtjQfAi8UxCP6Y=",
           "dev": true,
           "requires": {
             "fstream": "^1.0.0",
@@ -15008,14 +15061,16 @@
           "dependencies": {
             "semver": {
               "version": "5.3.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
               "dev": true
             }
           }
         },
         "nopt": {
           "version": "3.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
             "abbrev": "1"
@@ -15023,12 +15078,14 @@
         },
         "normalize-git-url": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jl8Uvgva7bc+ByADEKpBbCc1D8Q=",
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -15039,7 +15096,8 @@
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
               "dev": true,
               "requires": {
                 "builtin-modules": "^1.0.0"
@@ -15047,7 +15105,8 @@
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-EFOVX9mUpXRuUl5Kxxe4HK8HSRw=",
                   "dev": true
                 }
               }
@@ -15056,12 +15115,14 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
           "dev": true
         },
         "npm-install-checks": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-bZGu2grJaAHx7Xqt7hFqbAoIalc=",
           "dev": true,
           "requires": {
             "npmlog": "0.1 || 1 || 2",
@@ -15070,7 +15131,8 @@
         },
         "npm-package-arg": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LgFfisAHN8uX+ZfJy/BZ9Cp0Un0=",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -15079,7 +15141,8 @@
         },
         "npm-registry-client": {
           "version": "7.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-x5ImawiMwxP4Ul5+NSSGJscj23U=",
           "dev": true,
           "requires": {
             "concat-stream": "^1.5.2",
@@ -15096,7 +15159,8 @@
           "dependencies": {
             "concat-stream": {
               "version": "1.5.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
               "dev": true,
               "requires": {
                 "inherits": "~2.0.1",
@@ -15106,7 +15170,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                   "dev": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -15119,53 +15184,62 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                       "dev": true
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                       "dev": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                       "dev": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                       "dev": true
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                       "dev": true
                     }
                   }
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                   "dev": true
                 }
               }
             },
             "retry": {
               "version": "0.10.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ZJ4VykCEItmDGBYZNef31lLUNd0=",
               "dev": true
             }
           }
         },
         "npm-user-validate": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-UkZdUMLSApSlcSW5lrrtv1bFAEs=",
           "dev": true
         },
         "npmlog": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
           "dev": true,
           "requires": {
             "ansi": "~0.3.1",
@@ -15175,7 +15249,8 @@
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
               "dev": true,
               "requires": {
                 "delegates": "^1.0.0",
@@ -15184,14 +15259,16 @@
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                   "dev": true
                 }
               }
             },
             "gauge": {
               "version": "1.2.7",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
               "dev": true,
               "requires": {
                 "ansi": "^0.3.0",
@@ -15203,22 +15280,26 @@
               "dependencies": {
                 "has-unicode": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-o82Wwwe6QdVZxaLuQIwSoRxMLsM=",
                   "dev": true
                 },
                 "lodash._baseslice": {
                   "version": "4.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-9c4d+YKUjsr/Y/IjhTQVt7l2NwQ=",
                   "dev": true
                 },
                 "lodash._basetostring": {
                   "version": "4.12.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-kyfJ3FFYhmt/pLnUL0Y45XZt2d8=",
                   "dev": true
                 },
                 "lodash.pad": {
                   "version": "4.4.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-+qON8mwKaexQhqgiRslY4VDcsas=",
                   "dev": true,
                   "requires": {
                     "lodash._baseslice": "~4.0.0",
@@ -15228,7 +15309,8 @@
                 },
                 "lodash.padend": {
                   "version": "4.5.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-oonpN37i5t6Lp/EfOo6zJgcLdhk=",
                   "dev": true,
                   "requires": {
                     "lodash._baseslice": "~4.0.0",
@@ -15238,7 +15320,8 @@
                 },
                 "lodash.padstart": {
                   "version": "4.5.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-PqGQ9nNIQcM2TSedEeBWcmtgp5o=",
                   "dev": true,
                   "requires": {
                     "lodash._baseslice": "~4.0.0",
@@ -15248,7 +15331,8 @@
                 },
                 "lodash.tostring": {
                   "version": "4.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Vgwn0fjq3eA8LM4Zj+9cAx2CmPs=",
                   "dev": true
                 }
               }
@@ -15257,7 +15341,8 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -15265,12 +15350,14 @@
         },
         "opener": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-iXWQrNGu0zEbcDtYvMtNQ/VvKJU=",
           "dev": true
         },
         "osenv": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
           "dev": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -15279,24 +15366,28 @@
           "dependencies": {
             "os-homedir": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-43B4vGG1hpBjBTiXJX457BJhtwI=",
               "dev": true
             },
             "os-tmpdir": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24=",
               "dev": true
             }
           }
         },
         "path-is-inside": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
+          "integrity": "sha1-mNjx0DC/BL167uShulSF1AMY/Yk=",
           "dev": true
         },
         "read": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "dev": true,
           "requires": {
             "mute-stream": "~0.0.4"
@@ -15304,14 +15395,16 @@
           "dependencies": {
             "mute-stream": {
               "version": "0.0.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
               "dev": true
             }
           }
         },
         "read-installed": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -15325,12 +15418,14 @@
           "dependencies": {
             "debuglog": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
               "dev": true
             },
             "readdir-scoped-modules": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
               "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
@@ -15341,14 +15436,16 @@
             },
             "util-extend": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-u3A7eUgCk93Nz7PGqf6iD0g0Fbw=",
               "dev": true
             }
           }
         },
         "read-package-json": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Ye0bIlbqQ42ACIlQkL6EuOeZyFM=",
           "dev": true,
           "requires": {
             "glob": "^6.0.0",
@@ -15359,7 +15456,8 @@
           "dependencies": {
             "glob": {
               "version": "6.0.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
               "dev": true,
               "requires": {
                 "inflight": "^1.0.4",
@@ -15371,14 +15469,16 @@
               "dependencies": {
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                   "dev": true
                 }
               }
             },
             "json-parse-helpfulerror": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
               "dev": true,
               "requires": {
                 "jju": "^1.1.0"
@@ -15386,7 +15486,8 @@
               "dependencies": {
                 "jju": {
                   "version": "1.3.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
                   "dev": true
                 }
               }
@@ -15395,7 +15496,8 @@
         },
         "readable-stream": {
           "version": "2.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
           "dev": true,
           "requires": {
             "buffer-shims": "^1.0.0",
@@ -15409,39 +15511,46 @@
           "dependencies": {
             "buffer-shims": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
               "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
               "dev": true
             },
             "string_decoder": {
               "version": "0.10.31",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
               "dev": true
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true
             }
           }
         },
         "realize-package-specifier": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/eMukmRI44+ZM02Vt7CNUeOpjZ8=",
           "dev": true,
           "requires": {
             "dezalgo": "^1.0.1",
@@ -15450,7 +15559,8 @@
         },
         "request": {
           "version": "2.74.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
           "dev": true,
           "requires": {
             "aws-sign2": "~0.6.0",
@@ -15478,17 +15588,20 @@
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
               "dev": true
             },
             "aws4": {
               "version": "1.4.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
               "dev": true
             },
             "bl": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
               "dev": true,
               "requires": {
                 "readable-stream": "~2.0.5"
@@ -15496,7 +15609,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                   "dev": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -15509,27 +15623,32 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                       "dev": true
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                       "dev": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                       "dev": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                       "dev": true
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                       "dev": true
                     }
                   }
@@ -15538,12 +15657,14 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
               "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
               "dev": true,
               "requires": {
                 "delayed-stream": "~1.0.0"
@@ -15551,24 +15672,28 @@
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                   "dev": true
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
               "dev": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
               "dev": true
             },
             "form-data": {
               "version": "1.0.0-rc4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=",
               "dev": true,
               "requires": {
                 "async": "^1.5.2",
@@ -15578,14 +15703,16 @@
               "dependencies": {
                 "async": {
                   "version": "1.5.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
                   "dev": true
                 }
               }
             },
             "har-validator": {
               "version": "2.0.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
               "dev": true,
               "requires": {
                 "chalk": "^1.1.1",
@@ -15596,7 +15723,8 @@
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                   "dev": true,
                   "requires": {
                     "ansi-styles": "^2.2.1",
@@ -15608,17 +15736,20 @@
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
                       "dev": true
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                       "dev": true
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                       "dev": true,
                       "requires": {
                         "ansi-regex": "^2.0.0"
@@ -15626,14 +15757,16 @@
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                       "dev": true
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                   "dev": true,
                   "requires": {
                     "graceful-readlink": ">= 1.0.0"
@@ -15641,14 +15774,16 @@
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
                       "dev": true
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.13.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
                   "dev": true,
                   "requires": {
                     "generate-function": "^2.0.0",
@@ -15659,12 +15794,14 @@
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
                       "dev": true
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
                       "dev": true,
                       "requires": {
                         "is-property": "^1.0.0"
@@ -15672,26 +15809,30 @@
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
                           "dev": true
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
                       "dev": true
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                       "dev": true
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                   "dev": true,
                   "requires": {
                     "pinkie": "^2.0.0"
@@ -15699,7 +15840,8 @@
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
                       "dev": true
                     }
                   }
@@ -15708,7 +15850,8 @@
             },
             "hawk": {
               "version": "3.1.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
               "dev": true,
               "requires": {
                 "boom": "2.x.x",
@@ -15719,7 +15862,8 @@
               "dependencies": {
                 "boom": {
                   "version": "2.10.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                   "dev": true,
                   "requires": {
                     "hoek": "2.x.x"
@@ -15727,7 +15871,8 @@
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                   "dev": true,
                   "requires": {
                     "boom": "2.x.x"
@@ -15735,12 +15880,14 @@
                 },
                 "hoek": {
                   "version": "2.16.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
                   "dev": true
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                   "dev": true,
                   "requires": {
                     "hoek": "2.x.x"
@@ -15750,7 +15897,8 @@
             },
             "http-signature": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
               "dev": true,
               "requires": {
                 "assert-plus": "^0.2.0",
@@ -15760,12 +15908,14 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
                   "dev": true
                 },
                 "jsprim": {
                   "version": "1.3.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA=",
                   "dev": true,
                   "requires": {
                     "extsprintf": "1.0.2",
@@ -15775,17 +15925,20 @@
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
                       "dev": true
                     },
                     "json-schema": {
                       "version": "0.2.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
                       "dev": true
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
                       "dev": true,
                       "requires": {
                         "extsprintf": "1.0.2"
@@ -15795,7 +15948,8 @@
                 },
                 "sshpk": {
                   "version": "1.9.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-O0E1G7rVw03fS9gRmTfv7jGkZ2U=",
                   "dev": true,
                   "requires": {
                     "asn1": "~0.2.3",
@@ -15810,17 +15964,20 @@
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                       "dev": true
                     },
                     "assert-plus": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                       "dev": true
                     },
                     "dashdash": {
                       "version": "1.14.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
                       "dev": true,
                       "requires": {
                         "assert-plus": "^1.0.0"
@@ -15828,7 +15985,8 @@
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -15837,7 +15995,8 @@
                     },
                     "getpass": {
                       "version": "0.1.6",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
                       "dev": true,
                       "requires": {
                         "assert-plus": "^1.0.0"
@@ -15845,7 +16004,8 @@
                     },
                     "jodid25519": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -15854,13 +16014,15 @@
                     },
                     "jsbn": {
                       "version": "0.1.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
                       "dev": true,
                       "optional": true
                     },
                     "tweetnacl": {
                       "version": "0.13.3",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
                       "dev": true,
                       "optional": true
                     }
@@ -15870,22 +16032,26 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
               "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
               "dev": true
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
               "dev": true
             },
             "mime-types": {
               "version": "2.1.11",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
               "dev": true,
               "requires": {
                 "mime-db": "~1.23.0"
@@ -15893,51 +16059,60 @@
               "dependencies": {
                 "mime-db": {
                   "version": "1.23.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
                   "dev": true
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.7",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
               "dev": true
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
               "dev": true
             },
             "qs": {
               "version": "6.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
               "dev": true
             },
             "stringstream": {
               "version": "0.0.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
               "dev": true
             },
             "tough-cookie": {
               "version": "2.3.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0=",
               "dev": true
             },
             "tunnel-agent": {
               "version": "0.4.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
               "dev": true
             }
           }
         },
         "retry": {
           "version": "0.10.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ZJ4VykCEItmDGBYZNef31lLUNd0=",
           "dev": true
         },
         "rimraf": {
           "version": "2.5.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
           "dev": true,
           "requires": {
             "glob": "^7.0.5"
@@ -15945,12 +16120,14 @@
         },
         "semver": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
           "dev": true
         },
         "sha": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -15959,7 +16136,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-vsgb6ujPRVFovC5bKzH1vPrtmxs=",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -15972,27 +16150,32 @@
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
                   "dev": true
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
                   "dev": true
                 },
                 "process-nextick-args": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-4nLu2CXV6fTqdNjXOx/jEcO+tjA=",
                   "dev": true
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                   "dev": true
                 },
                 "util-deprecate": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-NVaj0TxMaqeYPX4kJUeBlxmbeIE=",
                   "dev": true
                 }
               }
@@ -16001,22 +16184,26 @@
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "sorted-object": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-HP6pgWCQR9gEOAekkKnZmzF/r38=",
           "dev": true
         },
         "spdx-license-ids": {
           "version": "1.2.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -16024,7 +16211,8 @@
         },
         "tar": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
             "block-stream": "*",
@@ -16034,22 +16222,26 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
           "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true,
           "requires": {
             "spdx-correct": "~1.0.0",
@@ -16058,7 +16250,8 @@
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
               "dev": true,
               "requires": {
                 "spdx-license-ids": "^1.0.2"
@@ -16066,7 +16259,8 @@
             },
             "spdx-expression-parse": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
               "dev": true,
               "requires": {
                 "spdx-exceptions": "^1.0.4",
@@ -16075,7 +16269,8 @@
               "dependencies": {
                 "spdx-exceptions": {
                   "version": "1.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
                   "dev": true
                 }
               }
@@ -16084,7 +16279,8 @@
         },
         "validate-npm-package-name": {
           "version": "2.2.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
           "dev": true,
           "requires": {
             "builtins": "0.0.7"
@@ -16092,14 +16288,16 @@
           "dependencies": {
             "builtins": {
               "version": "0.0.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+              "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo=",
               "dev": true
             }
           }
         },
         "which": {
           "version": "1.2.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
           "dev": true,
           "requires": {
             "isexe": "^1.1.1"
@@ -16107,19 +16305,22 @@
           "dependencies": {
             "isexe": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
               "dev": true
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8640,6 +8640,18 @@
             "hoek": "2.x.x",
             "joi": "6.x.x",
             "wreck": "5.x.x"
+          },
+          "dependencies": {
+            "wreck": {
+              "version": "5.6.1",
+              "resolved": "https://registry.npmjs.org/wreck/-/wreck-5.6.1.tgz",
+              "integrity": "sha1-r/ADBAATiJ11YZtccYcN0qjdBpo=",
+              "dev": true,
+              "requires": {
+                "boom": "2.x.x",
+                "hoek": "2.x.x"
+              }
+            }
           }
         },
         "heavy": {
@@ -8651,6 +8663,20 @@
             "boom": "2.x.x",
             "hoek": "2.x.x",
             "joi": "5.x.x"
+          },
+          "dependencies": {
+            "joi": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+              "integrity": "sha1-FSrQfbjunGQBmX/1/SwSiWBwv1g=",
+              "dev": true,
+              "requires": {
+                "hoek": "^2.2.x",
+                "isemail": "1.x.x",
+                "moment": "2.x.x",
+                "topo": "1.x.x"
+              }
+            }
           }
         },
         "hoek": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigcommerce-cornerstone",
-  "version": "4.0.0",
+  "version": "4.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -804,82 +804,48 @@
       "integrity": "sha1-1/VGSiBlczn8eHl5qYgJkbHulj4=",
       "dev": true
     },
-    "@bigcommerce/node-sass": {
-      "version": "git://github.com/bigcommerce-labs/node-sass.git#4ea0b8d5f7c418d5bf20b07e395b2609e020bb8b",
-      "from": "git://github.com/bigcommerce-labs/node-sass.git#v3.4.4",
+    "@bigcommerce/handlebars-v4": {
+      "version": "github:bigcommerce/handlebars-v4#89c779943955795b4f6d40cdb71a6aeb4b5d312c",
+      "from": "github:bigcommerce/handlebars-v4#v4.0.14",
       "dev": true,
       "requires": {
-        "async-foreach": "^0.1.3",
-        "chalk": "^1.1.1",
-        "cross-spawn": "^2.0.0",
-        "gaze": "^0.5.1",
-        "get-stdin": "^4.0.1",
-        "glob": "^5.0.14",
-        "meow": "^3.3.0",
-        "mkdirp": "^0.5.1",
-        "nan": "^2.3.2",
-        "node-gyp": "^3.0.1",
-        "npmconf": "^2.1.2",
-        "request": "^2.61.0",
-        "sass-graph": "^2.0.1"
+        "handlebars": "4.0.14"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+        "handlebars": {
+          "version": "4.0.14",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.14.tgz",
+          "integrity": "sha512-E7tDoyAA8ilZIV3xDJgl18sX3M8xB9/fMw8+mfW4msLW8jlX97bAnWgT3pmaNXuvzIEgSBMnAHfuXsB2hdzfow==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "async": "^2.5.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
           }
         },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
     },
     "@bigcommerce/stencil-cli": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-cli/-/stencil-cli-1.17.0.tgz",
-      "integrity": "sha512-teUX2jEJJzXUoeZ7GCpSUo8B2HWmQKoXkJhSUhiT8XcvsRDgf1vZHhrOr1FtHU18waUH2mhil+5+TW+QEukNSQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-cli/-/stencil-cli-1.21.1.tgz",
+      "integrity": "sha512-YG4vg/r80HIKhiN3UnGBgDLK9IS/hfCa4h5R42Z1ygb5lsgg2X4HZVKtwqb4umOUDsSRBWiguI1rHGKe2fdoAA==",
       "dev": true,
       "requires": {
-        "@bigcommerce/stencil-paper": "^2.0.17",
-        "@bigcommerce/stencil-styles": "1.1.0",
+        "@bigcommerce/stencil-paper": "^3.0.0-rc.26",
+        "@bigcommerce/stencil-styles": "1.2.0-rc1",
         "accept-language-parser": "^1.0.2",
         "archiver": "^0.14.4",
         "async": "^2.4.0",
         "babel-eslint": "^7.1.1",
         "boom": "^2.7.0",
-        "browser-sync": "git://github.com/bigcommerce/browser-sync.git#5114c787bc820d94e42c4be7f7bb6d774ae52bbd",
+        "browser-sync": "git://github.com/bigcommerce/browser-sync.git",
         "cheerio": "^0.19.0",
         "code": "^4.0.0",
         "colors": "^1.0.3",
@@ -994,9 +960,9 @@
           },
           "dependencies": {
             "glob": {
-              "version": "7.1.4",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-              "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+              "version": "7.1.5",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+              "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
               "dev": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
@@ -1049,9 +1015,9 @@
           "dev": true
         },
         "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
           "dev": true
         },
         "globals": {
@@ -1105,26 +1071,21 @@
       }
     },
     "@bigcommerce/stencil-paper": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-2.0.17.tgz",
-      "integrity": "sha512-4G2hSeZ60b78lzZPbAJwsr9nFYoyJ3g/0ArjvZsP45iPDu2wgWE7jyvJP56dLMU2xsr6J7TdOca9fvN87GUSIg==",
+      "version": "3.0.0-rc.26",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper/-/stencil-paper-3.0.0-rc.26.tgz",
+      "integrity": "sha512-lNEx4TDHhkOWzaD4wyzVXpPPXyell1u5hy/okt1Gqiuu7fdHuQR1JQzAOkGfzT+47zellqhOuo5Fh0SJUh7Axw==",
       "dev": true,
       "requires": {
-        "accept-language-parser": "^1.0.2",
-        "async": "^1.4.2",
-        "handlebars": "3.0.7",
-        "handlebars-helpers": "^0.8.0",
-        "handlebars-utils": "^1.0.6",
-        "lodash": "^3.6.0",
-        "messageformat": "^0.2.2",
-        "stringz": "^0.1.1",
-        "tarjan-graph": "^0.3.0"
+        "@bigcommerce/stencil-paper-handlebars": "4.2.3",
+        "accept-language-parser": "~1.4.1",
+        "lodash": "~3.10.1",
+        "messageformat": "~0.2.2"
       },
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+        "accept-language-parser": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.4.1.tgz",
+          "integrity": "sha1-OHdPqbgtHzj3MVr0QxZaIZDMgnY=",
           "dev": true
         },
         "lodash": {
@@ -1135,22 +1096,96 @@
         }
       }
     },
-    "@bigcommerce/stencil-styles": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-styles/-/stencil-styles-1.1.0.tgz",
-      "integrity": "sha512-HEZTrhLdX1Hh9GuIZ/kL7uGbydagHgZhndS7vTzxVISZhFTk8Lo9ZzFYrqzeITRtTytWWVYifsawUsenU4mFRA==",
+    "@bigcommerce/stencil-paper-handlebars": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-paper-handlebars/-/stencil-paper-handlebars-4.2.3.tgz",
+      "integrity": "sha512-Ua+lEcDJOYD9aZO9XjDHacCGEnxpgL+207BmHVWrWiI5pMVOSCGx6bVpENBwWQNkuRnJuqpoiNRxEuipd5Jw5Q==",
       "dev": true,
       "requires": {
-        "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#4ea0b8d5f7c418d5bf20b07e395b2609e020bb8b",
+        "@bigcommerce/handlebars-v4": "github:bigcommerce/handlebars-v4#v4.0.14",
+        "handlebars": "3.0.7",
+        "handlebars-helpers": "0.8.4",
+        "handlebars-utils": "^1.0.6",
+        "lodash": "^4.17.13",
+        "stringz": "^0.1.1"
+      }
+    },
+    "@bigcommerce/stencil-styles": {
+      "version": "1.2.0-rc1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-styles/-/stencil-styles-1.2.0-rc1.tgz",
+      "integrity": "sha512-m5SO/AxNSlB3Qjd849A30n2xB+8EoNzn1yrTV/Ti9EozC9AsYOIsMafiF5sS7dFeN979B7Fxfe8okHWy+f1TPA==",
+      "dev": true,
+      "requires": {
+        "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#v3.5.0",
         "autoprefixer": "^6.7.3",
         "lodash": "^3.10.1",
         "postcss": "^5.2.14"
       },
       "dependencies": {
+        "@bigcommerce/node-sass": {
+          "version": "git://github.com/bigcommerce-labs/node-sass.git#4d39efa672f6df16d3b88627658eb1cf3076c1e1",
+          "from": "git://github.com/bigcommerce-labs/node-sass.git#v3.5.0",
+          "dev": true,
+          "requires": {
+            "async-foreach": "^0.1.3",
+            "chalk": "^1.1.1",
+            "cross-spawn": "^2.0.0",
+            "gaze": "^0.5.1",
+            "get-stdin": "^4.0.1",
+            "glob": "^5.0.14",
+            "meow": "^3.3.0",
+            "mkdirp": "^0.5.1",
+            "nan": "^2.3.2",
+            "node-gyp": "^3.0.1",
+            "npmconf": "^2.1.2",
+            "request": "^2.61.0",
+            "sass-graph": "^2.0.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
@@ -1526,6 +1561,33 @@
         "typechecker": "^4.3.0"
       },
       "dependencies": {
+        "errlop": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.1.2.tgz",
+          "integrity": "sha512-djkRp+urJ+SmqDBd7F6LUgm4Be1TTYBxia2bhjNdFBuBDQtJDHExD2VbxR6eyst3h1TZy3qPRCdqb6FBoFttTA==",
+          "dev": true,
+          "requires": {
+            "editions": "^2.1.3"
+          },
+          "dependencies": {
+            "editions": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/editions/-/editions-2.2.0.tgz",
+              "integrity": "sha512-RYg3iEA2BDLCNVe8PUkD+ox5vAKxB9XS/mAhx1bdxGCF0CpX077C0pyTA9t5D6idCYA3avl5/XDHKPsHFrygfw==",
+              "dev": true,
+              "requires": {
+                "errlop": "^1.1.2",
+                "semver": "^6.3.0"
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
         "typechecker": {
           "version": "4.7.0",
           "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.7.0.tgz",
@@ -1536,13 +1598,13 @@
           },
           "dependencies": {
             "editions": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz",
-              "integrity": "sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==",
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/editions/-/editions-2.2.0.tgz",
+              "integrity": "sha512-RYg3iEA2BDLCNVe8PUkD+ox5vAKxB9XS/mAhx1bdxGCF0CpX077C0pyTA9t5D6idCYA3avl5/XDHKPsHFrygfw==",
               "dev": true,
               "requires": {
-                "errlop": "^1.1.1",
-                "semver": "^5.6.0"
+                "errlop": "^1.1.2",
+                "semver": "^6.3.0"
               }
             }
           }
@@ -1720,13 +1782,12 @@
       }
     },
     "argparse": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "underscore": "~1.7.0",
-        "underscore.string": "~2.4.0"
+        "sprintf-js": "~1.0.2"
       }
     },
     "aria-query": {
@@ -2001,10 +2062,13 @@
       "dev": true
     },
     "autolinker": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
-      "integrity": "sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI=",
-      "dev": true
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.28.1.tgz",
+      "integrity": "sha1-BlK0kYgYefB3XazgzcoyM5QqTkc=",
+      "dev": true,
+      "requires": {
+        "gulp-header": "^1.7.1"
+      }
     },
     "autoprefixer": {
       "version": "6.7.7",
@@ -3091,9 +3155,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000985",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000985.tgz",
-      "integrity": "sha512-1m3CC9+dYNh/FHd0V1/McOB73CxjmzzrcXi360x8mKoApUY8QIOYXg4bU5QeJmlenn++20GBI38EKw6qQpJ3kQ==",
+      "version": "1.0.30001006",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001006.tgz",
+      "integrity": "sha512-Xn25grc0GXATFnnEX+KP3IwEv6ZdHs4CALyLKvK8pBeeBe+hSpqy3/GyKBgEp4hn6o+bI+GNeNeQBf9PBOK0EQ==",
       "dev": true
     },
     "caniuse-lite": {
@@ -3516,6 +3580,23 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "concat-with-sourcemaps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "confidence": {
@@ -4758,14 +4839,14 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.50",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
-      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
+      "version": "0.10.52",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.52.tgz",
+      "integrity": "sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==",
       "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "^1.0.0"
+        "es6-symbol": "~3.1.2",
+        "next-tick": "~1.0.0"
       }
     },
     "es5-shim": {
@@ -4825,6 +4906,18 @@
         "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
         "event-emitter": "~0.3.5"
+      },
+      "dependencies": {
+        "es6-symbol": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+          "dev": true,
+          "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14"
+          }
+        }
       }
     },
     "es6-shim": {
@@ -4834,13 +4927,13 @@
       "dev": true
     },
     "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
       }
     },
     "es6-weak-map": {
@@ -4917,9 +5010,9 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
           "dev": true
         }
       }
@@ -6012,6 +6105,23 @@
         }
       }
     },
+    "ext": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.1.2.tgz",
+      "integrity": "sha512-/KLjJdTNyDepCihrk4HQt57nAE1IRCEo5jUt+WgWGCr1oARhibDvmI2DMcSNWood1T9AUWwq+jaV1wvRqaXfnA==",
+      "dev": true,
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+          "dev": true
+        }
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -6822,7 +6932,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6846,13 +6957,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6869,19 +6982,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7012,7 +7128,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7026,6 +7143,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7042,6 +7160,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7050,13 +7169,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7077,6 +7198,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7165,7 +7287,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7179,6 +7302,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7274,7 +7398,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7316,6 +7441,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7337,6 +7463,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7385,13 +7512,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8246,6 +8375,17 @@
         }
       }
     },
+    "gulp-header": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.8.12.tgz",
+      "integrity": "sha512-lh9HLdb53sC7XIZOYzTXM4lFuXElv3EVkSDhsd7DoJBj7hm+Ni7D3qYbb+Rr8DuM8nRanBvkVO9d7askreXGnQ==",
+      "dev": true,
+      "requires": {
+        "concat-with-sourcemaps": "*",
+        "lodash.template": "^4.4.0",
+        "through2": "^2.0.0"
+      }
+    },
     "gzip-size": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
@@ -8282,6 +8422,27 @@
           "dev": true,
           "requires": {
             "amdefine": ">=0.0.4"
+          }
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true,
+              "optional": true
+            }
           }
         }
       }
@@ -8324,9 +8485,9 @@
       },
       "dependencies": {
         "handlebars": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-          "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+          "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
           "dev": true,
           "requires": {
             "neo-async": "^2.6.0",
@@ -8349,17 +8510,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
-        },
-        "uglify-js": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-          "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "commander": "~2.20.0",
-            "source-map": "~0.6.1"
-          }
         }
       }
     },
@@ -8913,9 +9063,9 @@
       }
     },
     "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+      "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
       "dev": true,
       "requires": {
         "boom": "2.x.x",
@@ -10430,12 +10580,12 @@
           "dev": true
         },
         "graceful-fs": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+          "version": "3.0.12",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz",
+          "integrity": "sha512-J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==",
           "dev": true,
           "requires": {
-            "natives": "^1.1.0"
+            "natives": "^1.1.3"
           }
         },
         "minimatch": {
@@ -10657,24 +10807,12 @@
           }
         },
         "graceful-fs": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+          "version": "3.0.12",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz",
+          "integrity": "sha512-J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==",
           "dev": true,
           "requires": {
-            "natives": "^1.1.0"
-          }
-        },
-        "hawk": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-          "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
-          "dev": true,
-          "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "natives": "^1.1.3"
           }
         },
         "http-signature": {
@@ -10917,24 +11055,12 @@
           }
         },
         "graceful-fs": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+          "version": "3.0.12",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz",
+          "integrity": "sha512-J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==",
           "dev": true,
           "requires": {
-            "natives": "^1.1.0"
-          }
-        },
-        "hawk": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-          "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
-          "dev": true,
-          "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "natives": "^1.1.3"
           }
         },
         "http-signature": {
@@ -11730,9 +11856,9 @@
           "dev": true
         },
         "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
           "dev": true
         },
         "esutils": {
@@ -11754,9 +11880,9 @@
           "dev": true
         },
         "handlebars": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-          "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+          "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
           "dev": true,
           "requires": {
             "neo-async": "^2.6.0",
@@ -11932,17 +12058,6 @@
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
-        "uglify-js": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-          "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "commander": "~2.20.0",
-            "source-map": "~0.6.1"
-          }
-        },
         "user-home": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
@@ -12084,6 +12199,19 @@
           "requires": {
             "ajv": "^4.9.1",
             "har-schema": "^1.0.5"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "http-signature": {
@@ -12702,6 +12830,17 @@
           "requires": {
             "co": "^4.6.0",
             "json-stable-stringify": "^1.0.1"
+          },
+          "dependencies": {
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+              "dev": true,
+              "requires": {
+                "jsonify": "~0.0.0"
+              }
+            }
           }
         },
         "assert-plus": {
@@ -12832,6 +12971,26 @@
             "tough-cookie": "~2.3.0",
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.0.0"
+          },
+          "dependencies": {
+            "hawk": {
+              "version": "3.1.3",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+              "dev": true,
+              "requires": {
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
+              }
+            },
+            "stringstream": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+              "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+              "dev": true
+            }
           }
         },
         "tough-cookie": {
@@ -13038,6 +13197,12 @@
         "lodash.keysin": "^3.0.0"
       }
     },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
     "lodash.clonedeep": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
@@ -13150,6 +13315,25 @@
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
+    },
+    "lodash.template": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
     },
     "lodash.toplainobject": {
       "version": "3.0.0",
@@ -13467,12 +13651,6 @@
             "inherits": "2",
             "minimatch": "0.3"
           }
-        },
-        "underscore": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz",
-          "integrity": "sha1-EzXF5PXm0zu7SwBrqMhqAPVW3gg=",
-          "dev": true
         }
       }
     },
@@ -13977,9 +14155,9 @@
           "dev": true
         },
         "estraverse": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
           "dev": true
         },
         "esutils": {
@@ -14396,44 +14574,37 @@
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+          "bundled": true,
           "dev": true
         },
         "ansi": {
           "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-          "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
+          "bundled": true,
           "dev": true
         },
         "ansi-regex": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+          "bundled": true,
           "dev": true
         },
         "ansicolors": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+          "bundled": true,
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-          "integrity": "sha512-6QWEyvMgIXX0eO972y7YPBLSBsq7UWKFAoNNTLGaOJ9bstcEL9sCbcjf96dVfNDdUsRoGOK82vWFJlKApXds7g==",
+          "bundled": true,
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+          "bundled": true,
           "dev": true
         },
         "async-some": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "dezalgo": "^1.0.2"
@@ -14441,8 +14612,7 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inherits": "~2.0.0"
@@ -14450,26 +14620,22 @@
         },
         "char-spinner": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
-          "integrity": "sha1-5upnvSR+EHESmDt6sEee02KAAIE=",
+          "bundled": true,
           "dev": true
         },
         "chmodr": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
-          "integrity": "sha1-BGYrky0PAuxm3qorDqQoEZaOPrk=",
+          "bundled": true,
           "dev": true
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+          "bundled": true,
           "dev": true
         },
         "cmd-shim": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
-          "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -14478,8 +14644,7 @@
         },
         "columnify": {
           "version": "1.5.4",
-          "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "strip-ansi": "^3.0.0",
@@ -14488,8 +14653,7 @@
           "dependencies": {
             "wcwidth": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
-              "integrity": "sha1-AtBZ/3qPx0Hg9rXaHmmytA2uym8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "defaults": "^1.0.0"
@@ -14497,8 +14661,7 @@
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-                  "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "clone": "^1.0.2"
@@ -14506,8 +14669,7 @@
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-                      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -14518,8 +14680,7 @@
         },
         "config-chain": {
           "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
-          "integrity": "sha1-f8OD3g/MhNcRy0Zb0XZXnK1hI0Y=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ini": "^1.3.4",
@@ -14528,16 +14689,14 @@
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "dezalgo": {
           "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "asap": "^2.0.0",
@@ -14546,22 +14705,19 @@
           "dependencies": {
             "asap": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz",
-              "integrity": "sha1-H8HRVk7hFiDfym1nAphQkT+fRnk=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "editor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
+          "bundled": true,
           "dev": true
         },
         "fs-vacuum": {
           "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.9.tgz",
-          "integrity": "sha1-T5AZOrjqAokJlbzU6ARlml02ay0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -14571,8 +14727,7 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.8.tgz",
-          "integrity": "sha1-5Jqt3yiPh9Rv+eiC8hahOrxAd4s=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -14583,16 +14738,14 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "fstream": {
           "version": "1.0.10",
-          "resolved": false,
-          "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -14603,8 +14756,7 @@
         },
         "fstream-npm": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.1.1.tgz",
-          "integrity": "sha1-a5F122I5qD2CCeIyQmxJTbspaQw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fstream-ignore": "^1.0.0",
@@ -14613,8 +14765,7 @@
           "dependencies": {
             "fstream-ignore": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-              "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "fstream": "^1.0.0",
@@ -14626,20 +14777,17 @@
         },
         "github-url-from-git": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
-          "integrity": "sha1-KF5rUggZABveEoZ0cEN55P8D4N4=",
+          "bundled": true,
           "dev": true
         },
         "github-url-from-username-repo": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo=",
+          "bundled": true,
           "dev": true
         },
         "glob": {
           "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -14652,40 +14800,34 @@
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+              "bundled": true,
               "dev": true
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.1.6",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
-          "integrity": "sha1-UUw4dysxvuLgi+3CGgrrOr9UwZ4=",
+          "bundled": true,
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.1.5",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
+          "bundled": true,
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-          "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -14694,20 +14836,17 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "bundled": true,
           "dev": true
         },
         "init-package-json": {
           "version": "1.9.4",
-          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.4.tgz",
-          "integrity": "sha1-tAU9C0Dwz4QqQZZpN8s9wPU06FY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^6.0.0",
@@ -14722,8 +14861,7 @@
           "dependencies": {
             "glob": {
               "version": "6.0.4",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inflight": "^1.0.4",
@@ -14735,16 +14873,14 @@
               "dependencies": {
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "promzard": {
               "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-              "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "read": "1"
@@ -14754,14 +14890,12 @@
         },
         "lockfile": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
-          "integrity": "sha1-nTU+z+P1TRULtX+J1RdGk1o5xPU=",
+          "bundled": true,
           "dev": true
         },
         "lru-cache": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-          "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.1",
@@ -14770,22 +14904,19 @@
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+              "bundled": true,
               "dev": true
             },
             "yallist": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-              "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "minimatch": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "^1.0.0"
@@ -14793,8 +14924,7 @@
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-              "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "balanced-match": "^0.4.1",
@@ -14803,14 +14933,12 @@
               "dependencies": {
                 "balanced-match": {
                   "version": "0.4.2",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                  "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                  "bundled": true,
                   "dev": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -14819,8 +14947,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -14828,16 +14955,14 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "node-gyp": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.0.tgz",
-          "integrity": "sha1-dHT2OjoFARYd2gtjQfAi8UxCP6Y=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fstream": "^1.0.0",
@@ -14857,16 +14982,14 @@
           "dependencies": {
             "semver": {
               "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "nopt": {
           "version": "3.0.6",
-          "resolved": false,
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "abbrev": "1"
@@ -14874,14 +14997,12 @@
         },
         "normalize-git-url": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
-          "integrity": "sha1-jl8Uvgva7bc+ByADEKpBbCc1D8Q=",
+          "bundled": true,
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-          "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -14892,8 +15013,7 @@
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "builtin-modules": "^1.0.0"
@@ -14901,8 +15021,7 @@
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
-                  "integrity": "sha1-EFOVX9mUpXRuUl5Kxxe4HK8HSRw=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -14911,14 +15030,12 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
+          "bundled": true,
           "dev": true
         },
         "npm-install-checks": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.7.tgz",
-          "integrity": "sha1-bZGu2grJaAHx7Xqt7hFqbAoIalc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "npmlog": "0.1 || 1 || 2",
@@ -14927,8 +15044,7 @@
         },
         "npm-package-arg": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.0.tgz",
-          "integrity": "sha1-LgFfisAHN8uX+ZfJy/BZ9Cp0Un0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -14937,8 +15053,7 @@
         },
         "npm-registry-client": {
           "version": "7.2.1",
-          "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
-          "integrity": "sha1-x5ImawiMwxP4Ul5+NSSGJscj23U=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "concat-stream": "^1.5.2",
@@ -14955,8 +15070,7 @@
           "dependencies": {
             "concat-stream": {
               "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-              "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inherits": "~2.0.1",
@@ -14966,8 +15080,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -14980,62 +15093,53 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "bundled": true,
                       "dev": true
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                      "bundled": true,
                       "dev": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                      "bundled": true,
                       "dev": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "retry": {
               "version": "0.10.0",
-              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
-              "integrity": "sha1-ZJ4VykCEItmDGBYZNef31lLUNd0=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "npm-user-validate": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
-          "integrity": "sha1-UkZdUMLSApSlcSW5lrrtv1bFAEs=",
+          "bundled": true,
           "dev": true
         },
         "npmlog": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
-          "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi": "~0.3.1",
@@ -15045,8 +15149,7 @@
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-              "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "delegates": "^1.0.0",
@@ -15055,16 +15158,14 @@
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                  "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "gauge": {
               "version": "1.2.7",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-              "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi": "^0.3.0",
@@ -15076,26 +15177,22 @@
               "dependencies": {
                 "has-unicode": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz",
-                  "integrity": "sha1-o82Wwwe6QdVZxaLuQIwSoRxMLsM=",
+                  "bundled": true,
                   "dev": true
                 },
                 "lodash._baseslice": {
                   "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz",
-                  "integrity": "sha1-9c4d+YKUjsr/Y/IjhTQVt7l2NwQ=",
+                  "bundled": true,
                   "dev": true
                 },
                 "lodash._basetostring": {
                   "version": "4.12.0",
-                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
-                  "integrity": "sha1-kyfJ3FFYhmt/pLnUL0Y45XZt2d8=",
+                  "bundled": true,
                   "dev": true
                 },
                 "lodash.pad": {
                   "version": "4.4.0",
-                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.4.0.tgz",
-                  "integrity": "sha1-+qON8mwKaexQhqgiRslY4VDcsas=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "lodash._baseslice": "~4.0.0",
@@ -15105,8 +15202,7 @@
                 },
                 "lodash.padend": {
                   "version": "4.5.0",
-                  "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.5.0.tgz",
-                  "integrity": "sha1-oonpN37i5t6Lp/EfOo6zJgcLdhk=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "lodash._baseslice": "~4.0.0",
@@ -15116,8 +15212,7 @@
                 },
                 "lodash.padstart": {
                   "version": "4.5.0",
-                  "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.5.0.tgz",
-                  "integrity": "sha1-PqGQ9nNIQcM2TSedEeBWcmtgp5o=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "lodash._baseslice": "~4.0.0",
@@ -15127,8 +15222,7 @@
                 },
                 "lodash.tostring": {
                   "version": "4.1.4",
-                  "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz",
-                  "integrity": "sha1-Vgwn0fjq3eA8LM4Zj+9cAx2CmPs=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -15137,8 +15231,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -15146,14 +15239,12 @@
         },
         "opener": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz",
-          "integrity": "sha1-iXWQrNGu0zEbcDtYvMtNQ/VvKJU=",
+          "bundled": true,
           "dev": true
         },
         "osenv": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-          "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -15162,28 +15253,24 @@
           "dependencies": {
             "os-homedir": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz",
-              "integrity": "sha1-43B4vGG1hpBjBTiXJX457BJhtwI=",
+              "bundled": true,
               "dev": true
             },
             "os-tmpdir": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-              "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "path-is-inside": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
-          "integrity": "sha512-SBjqBPwe10u8a3phuxQZMZ68VZ4bHMFV8BsXf37s6+GoIjMcL4KmcOW0VGAyTuekHZdsVM79HgirZANGPFRrvg==",
+          "bundled": true,
           "dev": true
         },
         "read": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mute-stream": "~0.0.4"
@@ -15191,16 +15278,14 @@
           "dependencies": {
             "mute-stream": {
               "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-              "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "read-installed": {
           "version": "4.0.3",
-          "resolved": false,
-          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -15214,14 +15299,12 @@
           "dependencies": {
             "debuglog": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-              "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+              "bundled": true,
               "dev": true
             },
             "readdir-scoped-modules": {
               "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
@@ -15232,16 +15315,14 @@
             },
             "util-extend": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.1.tgz",
-              "integrity": "sha1-u3A7eUgCk93Nz7PGqf6iD0g0Fbw=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "read-package-json": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
-          "integrity": "sha1-Ye0bIlbqQ42ACIlQkL6EuOeZyFM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^6.0.0",
@@ -15252,8 +15333,7 @@
           "dependencies": {
             "glob": {
               "version": "6.0.4",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inflight": "^1.0.4",
@@ -15265,16 +15345,14 @@
               "dependencies": {
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "json-parse-helpfulerror": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
-              "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "jju": "^1.1.0"
@@ -15282,8 +15360,7 @@
               "dependencies": {
                 "jju": {
                   "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
-                  "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -15292,8 +15369,7 @@
         },
         "readable-stream": {
           "version": "2.1.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-          "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "buffer-shims": "^1.0.0",
@@ -15307,46 +15383,39 @@
           "dependencies": {
             "buffer-shims": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+              "bundled": true,
               "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+              "bundled": true,
               "dev": true
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "bundled": true,
               "dev": true
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+              "bundled": true,
               "dev": true
             },
             "string_decoder": {
               "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "bundled": true,
               "dev": true
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "realize-package-specifier": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.1.tgz",
-          "integrity": "sha1-/eMukmRI44+ZM02Vt7CNUeOpjZ8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "dezalgo": "^1.0.1",
@@ -15355,8 +15424,7 @@
         },
         "request": {
           "version": "2.74.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
-          "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "aws-sign2": "~0.6.0",
@@ -15384,20 +15452,17 @@
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+              "bundled": true,
               "dev": true
             },
             "aws4": {
               "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-              "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
+              "bundled": true,
               "dev": true
             },
             "bl": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-              "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "readable-stream": "~2.0.5"
@@ -15405,8 +15470,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -15419,32 +15483,27 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "bundled": true,
                       "dev": true
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                      "bundled": true,
                       "dev": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                      "bundled": true,
                       "dev": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -15453,14 +15512,12 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+              "bundled": true,
               "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "delayed-stream": "~1.0.0"
@@ -15468,28 +15525,24 @@
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "bundled": true,
               "dev": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+              "bundled": true,
               "dev": true
             },
             "form-data": {
               "version": "1.0.0-rc4",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-              "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "async": "^1.5.2",
@@ -15499,16 +15552,14 @@
               "dependencies": {
                 "async": {
                   "version": "1.5.2",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "har-validator": {
               "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "chalk": "^1.1.1",
@@ -15519,8 +15570,7 @@
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "ansi-styles": "^2.2.1",
@@ -15532,20 +15582,17 @@
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                      "bundled": true,
                       "dev": true
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "ansi-regex": "^2.0.0"
@@ -15553,16 +15600,14 @@
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "graceful-readlink": ">= 1.0.0"
@@ -15570,16 +15615,14 @@
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.13.1",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-                  "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "generate-function": "^2.0.0",
@@ -15590,14 +15633,12 @@
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                      "bundled": true,
                       "dev": true
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "is-property": "^1.0.0"
@@ -15605,30 +15646,26 @@
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                      "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
+                      "bundled": true,
                       "dev": true
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "pinkie": "^2.0.0"
@@ -15636,8 +15673,7 @@
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -15646,8 +15682,7 @@
             },
             "hawk": {
               "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "boom": "2.x.x",
@@ -15658,8 +15693,7 @@
               "dependencies": {
                 "boom": {
                   "version": "2.10.1",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "hoek": "2.x.x"
@@ -15667,8 +15701,7 @@
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "boom": "2.x.x"
@@ -15676,14 +15709,12 @@
                 },
                 "hoek": {
                   "version": "2.16.3",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                  "bundled": true,
                   "dev": true
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "hoek": "2.x.x"
@@ -15693,8 +15724,7 @@
             },
             "http-signature": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "assert-plus": "^0.2.0",
@@ -15704,14 +15734,12 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                  "bundled": true,
                   "dev": true
                 },
                 "jsprim": {
                   "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
-                  "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "extsprintf": "1.0.2",
@@ -15721,20 +15749,17 @@
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                      "bundled": true,
                       "dev": true
                     },
                     "json-schema": {
                       "version": "0.2.2",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                      "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
+                      "bundled": true,
                       "dev": true
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "extsprintf": "1.0.2"
@@ -15744,8 +15769,7 @@
                 },
                 "sshpk": {
                   "version": "1.9.2",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
-                  "integrity": "sha1-O0E1G7rVw03fS9gRmTfv7jGkZ2U=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "asn1": "~0.2.3",
@@ -15760,20 +15784,17 @@
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                      "bundled": true,
                       "dev": true
                     },
                     "assert-plus": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                      "bundled": true,
                       "dev": true
                     },
                     "dashdash": {
                       "version": "1.14.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-                      "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "assert-plus": "^1.0.0"
@@ -15781,8 +15802,7 @@
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -15791,8 +15811,7 @@
                     },
                     "getpass": {
                       "version": "0.1.6",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                      "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                      "bundled": true,
                       "dev": true,
                       "requires": {
                         "assert-plus": "^1.0.0"
@@ -15800,8 +15819,7 @@
                     },
                     "jodid25519": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -15810,15 +15828,13 @@
                     },
                     "jsbn": {
                       "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                      "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     },
                     "tweetnacl": {
                       "version": "0.13.3",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-                      "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
+                      "bundled": true,
                       "dev": true,
                       "optional": true
                     }
@@ -15828,26 +15844,22 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+              "bundled": true,
               "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "bundled": true,
               "dev": true
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+              "bundled": true,
               "dev": true
             },
             "mime-types": {
               "version": "2.1.11",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-              "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "mime-db": "~1.23.0"
@@ -15855,60 +15867,51 @@
               "dependencies": {
                 "mime-db": {
                   "version": "1.23.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-                  "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
+                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.7",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+              "bundled": true,
               "dev": true
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+              "bundled": true,
               "dev": true
             },
             "qs": {
               "version": "6.2.1",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
-              "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
+              "bundled": true,
               "dev": true
             },
             "stringstream": {
               "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+              "bundled": true,
               "dev": true
             },
             "tough-cookie": {
               "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
-              "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0=",
+              "bundled": true,
               "dev": true
             },
             "tunnel-agent": {
               "version": "0.4.3",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-              "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "retry": {
           "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
-          "integrity": "sha1-ZJ4VykCEItmDGBYZNef31lLUNd0=",
+          "bundled": true,
           "dev": true
         },
         "rimraf": {
           "version": "2.5.4",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.0.5"
@@ -15916,14 +15919,12 @@
         },
         "semver": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+          "bundled": true,
           "dev": true
         },
         "sha": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
-          "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -15932,8 +15933,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-              "integrity": "sha1-vsgb6ujPRVFovC5bKzH1vPrtmxs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -15946,32 +15946,27 @@
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                  "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
+                  "bundled": true,
                   "dev": true
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                  "bundled": true,
                   "dev": true
                 },
                 "process-nextick-args": {
                   "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
-                  "integrity": "sha1-4nLu2CXV6fTqdNjXOx/jEcO+tjA=",
+                  "bundled": true,
                   "dev": true
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                  "bundled": true,
                   "dev": true
                 },
                 "util-deprecate": {
                   "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
-                  "integrity": "sha1-NVaj0TxMaqeYPX4kJUeBlxmbeIE=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -15980,26 +15975,22 @@
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+          "bundled": true,
           "dev": true
         },
         "sorted-object": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.0.tgz",
-          "integrity": "sha1-HP6pgWCQR9gEOAekkKnZmzF/r38=",
+          "bundled": true,
           "dev": true
         },
         "spdx-license-ids": {
           "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+          "bundled": true,
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -16007,8 +15998,7 @@
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": false,
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "block-stream": "*",
@@ -16018,26 +16008,22 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+          "bundled": true,
           "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "bundled": true,
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
+          "bundled": true,
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-correct": "~1.0.0",
@@ -16046,8 +16032,7 @@
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "spdx-license-ids": "^1.0.2"
@@ -16055,8 +16040,7 @@
             },
             "spdx-expression-parse": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-              "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "spdx-exceptions": "^1.0.4",
@@ -16065,8 +16049,7 @@
               "dependencies": {
                 "spdx-exceptions": {
                   "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-                  "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
+                  "bundled": true,
                   "dev": true
                 }
               }
@@ -16075,8 +16058,7 @@
         },
         "validate-npm-package-name": {
           "version": "2.2.2",
-          "resolved": false,
-          "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "builtins": "0.0.7"
@@ -16084,16 +16066,14 @@
           "dependencies": {
             "builtins": {
               "version": "0.0.7",
-              "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
-              "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "which": {
           "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
-          "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isexe": "^1.1.1"
@@ -16101,22 +16081,19 @@
           "dependencies": {
             "isexe": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-              "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.1.4",
-          "resolved": false,
-          "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -22304,13 +22281,13 @@
       }
     },
     "remarkable": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
-      "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.4.tgz",
+      "integrity": "sha512-e6NKUXgX95whv7IgddywbeN/ItCkWbISmc2DiqHJb0wTrqZIexqdco5b8Z3XZoo/48IdNVKM9ZCvTPJ4F5uvhg==",
       "dev": true,
       "requires": {
-        "argparse": "~0.1.15",
-        "autolinker": "~0.15.0"
+        "argparse": "^1.0.10",
+        "autolinker": "~0.28.0"
       }
     },
     "remove-trailing-separator": {
@@ -23045,9 +23022,9 @@
       "dev": true
     },
     "simple-git": {
-      "version": "1.122.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.122.0.tgz",
-      "integrity": "sha512-plTwhnkIHrw2TFMJbJH/mKwWGgFbj03V9wcfBKa4FsuvgJbpwdlSJnlvkIQWDV1CVLaf2Gl6zSNeRRnxBRhX1g==",
+      "version": "1.126.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.126.0.tgz",
+      "integrity": "sha512-47mqHxgZnN8XRa9HbpWprzUv3Ooqz9RY/LSZgvA7jCkW8jcwLahMz7LKugY91KZehfG0sCVPtgXiU72hd6b1Bw==",
       "dev": true,
       "requires": {
         "debug": "^4.0.1"
@@ -23679,6 +23656,25 @@
           "requires": {
             "amdefine": ">=0.0.4"
           }
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "dev": true,
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -23838,21 +23834,12 @@
       }
     },
     "temp": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
+      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "^1.0.0",
-        "rimraf": "~2.2.6"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-          "dev": true
-        }
+        "rimraf": "~2.6.2"
       }
     },
     "term-size": {
@@ -24394,9 +24381,9 @@
       "dev": true
     },
     "type": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
-      "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
       "dev": true
     },
     "type-check": {
@@ -24446,14 +24433,30 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.6.tgz",
+      "integrity": "sha512-q3Zusqd028P8MdbarqL0I1snTZ7+IbIWiKUXVZyXMVdOSxOG2FFqLXyGlgYSqYu46SR7tR3Sk0xqN1VtvxGWnQ==",
       "dev": true,
+      "optional": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "commander": "~2.20.3",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "uglify-to-browserify": {
@@ -24481,15 +24484,15 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz",
+      "integrity": "sha1-EzXF5PXm0zu7SwBrqMhqAPVW3gg=",
       "dev": true
     },
     "underscore.string": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -24631,12 +24634,6 @@
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "underscore.string": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/preset-env": "^7.2.0",
     "@bigcommerce/citadel": "^2.15.1",
-    "@bigcommerce/stencil-cli": "^1.15.4",
+    "@bigcommerce/stencil-cli": "^1.21.1",
     "babel-loader": "^8.0.4",
     "babel-plugin-lodash": "^3.3.4",
     "clean-webpack-plugin": "^0.1.19",


### PR DESCRIPTION
#### What?

Updating the stencil-cli dependency version to latest in order to support node 10.