### PR TITLE
Add jquery-migrate to Modal test

### DIFF
--- a/assets/js/test-unit/theme/global/modal.spec.js
+++ b/assets/js/test-unit/theme/global/modal.spec.js
@@ -1,3 +1,4 @@
+import '../../../theme/global/jquery-migrate';
 import modalFactory, { ModalEvents } from '../../../theme/global/modal';
 import $ from 'jquery';
 


### PR DESCRIPTION
#### What?

As written at [`assets/js/theme/global/jquery-migrate.js`](https://github.com/bigcommerce/cornerstone/blob/4.3.0/assets/js/theme/global/jquery-migrate.js):

```js
// Needed because we use Foundation 5.5, which expects jQuery 2.x. However,
// rather than bringing in all of jquery-migrate, we're cherry picking individual
// fixes needed for Foundation.
```

This is also true for the **testing environment**. Foundation 5.5 still expects jQuery 2.x, and the need for jquery-migrate is the same.

However, Foundation is used at [`assets/js/test-unit/theme/global/modal.spec.js`](https://github.com/bigcommerce/cornerstone/blob/4.3.0/assets/js/test-unit/theme/global/modal.spec.js), but jquery-migrate is not loaded.

The purpose of this PR is to fix this situation. It includes the missing jquery-migrate import to this test, before Foundation is used.

#### Why this needs to be fixed? (easy to reproduce)

We stumbled upon this problem when adding our own tests to our custom theme. It is very easy to reproduce.

:arrow_right: Simply save the following test specification as <br> `assets/js/test-unit/theme/common/sample.spec.js`:

```js
import '../../../theme/global/jquery-migrate';
import $ from 'jquery';
import foundation from '../../../theme/global/foundation';

describe('Sample', () => {
    beforeEach(() => {
        window.Foundation.global.namespace = '';
        foundation($(document));
    });

    describe('when nothing happens', () => {
        it('true should be true', () => {
            expect(true).toBeTruthy();
        });
    });
});
```

:arrow_right: Now, run `npx karma start` (or `npx grunt karma`) to run the tests. It will fail.

Why does it fail? 

When we call `foundation($('document'));`, it internally calls `$(window).load()` - but the `load` event has been removed in newer jQuery versions. The `$(window).load()` Foundation code would work with old jQuery (or modified by jquery-migrate), but in modern jQuery it will call the [Ajax load](https://api.jquery.com/load/) function instead!

Even though we are importing jquery-migrate, the Modal test ran before, and Foundation has been somehow tied to a jQuery instance which does not have the jquery-migrate changes.

:arrow_right: Now, apply the simple change from this PR, and run the tests again. It will succeed!

Why does it suceed?

When Foundation is initialized at Modal testing, jquery-migrate changes were already applied, and thus Foundation gets tied to a jQuery instance properly modified, and works as expected at all the following tests.

<hr>

In fact, a separate test specification is not required to reproduce the issue. We can just [add a few lines to the beginning of the Modal test spec](https://github.com/bigcommerce/cornerstone/compare/master...jbruni:jquery-migrate-issue-on-tests#diff-ccf4ba81f52b2b9b57761a53bc73acbd
), and it will also reveal the problem.

#### Screenshots

:arrow_down: Running the test which uses Foundation, **before** this PR fix:

![test-failure](https://user-images.githubusercontent.com/69181/68973024-f77ad800-07cb-11ea-89c5-52bdc98b8f1a.png)

:arrow_down: Running the test which uses Foundation, **after** this PR fix:

![test-success](https://user-images.githubusercontent.com/69181/68973061-0b263e80-07cc-11ea-9a5e-77f9ef4e62ca.png)
