### PR TITLE
Fix cart quantity for bundled items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix styling of review modal image [#1592](https://github.com/bigcommerce/cornerstone/pull/1592)
 - Fix typo in README.md [#1588](https://github.com/bigcommerce/cornerstone/pull/1588)
 - Fix corejs warning [#1594](https://github.com/bigcommerce/cornerstone/pull/1594)
+- Fix cart quantity calculation for bundled products [#1596](https://github.com/bigcommerce/cornerstone/pull/1596)
 
 ## 4.2.1 (2019-10-15)
 - Added missing gift certificate translation

--- a/assets/js/theme/global/cart-preview.js
+++ b/assets/js/theme/global/cart-preview.js
@@ -67,7 +67,7 @@ export default function (secureBaseUrl, cartId) {
 
         // Get updated cart quantity from the Cart API
         const cartQtyPromise = new Promise((resolve, reject) => {
-            utils.api.cart.getCartQuantity({ baseUrl: secureBaseUrl }, (err, qty) => {
+            utils.api.cart.getCartQuantity({ baseUrl: secureBaseUrl, cartId }, (err, qty) => {
                 if (err) {
                     reject(err);
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -832,6 +832,68 @@
         }
       }
     },
+    "@bigcommerce/node-sass": {
+      "version": "git://github.com/bigcommerce-labs/node-sass.git#4d39efa672f6df16d3b88627658eb1cf3076c1e1",
+      "from": "git://github.com/bigcommerce-labs/node-sass.git#v3.5.0",
+      "dev": true,
+      "requires": {
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^2.0.0",
+        "gaze": "^0.5.1",
+        "get-stdin": "^4.0.1",
+        "glob": "^5.0.14",
+        "meow": "^3.3.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.3.2",
+        "node-gyp": "^3.0.1",
+        "npmconf": "^2.1.2",
+        "request": "^2.61.0",
+        "sass-graph": "^2.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "@bigcommerce/stencil-cli": {
       "version": "1.21.1",
       "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-cli/-/stencil-cli-1.21.1.tgz",
@@ -1122,78 +1184,18 @@
         "postcss": "^5.2.14"
       },
       "dependencies": {
-        "@bigcommerce/node-sass": {
-          "version": "git://github.com/bigcommerce-labs/node-sass.git#4d39efa672f6df16d3b88627658eb1cf3076c1e1",
-          "from": "git://github.com/bigcommerce-labs/node-sass.git#v3.5.0",
-          "dev": true,
-          "requires": {
-            "async-foreach": "^0.1.3",
-            "chalk": "^1.1.1",
-            "cross-spawn": "^2.0.0",
-            "gaze": "^0.5.1",
-            "get-stdin": "^4.0.1",
-            "glob": "^5.0.14",
-            "meow": "^3.3.0",
-            "mkdirp": "^0.5.1",
-            "nan": "^2.3.2",
-            "node-gyp": "^3.0.1",
-            "npmconf": "^2.1.2",
-            "request": "^2.61.0",
-            "sass-graph": "^2.0.1"
-          }
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         }
       }
     },
     "@bigcommerce/stencil-utils": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-4.2.0.tgz",
-      "integrity": "sha512-msOiRJq06q4BtZEYDzu606RzvBHVgSL8bdQcqDkh7seVb/l4a7URmIYs8zB5QmjOz1BrVji1gVMWHAxn7F1jMA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-5.0.1.tgz",
+      "integrity": "sha512-dnn1E8t1UhsjSOQWVyHf3oZuzIlz6ZsCn9WfDsvkY0oxqAf7YcR7sJAn2JeYpcs6QKZSbkIPKwUHWzcsfOvNWw==",
       "requires": {
         "eventemitter2": "^0.4.14",
         "jquery": "^3.4.1",
@@ -12811,17 +12813,6 @@
           "requires": {
             "co": "^4.6.0",
             "json-stable-stringify": "^1.0.1"
-          },
-          "dependencies": {
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-              "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-              "dev": true,
-              "requires": {
-                "jsonify": "~0.0.0"
-              }
-            }
           }
         },
         "assert-plus": {
@@ -12881,6 +12872,18 @@
           "requires": {
             "ajv": "^4.9.1",
             "har-schema": "^1.0.5"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "requires": {
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "http-signature": {
@@ -12952,26 +12955,6 @@
             "tough-cookie": "~2.3.0",
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.0.0"
-          },
-          "dependencies": {
-            "hawk": {
-              "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-              "dev": true,
-              "requires": {
-                "boom": "2.x.x",
-                "cryptiles": "2.x.x",
-                "hoek": "2.x.x",
-                "sntp": "1.x.x"
-              }
-            },
-            "stringstream": {
-              "version": "0.0.6",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-              "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-              "dev": true
-            }
           }
         },
         "tough-cookie": {
@@ -14271,9 +14254,9 @@
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -22864,9 +22847,9 @@
           }
         },
         "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
-    "@bigcommerce/stencil-utils": "^4.2.0",
+    "@bigcommerce/stencil-utils": "^5.0.1",
     "core-js": "^2.6.10",
     "creditcards": "^3.0.1",
     "easyzoom": "^2.5.2",


### PR DESCRIPTION
#### What?

Fix the cart quantity calculation for bundled products by pulling in stencil-utils 5.0.1.

This will stop bundled products from being added to the quantity-in-cart for the cart preview, which will make it match the quantity reported on the cart page.

Also: small refactor to explicitly request cart by ID.

