### PR TITLE
PAYMENTS-5111 Proper address formatting without any additional commas…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Draft
 - Add translation key for "read more" blog post link [#1625](https://github.com/bigcommerce/cornerstone/pull/1625)
 - Update My Account Payment Methods template to expose all new savable payment methods [1603](https://github.com/bigcommerce/cornerstone/pull/1603)
-
+- Proper address formatting without any additional commas in My Account Payment Methods [1626](https://github.com/bigcommerce/cornerstone/pull/1626)
 
 ## 4.3.1 (2020-01-17)
 - Resolve visual regression in error modal icon animation [#1619](https://github.com/bigcommerce/cornerstone/pull/1619)

--- a/templates/components/account/payment-methods-list.html
+++ b/templates/components/account/payment-methods-list.html
@@ -52,7 +52,13 @@
                                 {{!-- If there is an address STARTS --}}
                                 <p class="methodDetails">
                                     <span class="methodDetails-label">{{lang 'account.payment_methods.billing_address'}}:</span>
-                                    <span class="methodDetails-description">{{billing_address.address1}}, {{billing_address.address2}}, {{billing_address.city}}, {{billing_address.state}}, {{billing_address.zip}}, {{billing_address.country}}</span>
+                                    <span class="methodDetails-description">
+                                        <span>{{billing_address.address1}}, </span>
+                                        {{#if billing_address.address2}}
+                                            <span>{{billing_address.address2}}, </span>
+                                        {{/if}}
+                                        <span>{{billing_address.city}}, {{billing_address.state}} {{billing_address.zip}} {{billing_address.country}}</span>
+                                    </span>
                                 </p>
                                 {{!-- If there is an address ENDS --}}
 


### PR DESCRIPTION
… in My Account Payment Methods

#### What?
Handle the case when `address2` filed in the billing address is empty to prevent adding an unnecessary extra comma.

#### Tickets / Documentation
[Jira ticket #5111](https://jira.bigcommerce.com/browse/PAYMENTS-5111)

#### Screenshots
**Before**
<img width="980" alt="Screen Shot 2020-01-30 at 5 19 17 pm" src="https://user-images.githubusercontent.com/36555311/73425085-a9b24c80-4384-11ea-9c25-d1ddd562ddf9.png">

**After**
<img width="981" alt="Screen Shot 2020-01-30 at 5 35 48 pm" src="https://user-images.githubusercontent.com/36555311/73425875-07479880-4387-11ea-8bb0-436440cfa502.png">


