### PR TITLE
Prevent triggering quantity change when pressing enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Prevent triggering quantity change when pressing enter [#1630](https://github.com/bigcommerce/cornerstone/pull/1630)
 
 ## 4.4.0 (2020-01-31)
 - Add translation key for "read more" blog post link [#1625](https://github.com/bigcommerce/cornerstone/pull/1625)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -351,6 +351,16 @@ export default class ProductDetails {
             // update text
             viewModel.quantity.$text.text(qty);
         });
+
+        // Prevent triggering quantity change when pressing enter
+        this.$scope.on('keypress', '.form-input--incrementTotal', event => {
+            // If the browser supports event.which, then use event.which, otherwise use event.keyCode
+            const x = event.which || event.keyCode;
+            if (x === 13) {
+                // Prevent default
+                event.preventDefault();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
#### What?

When you manually input a quantity and press enter, it triggers a decrease to the quantity. This PR addresses this problem.

#### Tickets / Documentation

#1616 