### PR TITLE
Upgrade core-js to version 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigcommerce-cornerstone",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -690,6 +690,13 @@
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+        }
       }
     },
     "@babel/preset-env": {
@@ -907,7 +914,7 @@
         "async": "^2.4.0",
         "babel-eslint": "^7.1.1",
         "boom": "^2.7.0",
-        "browser-sync": "git://github.com/bigcommerce/browser-sync.git#5114c787bc820d94e42c4be7f7bb6d774ae52bbd",
+        "browser-sync": "git://github.com/bigcommerce/browser-sync.git",
         "cheerio": "^0.19.0",
         "code": "^4.0.0",
         "colors": "^1.0.3",
@@ -1164,7 +1171,7 @@
       "integrity": "sha512-Ua+lEcDJOYD9aZO9XjDHacCGEnxpgL+207BmHVWrWiI5pMVOSCGx6bVpENBwWQNkuRnJuqpoiNRxEuipd5Jw5Q==",
       "dev": true,
       "requires": {
-        "@bigcommerce/handlebars-v4": "github:bigcommerce/handlebars-v4#89c779943955795b4f6d40cdb71a6aeb4b5d312c",
+        "@bigcommerce/handlebars-v4": "github:bigcommerce/handlebars-v4#v4.0.14",
         "handlebars": "3.0.7",
         "handlebars-helpers": "0.8.4",
         "handlebars-utils": "^1.0.6",
@@ -1178,7 +1185,7 @@
       "integrity": "sha512-m5SO/AxNSlB3Qjd849A30n2xB+8EoNzn1yrTV/Ti9EozC9AsYOIsMafiF5sS7dFeN979B7Fxfe8okHWy+f1TPA==",
       "dev": true,
       "requires": {
-        "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#4d39efa672f6df16d3b88627658eb1cf3076c1e1",
+        "@bigcommerce/node-sass": "git://github.com/bigcommerce-labs/node-sass.git#v3.5.0",
         "autoprefixer": "^6.7.3",
         "lodash": "^3.10.1",
         "postcss": "^5.2.14"
@@ -2282,6 +2289,12 @@
         "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -3798,9 +3811,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.1.tgz",
+      "integrity": "sha512-KX/dnuY/J8FtEwbnrzmAjUYgLqtk+cxM86hfG60LGiW3MmltIc2yAmDgBgEkfm0blZhUrdr1Zd84J2Y14mLxzg=="
     },
     "core-js-compat": {
       "version": "3.1.4",
@@ -6934,7 +6947,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6958,13 +6972,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6981,19 +6997,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7124,7 +7143,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7138,6 +7158,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7154,6 +7175,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7162,13 +7184,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7189,6 +7213,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7277,7 +7302,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7291,6 +7317,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7386,7 +7413,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7428,6 +7456,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7449,6 +7478,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7497,13 +7527,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11264,6 +11296,12 @@
             "utils-merge": "1.0.1"
           }
         },
+        "core-js": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+          "dev": true
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -14538,19 +14576,19 @@
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
           "dev": true
         },
         "ansi": {
           "version": "0.3.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
           "dev": true
         },
         "ansi-regex": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
           "dev": true
         },
