### PR TITLE
Show a button to launch the cookie consent modal when the feature is enabled

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -868,6 +868,9 @@
     "cookies": {
         "accept": "Accept Cookies"
     },
+    "privacy": {
+        "data_collection_preferences": "Website Data Collection Preferences"
+    },
     "maintenance": {
         "down": "Down for Maintenance"
     }

--- a/templates/components/common/footer.html
+++ b/templates/components/common/footer.html
@@ -91,6 +91,11 @@
                 {{> components/common/geotrust-ssl-seal}}
             </div>
         {{/if}}
+        {{#if settings.shopper_consent_tracking_enabled}}
+            <div class="footer-consent-modal-launch-link">
+                <p class="powered-by" href="#" onclick="event.stopPropagation(); window.consentManager.openConsentManager();">{{lang 'privacy.data_collection_preferences'}}</p>
+            </div>
+        {{/if}}
         {{#if theme_settings.show_powered_by}}
             <div class="footer-copyright">
                 <p class="powered-by">Powered by <a href="https://www.bigcommerce.com?utm_source=merchant&amp;utm_medium=poweredbyBC" rel="nofollow">BigCommerce</a></p>


### PR DESCRIPTION
#### What?

When consent tracking is enabled, shoppers need a means of changing their preferences at any time.

To accomplish this, we give them a link in the footer of the website to re-launch the cookie consent modal.

#### Screenshots (if appropriate)

Link in footer:

![image](https://user-images.githubusercontent.com/8922457/71569662-4b006700-2a96-11ea-83be-ec0f0eb4044e.png)

Ping @junedkazi @ncheikh 
