### PR TITLE
feat(search): ES-721 fixed the issue for price filter collapse CP settings

### DIFF
--- a/templates/components/faceted-search/facets/range.html
+++ b/templates/components/faceted-search/facets/range.html
@@ -1,6 +1,6 @@
 <div class="accordion-block">
     <div
-        class="accordion-navigation toggleLink {{#unless ../start_collapsed }} is-open {{/unless}}"
+        class="accordion-navigation toggleLink {{#unless start_collapsed }} is-open {{/unless}}"
         role="button"
         data-collapsible="#facetedSearch-content--{{hyphenate facet }}">
         <h5 class="accordion-title">
@@ -20,7 +20,7 @@
         </div>
     </div>
 
-    <div id="facetedSearch-content--{{hyphenate facet }}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
+    <div id="facetedSearch-content--{{hyphenate facet }}" class="accordion-content {{#unless start_collapsed }} is-open {{/unless}}">
         <form id="facet-range-form" class="form" method="get" data-faceted-search-range novalidate>
             {{#each current_selected_items}}
                 <input type="hidden" name="{{ param_name }}[]" value="{{ param_value }}"/>


### PR DESCRIPTION
#### What?
Price filter always displays in expanded mode ignoring CP Setting. With this fix, Price filter honors the CP settings.

#### Tickets / Documentation
- [https://jira.bigcommerce.com/browse/ES-721](ES-721)

#### Screenshots (if appropriate)

Case 1: Expanded
![image](https://user-images.githubusercontent.com/39140274/73989645-5d728980-48fb-11ea-8054-55f65845d965.png)

![image](https://user-images.githubusercontent.com/39140274/73989660-682d1e80-48fb-11ea-9b9e-13f0eae43210.png)

Case 2:  Collapsed
![image](https://user-images.githubusercontent.com/39140274/73989680-7aa75800-48fb-11ea-9b1e-422d7f950e6e.png)

![image](https://user-images.githubusercontent.com/39140274/73989718-9b6fad80-48fb-11ea-9083-bcfe97f31d78.png)
