### PR TITLE
STRF-7604 - Fix remaining itemprop availability tag for pricing

### DIFF
--- a/templates/components/products/price.html
+++ b/templates/components/products/price.html
@@ -29,7 +29,8 @@ If you are making a change here or in price-range.html, you probably want to mak
             </span>
             <span data-product-price-with-tax class="price price--withTax">{{price.with_tax.formatted}}</span>
             {{#if schema_org}}
-                <meta itemprop="availability" content="{{product.availability}}">
+                <meta itemprop="availability" itemtype="http://schema.org/ItemAvailability" 
+                	content="http://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
                 <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
                 <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
                 <meta itemprop="url" content="{{product.url}}">


### PR DESCRIPTION
#### What?
Fixes `itemprop` availability meta tag for price including tax case in price.html component. This is to address the `availability` not being set in a Google Structured Data test on PDP only when price is including tax.

This was missed in updates on STRF-6450.

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/STRF-7604

#### Screenshots (if appropriate)
**master** - This is the google structured data test with store set to display prices including taxes on PDP:
<img width="1645" alt="Screen Shot 2019-11-22 at 2 28 38 PM" src="https://user-images.githubusercontent.com/6527334/69458476-049c4780-0d35-11ea-880c-0627359c12c7.png">

**On my branch** - This is the same PDP test for prices including tax:
<img width="1647" alt="Screen Shot 2019-11-22 at 2 31 18 PM" src="https://user-images.githubusercontent.com/6527334/69458585-4c22d380-0d35-11ea-993e-be30c8115cdd.png">
 
