### PR TITLE
Add translation key for "read more" blog post link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Add translation key for "read more" blog post link [#1625](https://github.com/bigcommerce/cornerstone/pull/1625)
 
 ## 4.3.1 (2020-01-17)
 - Resolve visual regression in error modal icon animation [#1619](https://github.com/bigcommerce/cornerstone/pull/1619)

--- a/lang/en.json
+++ b/lang/en.json
@@ -15,7 +15,8 @@
     "blog": {
         "recent_posts": "Recent Posts",
         "label": "Blog",
-        "posted_by": "Posted by {name}"
+        "posted_by": "Posted by {name}",
+        "read_more": "read more"
     },
     "unavailable": {
         "hibernation_title": "We'll be back",

--- a/templates/components/blog/post.html
+++ b/templates/components/blog/post.html
@@ -27,7 +27,7 @@
             {{else}}
                 {{{post.summary}}}
                 {{#if post.show_read_more}}
-                    &hellip; <a href="{{url}}">read more</a>
+                    &hellip; <a href="{{url}}">{{lang 'blog.read_more'}}</a>
                 {{/if}}
             {{/if}}
         </div>


### PR DESCRIPTION
### What?

Make "read more" link for blog posts translatable by adding string to english language file.

Reference: #1623 