### PR TITLE
STRF-7334 - Fix image sizing on review modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Fixes body text color not taking effect for cart item headings on mobile / tablet [#1586](https://github.com/bigcommerce/cornerstone/pull/1586)
+- Fix styling of review modal image [#1592](https://github.com/bigcommerce/cornerstone/pull/1592)
 
 ## 4.2.1 (2019-10-15)
 - Added missing gift certificate translation

--- a/assets/scss/components/stencil/writeReview/_writeReview.scss
+++ b/assets/scss/components/stencil/writeReview/_writeReview.scss
@@ -31,6 +31,10 @@
 
     img {
         @include lazy-loaded-img;
+        height: 100%;
+        object-fit: contain;
+        /* Object-fit polyfill */
+        font-family: 'object-fit: contain;';
     }
 
     @include lazy-loaded-padding('product_size');


### PR DESCRIPTION
#### What?

Update the review modal image styling to make sure the image shows full-width.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [STRF-7334](https://jira.bigcommerce.com/browse/STRF-7334)

#### Screenshots (if appropriate)

Before:

![image](https://user-images.githubusercontent.com/8922457/68239100-042f4d00-ffd0-11e9-8923-cdff21ebd213.png)

After:

![image](https://user-images.githubusercontent.com/8922457/68239272-4a84ac00-ffd0-11e9-9d9d-bc5eaba9beb5.png)
