### PR TITLE
fix(checkout): CHECKOUT-4233 Cannot add wishlist with item when logged out

### DIFF
--- a/assets/js/theme/wishlist.js
+++ b/assets/js/theme/wishlist.js
@@ -2,8 +2,6 @@ import 'foundation-sites/js/foundation/foundation';
 import 'foundation-sites/js/foundation/foundation.reveal';
 import nod from './common/nod';
 import PageManager from './page-manager';
-import { api } from '@bigcommerce/stencil-utils';
-import { defaultModal } from './global/modal';
 
 export default class WishList extends PageManager {
     constructor(context) {
@@ -59,29 +57,6 @@ export default class WishList extends PageManager {
         });
     }
 
-    wishListHandler() {
-        $('body').on('click', '[data-wishlist]', event => {
-            const wishListUrl = event.currentTarget.href;
-            const modal = defaultModal();
-
-            event.preventDefault();
-
-            modal.open();
-
-            api.getPage(wishListUrl, this.options, (err, content) => {
-                if (err) {
-                    return modal.updateContent(err);
-                }
-
-                modal.updateContent(content, { wrap: true });
-
-                const $wishlistForm = $('.wishlist-form', modal.$content);
-
-                this.registerAddWishListValidation($wishlistForm);
-            });
-        });
-    }
-
     onReady() {
         const $addWishListForm = $('.wishlist-form');
 
@@ -90,6 +65,5 @@ export default class WishList extends PageManager {
         }
 
         this.wishlistDeleteConfirm();
-        this.wishListHandler();
     }
 }


### PR DESCRIPTION
#### What?
When a user is logged out and we try to create a wishlist from a PDP page the server attempts to redirect due to the shopper being logged out. Whilst this will work in blueprint, it breaks the user flow on cornerstone, which ends up with the shopper eventually logging in and creating a wishlist without the selected product in it. After discussion with product we have decided to remove the modal for creating a new wishlist 

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/CHECKOUT-4233

#### Screenshots
#### Before
![Screen Shot 2020-01-08 at 4 21 59 pm](https://user-images.githubusercontent.com/9570178/71952552-31e47c80-3233-11ea-87c3-ea3a54192882.png)
![Screen Shot 2020-01-08 at 4 22 21 pm](https://user-images.githubusercontent.com/9570178/71952546-2d1fc880-3233-11ea-8b32-3f0d127b46d0.png)

#### After
![Screen Shot 2020-01-08 at 4 21 31 pm](https://user-images.githubusercontent.com/9570178/71952557-3741c700-3233-11ea-900b-e2db14da2a19.png)
![Screen Shot 2020-01-08 at 4 21 41 pm](https://user-images.githubusercontent.com/9570178/71952558-3741c700-3233-11ea-82e4-3d46acfc0649.png)

@bigcommerce/storefront-team @davidchin 