@@ -14568,13 +14606,13 @@
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "async-some": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
           "dev": true,
           "requires": {
@@ -14583,7 +14621,7 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true,
           "requires": {
@@ -14592,25 +14630,25 @@
         },
         "char-spinner": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-5upnvSR+EHESmDt6sEee02KAAIE=",
           "dev": true
         },
         "chmodr": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BGYrky0PAuxm3qorDqQoEZaOPrk=",
           "dev": true
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true
         },
         "cmd-shim": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
           "dev": true,
           "requires": {
@@ -14620,7 +14658,7 @@
         },
         "columnify": {
           "version": "1.5.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "dev": true,
           "requires": {
@@ -14630,7 +14668,7 @@
           "dependencies": {
             "wcwidth": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-AtBZ/3qPx0Hg9rXaHmmytA2uym8=",
               "dev": true,
               "requires": {
@@ -14639,7 +14677,7 @@
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                   "dev": true,
                   "requires": {
@@ -14648,7 +14686,7 @@
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
                       "dev": true
                     }
@@ -14660,7 +14698,7 @@
         },
         "config-chain": {
           "version": "1.1.10",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-f8OD3g/MhNcRy0Zb0XZXnK1hI0Y=",
           "dev": true,
           "requires": {
@@ -14670,7 +14708,7 @@
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
               "dev": true
             }
@@ -14678,7 +14716,7 @@
         },
         "dezalgo": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "dev": true,
           "requires": {
@@ -14688,7 +14726,7 @@
           "dependencies": {
             "asap": {
               "version": "2.0.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-H8HRVk7hFiDfym1nAphQkT+fRnk=",
               "dev": true
             }
@@ -14696,13 +14734,13 @@
         },
         "editor": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
           "dev": true
         },
         "fs-vacuum": {
           "version": "1.2.9",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-T5AZOrjqAokJlbzU6ARlml02ay0=",
           "dev": true,
           "requires": {
@@ -14713,7 +14751,7 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-5Jqt3yiPh9Rv+eiC8hahOrxAd4s=",
           "dev": true,
           "requires": {
@@ -14725,7 +14763,7 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             }
@@ -14733,7 +14771,7 @@
         },
         "fstream": {
           "version": "1.0.10",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
           "dev": true,
           "requires": {
@@ -14745,7 +14783,7 @@
         },
         "fstream-npm": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-a5F122I5qD2CCeIyQmxJTbspaQw=",
           "dev": true,
           "requires": {
@@ -14755,7 +14793,7 @@
           "dependencies": {
             "fstream-ignore": {
               "version": "1.0.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
               "dev": true,
               "requires": {
@@ -14768,19 +14806,19 @@
         },
         "github-url-from-git": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-KF5rUggZABveEoZ0cEN55P8D4N4=",
           "dev": true
         },
         "github-url-from-username-repo": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo=",
           "dev": true
         },
         "glob": {
           "version": "7.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "dev": true,
           "requires": {
@@ -14794,13 +14832,13 @@
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
               "dev": true
             }
@@ -14808,25 +14846,25 @@
         },
         "graceful-fs": {
           "version": "4.1.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-UUw4dysxvuLgi+3CGgrrOr9UwZ4=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
           "dev": true,
           "requires": {
@@ -14836,19 +14874,19 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true
         },
         "init-package-json": {
           "version": "1.9.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tAU9C0Dwz4QqQZZpN8s9wPU06FY=",
           "dev": true,
           "requires": {
@@ -14864,7 +14902,7 @@
           "dependencies": {
             "glob": {
               "version": "6.0.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
               "dev": true,
               "requires": {
@@ -14877,7 +14915,7 @@
               "dependencies": {
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                   "dev": true
                 }
@@ -14885,7 +14923,7 @@
             },
             "promzard": {
               "version": "0.3.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
               "dev": true,
               "requires": {
@@ -14896,13 +14934,13 @@
         },
         "lockfile": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-nTU+z+P1TRULtX+J1RdGk1o5xPU=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
           "dev": true,
           "requires": {
@@ -14912,13 +14950,13 @@
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
               "dev": true
             },
             "yallist": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
               "dev": true
             }
@@ -14926,7 +14964,7 @@
         },
         "minimatch": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "dev": true,
           "requires": {
@@ -14935,7 +14973,7 @@
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
               "dev": true,
               "requires": {
@@ -14945,13 +14983,13 @@
               "dependencies": {
                 "balanced-match": {
                   "version": "0.4.2",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                   "dev": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                   "dev": true
                 }
@@ -14961,7 +14999,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -14970,7 +15008,7 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             }
@@ -14978,7 +15016,7 @@
         },
         "node-gyp": {
           "version": "3.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-dHT2OjoFARYd2gtjQfAi8UxCP6Y=",
           "dev": true,
           "requires": {
@@ -14999,7 +15037,7 @@
           "dependencies": {
             "semver": {
               "version": "5.3.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
               "dev": true
             }
@@ -15007,7 +15045,7 @@
         },
         "nopt": {
           "version": "3.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
@@ -15016,13 +15054,13 @@
         },
         "normalize-git-url": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-jl8Uvgva7bc+ByADEKpBbCc1D8Q=",
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
           "dev": true,
           "requires": {
@@ -15034,7 +15072,7 @@
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
               "dev": true,
               "requires": {
@@ -15043,7 +15081,7 @@
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-EFOVX9mUpXRuUl5Kxxe4HK8HSRw=",
                   "dev": true
                 }
@@ -15053,13 +15091,13 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
           "dev": true
         },
         "npm-install-checks": {
           "version": "1.0.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-bZGu2grJaAHx7Xqt7hFqbAoIalc=",
           "dev": true,
           "requires": {
@@ -15069,7 +15107,7 @@
         },
         "npm-package-arg": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LgFfisAHN8uX+ZfJy/BZ9Cp0Un0=",
           "dev": true,
           "requires": {
@@ -15079,7 +15117,7 @@
         },
         "npm-registry-client": {
           "version": "7.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-x5ImawiMwxP4Ul5+NSSGJscj23U=",
           "dev": true,
           "requires": {
@@ -15097,7 +15135,7 @@
           "dependencies": {
             "concat-stream": {
               "version": "1.5.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
               "dev": true,
               "requires": {
@@ -15108,7 +15146,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                   "dev": true,
                   "requires": {
@@ -15122,31 +15160,31 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                       "dev": true
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                       "dev": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                       "dev": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                       "dev": true
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                       "dev": true
                     }
@@ -15154,7 +15192,7 @@
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                   "dev": true
                 }
@@ -15162,7 +15200,7 @@
             },
             "retry": {
               "version": "0.10.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-ZJ4VykCEItmDGBYZNef31lLUNd0=",
               "dev": true
             }
@@ -15170,13 +15208,13 @@
         },
         "npm-user-validate": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-UkZdUMLSApSlcSW5lrrtv1bFAEs=",
           "dev": true
         },
         "npmlog": {
           "version": "2.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
           "dev": true,
           "requires": {
@@ -15187,7 +15225,7 @@
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
               "dev": true,
               "requires": {
@@ -15197,7 +15235,7 @@
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                   "dev": true
                 }
@@ -15205,7 +15243,7 @@
             },
             "gauge": {
               "version": "1.2.7",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
               "dev": true,
               "requires": {
@@ -15218,25 +15256,25 @@
               "dependencies": {
                 "has-unicode": {
                   "version": "2.0.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-o82Wwwe6QdVZxaLuQIwSoRxMLsM=",
                   "dev": true
                 },
                 "lodash._baseslice": {
                   "version": "4.0.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-9c4d+YKUjsr/Y/IjhTQVt7l2NwQ=",
                   "dev": true
                 },
                 "lodash._basetostring": {
                   "version": "4.12.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-kyfJ3FFYhmt/pLnUL0Y45XZt2d8=",
                   "dev": true
                 },
                 "lodash.pad": {
                   "version": "4.4.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-+qON8mwKaexQhqgiRslY4VDcsas=",
                   "dev": true,
                   "requires": {
@@ -15247,7 +15285,7 @@
                 },
                 "lodash.padend": {
                   "version": "4.5.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-oonpN37i5t6Lp/EfOo6zJgcLdhk=",
                   "dev": true,
                   "requires": {
@@ -15258,7 +15296,7 @@
                 },
                 "lodash.padstart": {
                   "version": "4.5.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-PqGQ9nNIQcM2TSedEeBWcmtgp5o=",
                   "dev": true,
                   "requires": {
@@ -15269,7 +15307,7 @@
                 },
                 "lodash.tostring": {
                   "version": "4.1.4",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-Vgwn0fjq3eA8LM4Zj+9cAx2CmPs=",
                   "dev": true
                 }
@@ -15279,7 +15317,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
@@ -15288,13 +15326,13 @@
         },
         "opener": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-iXWQrNGu0zEbcDtYvMtNQ/VvKJU=",
           "dev": true
         },
         "osenv": {
           "version": "0.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
           "dev": true,
           "requires": {
@@ -15304,13 +15342,13 @@
           "dependencies": {
             "os-homedir": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-43B4vGG1hpBjBTiXJX457BJhtwI=",
               "dev": true
             },
             "os-tmpdir": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24=",
               "dev": true
             }
@@ -15324,7 +15362,7 @@
         },
         "read": {
           "version": "1.0.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "dev": true,
           "requires": {
@@ -15333,7 +15371,7 @@
           "dependencies": {
             "mute-stream": {
               "version": "0.0.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
               "dev": true
             }
@@ -15341,7 +15379,7 @@
         },
         "read-installed": {
           "version": "4.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "dev": true,
           "requires": {
@@ -15356,13 +15394,13 @@
           "dependencies": {
             "debuglog": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
               "dev": true
             },
             "readdir-scoped-modules": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
               "dev": true,
               "requires": {
@@ -15374,7 +15412,7 @@
             },
             "util-extend": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-u3A7eUgCk93Nz7PGqf6iD0g0Fbw=",
               "dev": true
             }
@@ -15382,7 +15420,7 @@
         },
         "read-package-json": {
           "version": "2.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Ye0bIlbqQ42ACIlQkL6EuOeZyFM=",
           "dev": true,
           "requires": {
@@ -15394,7 +15432,7 @@
           "dependencies": {
             "glob": {
               "version": "6.0.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
               "dev": true,
               "requires": {
@@ -15407,7 +15445,7 @@
               "dependencies": {
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                   "dev": true
                 }
@@ -15415,7 +15453,7 @@
             },
             "json-parse-helpfulerror": {
               "version": "1.0.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
               "dev": true,
               "requires": {
@@ -15424,7 +15462,7 @@
               "dependencies": {
                 "jju": {
                   "version": "1.3.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
                   "dev": true
                 }
@@ -15434,7 +15472,7 @@
         },
         "readable-stream": {
           "version": "2.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
           "dev": true,
           "requires": {
@@ -15449,37 +15487,37 @@
           "dependencies": {
             "buffer-shims": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
               "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
               "dev": true
             },
             "string_decoder": {
               "version": "0.10.31",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
               "dev": true
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true
             }
@@ -15487,7 +15525,7 @@
         },
         "realize-package-specifier": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/eMukmRI44+ZM02Vt7CNUeOpjZ8=",
           "dev": true,
           "requires": {
@@ -15497,7 +15535,7 @@
         },
         "request": {
           "version": "2.74.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
           "dev": true,
           "requires": {
@@ -15526,19 +15564,19 @@
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
               "dev": true
             },
             "aws4": {
               "version": "1.4.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
               "dev": true
             },
             "bl": {
               "version": "1.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
               "dev": true,
               "requires": {
@@ -15547,7 +15585,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                   "dev": true,
                   "requires": {
@@ -15561,31 +15599,31 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                       "dev": true
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                       "dev": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                       "dev": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                       "dev": true
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                       "dev": true
                     }
@@ -15595,13 +15633,13 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
               "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
               "dev": true,
               "requires": {
@@ -15610,7 +15648,7 @@
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                   "dev": true
                 }
@@ -15618,19 +15656,19 @@
             },
             "extend": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
               "dev": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
               "dev": true
             },
             "form-data": {
               "version": "1.0.0-rc4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=",
               "dev": true,
               "requires": {
@@ -15641,7 +15679,7 @@
               "dependencies": {
                 "async": {
                   "version": "1.5.2",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
                   "dev": true
                 }
@@ -15649,7 +15687,7 @@
             },
             "har-validator": {
               "version": "2.0.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
               "dev": true,
               "requires": {
@@ -15661,7 +15699,7 @@
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                   "dev": true,
                   "requires": {
@@ -15674,19 +15712,19 @@
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
                       "dev": true
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                       "dev": true
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                       "dev": true,
                       "requires": {
@@ -15695,7 +15733,7 @@
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                       "dev": true
                     }
@@ -15703,7 +15741,7 @@
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                   "dev": true,
                   "requires": {
@@ -15712,7 +15750,7 @@
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
                       "dev": true
                     }
@@ -15720,7 +15758,7 @@
                 },
                 "is-my-json-valid": {
                   "version": "2.13.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
                   "dev": true,
                   "requires": {
@@ -15732,13 +15770,13 @@
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
                       "dev": true
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
                       "dev": true,
                       "requires": {
@@ -15747,7 +15785,7 @@
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "resolved": false,
+                          "resolved": "",
                           "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
                           "dev": true
                         }
@@ -15755,13 +15793,13 @@
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
                       "dev": true
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                       "dev": true
                     }
@@ -15769,7 +15807,7 @@
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                   "dev": true,
                   "requires": {
@@ -15778,7 +15816,7 @@
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
                       "dev": true
                     }
@@ -15788,7 +15826,7 @@
             },
             "hawk": {
               "version": "3.1.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
               "dev": true,
               "requires": {
@@ -15800,7 +15838,7 @@
               "dependencies": {
                 "boom": {
                   "version": "2.10.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                   "dev": true,
                   "requires": {
@@ -15809,7 +15847,7 @@
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                   "dev": true,
                   "requires": {
@@ -15818,13 +15856,13 @@
                 },
                 "hoek": {
                   "version": "2.16.3",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
                   "dev": true
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                   "dev": true,
                   "requires": {
@@ -15835,7 +15873,7 @@
             },
             "http-signature": {
               "version": "1.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
               "dev": true,
               "requires": {
@@ -15846,13 +15884,13 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
                   "dev": true
                 },
                 "jsprim": {
                   "version": "1.3.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA=",
                   "dev": true,
                   "requires": {
@@ -15863,19 +15901,19 @@
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.0.2",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
                       "dev": true
                     },
                     "json-schema": {
                       "version": "0.2.2",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
                       "dev": true
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
                       "dev": true,
                       "requires": {
@@ -15886,7 +15924,7 @@
                 },
                 "sshpk": {
                   "version": "1.9.2",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-O0E1G7rVw03fS9gRmTfv7jGkZ2U=",
                   "dev": true,
                   "requires": {
@@ -15902,19 +15940,19 @@
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                       "dev": true
                     },
                     "assert-plus": {
                       "version": "1.0.0",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                       "dev": true
                     },
                     "dashdash": {
                       "version": "1.14.0",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
                       "dev": true,
                       "requires": {
@@ -15923,7 +15961,7 @@
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                       "dev": true,
                       "optional": true,
@@ -15933,7 +15971,7 @@
                     },
                     "getpass": {
                       "version": "0.1.6",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
                       "dev": true,
                       "requires": {
@@ -15942,7 +15980,7 @@
                     },
                     "jodid25519": {
                       "version": "1.0.2",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
                       "dev": true,
                       "optional": true,
@@ -15952,14 +15990,14 @@
                     },
                     "jsbn": {
                       "version": "0.1.0",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
                       "dev": true,
                       "optional": true
                     },
                     "tweetnacl": {
                       "version": "0.13.3",
-                      "resolved": false,
+                      "resolved": "",
                       "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
                       "dev": true,
                       "optional": true
@@ -15970,25 +16008,25 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
               "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
               "dev": true
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
               "dev": true
             },
             "mime-types": {
               "version": "2.1.11",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
               "dev": true,
               "requires": {
@@ -15997,7 +16035,7 @@
               "dependencies": {
                 "mime-db": {
                   "version": "1.23.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
                   "dev": true
                 }
@@ -16005,37 +16043,37 @@
             },
             "node-uuid": {
               "version": "1.4.7",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
               "dev": true
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
               "dev": true
             },
             "qs": {
               "version": "6.2.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
               "dev": true
             },
             "stringstream": {
               "version": "0.0.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
               "dev": true
             },
             "tough-cookie": {
               "version": "2.3.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0=",
               "dev": true
             },
             "tunnel-agent": {
               "version": "0.4.3",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
               "dev": true
             }
@@ -16043,13 +16081,13 @@
         },
         "retry": {
           "version": "0.10.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ZJ4VykCEItmDGBYZNef31lLUNd0=",
           "dev": true
         },
         "rimraf": {
           "version": "2.5.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
           "dev": true,
           "requires": {
@@ -16058,13 +16096,13 @@
         },
         "semver": {
           "version": "5.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
           "dev": true
         },
         "sha": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
           "dev": true,
           "requires": {
@@ -16074,7 +16112,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-vsgb6ujPRVFovC5bKzH1vPrtmxs=",
               "dev": true,
               "requires": {
@@ -16088,31 +16126,31 @@
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
                   "dev": true
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
                   "dev": true
                 },
                 "process-nextick-args": {
                   "version": "1.0.3",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-4nLu2CXV6fTqdNjXOx/jEcO+tjA=",
                   "dev": true
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                   "dev": true
                 },
                 "util-deprecate": {
                   "version": "1.0.1",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-NVaj0TxMaqeYPX4kJUeBlxmbeIE=",
                   "dev": true
                 }
@@ -16122,25 +16160,25 @@
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "sorted-object": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-HP6pgWCQR9gEOAekkKnZmzF/r38=",
           "dev": true
         },
         "spdx-license-ids": {
           "version": "1.2.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -16149,7 +16187,7 @@
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
@@ -16166,19 +16204,19 @@
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true,
           "requires": {
@@ -16188,7 +16226,7 @@
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
               "dev": true,
               "requires": {
@@ -16197,7 +16235,7 @@
             },
             "spdx-expression-parse": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
               "dev": true,
               "requires": {
@@ -16207,7 +16245,7 @@
               "dependencies": {
                 "spdx-exceptions": {
                   "version": "1.0.4",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
                   "dev": true
                 }
@@ -16217,7 +16255,7 @@
         },
         "validate-npm-package-name": {
           "version": "2.2.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
           "dev": true,
           "requires": {
@@ -16234,7 +16272,7 @@
         },
         "which": {
           "version": "1.2.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
           "dev": true,
           "requires": {
@@ -16243,7 +16281,7 @@
           "dependencies": {
             "isexe": {
               "version": "1.1.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
               "dev": true
             }
@@ -16251,13 +16289,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
     "@bigcommerce/stencil-utils": "^5.0.1",
-    "core-js": "^2.6.10",
+    "core-js": "^3.4.1",
     "creditcards": "^3.0.1",
     "easyzoom": "^2.5.2",
     "foundation-sites": "^5.5.3",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -30,7 +30,7 @@ module.exports = {
                                 modules: false, // Don't transform modules; needed for tree-shaking
                                 useBuiltIns: 'usage', // Tree-shake babel-polyfill
                                 targets: '> 1%, last 2 versions, Firefox ESR',
-                                corejs: '^2.6.10',
+                                corejs: '^3.4.1',
                             }],
                         ],
                     },


### PR DESCRIPTION
#### What?

Reasons to upgrade to core-js version 3 are many, mainly the improved Babel integration.

In our case, we had a theme failing on Internet Explorer 11, and it boiled down to the fact that core-js version 2 does not provide polyfill for `NodeList.forEach` method. Version 3 of core-js provides this polyfill.

If only Cornerstone was using core-js version 3 out of the box, we would not have ran into that issue.

#### Tickets / Documentation

- [Advantages of core-js version 3](https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md#what-changed-in-core-js3)

#### Screenshots (if appropriate)

:arrow_down: Comparison from core-js's README for v2 and v3:
- https://github.com/zloirock/core-js/tree/v2#iterable-dom-collections
- https://github.com/zloirock/core-js/tree/v3#iterable-dom-collections

![core-js-idc](https://user-images.githubusercontent.com/69181/68962559-a3fc9000-07b3-11ea-91c5-766ac5ab5522.png)

<hr>

:arrow_down: Although NodeList usage is properly detected, core-js version 2 is missing polyfills for IE 11.

![babel-preset-env-debug](https://user-images.githubusercontent.com/69181/68962587-b080e880-07b3-11ea-9f83-f1d311c2c758.png)
