### PR TITLE
feat(search): ES-98 Product filters configured to not display product count show a count when you use the "More" modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigcommerce-cornerstone",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/templates/components/faceted-search/show-more-facets.html
+++ b/templates/components/faceted-search/show-more-facets.html
@@ -9,12 +9,22 @@
         {{#each facets}}
             {{#if facet '===' ../all_facets}}
                 {{#each items}}
-                    <li class="navList-item"><a
+                    <li class="navList-item">
+                        <a
                         href="{{url}}"
                         class="navList-action {{#if selected }} is-active {{/if}}"
                         rel="nofollow"
                         data-id="{{ id }}"
-                        data-faceted-search-facet>{{title}} ({{count}})</a></li>
+                        data-faceted-search-facet
+                        >
+                            {{title}}
+                            {{#if ../show_product_counts}}
+                                {{#if count}}
+                                    <span>({{count}})</span>
+                                {{/if}}
+                            {{/if}}
+                        </a>
+                    </li>
                 {{/each}}
             {{/if}}
         {{/each}}


### PR DESCRIPTION
#### What?
Product filters that have more than 10 values and are configured within the control panel to not display the product count on the storefront still shows product counts in the "View More" facets modal.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- https://jira.bigcommerce.com/browse/ES-98


#### Screenshots (if appropriate)
**`Before fix:`**
`Store (local)`: https://my-dev-store-740294812.store.bcdev/
Product count is being displayed on the "more" modal when `Display Product Count` is not selected on Product Filtering.
<img width="1680" alt="Screen Shot 2020-01-23 at 4 38 29 PM" src="https://user-images.githubusercontent.com/58491357/73036001-e9b28600-3dfe-11ea-87be-7d5d1d914720.png">
<img width="1680" alt="Screen Shot 2020-01-23 at 4 38 42 PM" src="https://user-images.githubusercontent.com/58491357/73036002-e9b28600-3dfe-11ea-8c33-1b2a6d7c6596.png">

**`After fix:`**
`Store (integration)`: https://sumayyahasgar1579809024-testington.my-integration.zone/
Product count no longer being displayed  on the "more" modal when `Display Product Count` is not selected on Product Filtering
<img width="1680" alt="Screen Shot 2020-01-23 at 4 36 09 PM" src="https://user-images.githubusercontent.com/58491357/73035882-93454780-3dfe-11ea-9e5e-444ee40dc60a.png">
<img width="1680" alt="Screen Shot 2020-01-23 at 4 36 17 PM" src="https://user-images.githubusercontent.com/58491357/73035883-93454780-3dfe-11ea-8d84-2e031e7d1375.png">

#### Testing 

1. Go to https://sumayyahasgar1579809024-testington.my-integration.zone/admin/staff
2. Make sure search.disable_production_option_facet_counts experiment is turned `OFF`
3. Go to Products -> Turn on Product Filtering -> click on color settings to toggle product count
<img width="1680" alt="Screen Shot 2020-01-24 at 10 52 13 AM" src="https://user-images.githubusercontent.com/58491357/73095537-b53ed880-3e97-11ea-9535-f7d469645bb1.png">
4. Turn on/off product count and see if the see more modal is now showing the product count only when specified ✔️

- Toggling count `OFF` doesn't show the count in the see more modal anymore
<img width="1680" alt="Screen Shot 2020-01-24 at 10 52 26 AM" src="https://user-images.githubusercontent.com/58491357/73095556-c0920400-3e97-11ea-86dc-7ce8fb527805.png">

5. Search for **`test`** on the storefront (a product I created with over 10 variant option colors)
<img width="1680" alt="Screen Shot 2020-01-24 at 11 06 58 AM" src="https://user-images.githubusercontent.com/58491357/73096518-d30d3d00-3e99-11ea-87a5-dd1de8e7d79b.png">
<img width="1680" alt="Screen Shot 2020-01-24 at 11 07 05 AM" src="https://user-images.githubusercontent.com/58491357/73096519-d30d3d00-3e99-11ea-9725-dc2f547582cb.png">

- Toggling count `ON` shows the count in see more modal 
<img width="1680" alt="Screen Shot 2020-01-24 at 10 52 39 AM" src="https://user-images.githubusercontent.com/58491357/73095550-bcfe7d00-3e97-11ea-8196-2092719b023f.png">
<img width="1680" alt="Screen Shot 2020-01-24 at 11 15 20 AM" src="https://user-images.githubusercontent.com/58491357/73096938-dce37000-3e9a-11ea-8c6d-dc99ba26949e.png">
<img width="1680" alt="Screen Shot 2020-01-24 at 11 15 29 AM" src="https://user-images.githubusercontent.com/58491357/73096940-dce37000-3e9a-11ea-84cd-6d4db0a11de2.png">

