### PR TITLE
Remove "cookie notification" feature as it is no longer useful

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -867,9 +867,6 @@
         "view_more": "View more details",
         "view_less": "Hide details"
     },
-    "cookies": {
-        "accept": "Accept Cookies"
-    },
     "maintenance": {
         "down": "Down for Maintenance"
     }

--- a/templates/components/common/cookie.html
+++ b/templates/components/common/cookie.html
@@ -1,8 +1,0 @@
-<div class="cookieMessage">
-    <div class="cookieMessage-container">
-        <div class="cookieMessage-text">
-            <p>{{settings.privacy_cookie}}</p>
-        </div>
-        <button class="button button--primary button--small" data-privacy-accept>{{lang 'cookies.accept'}}</button>
-    </div>
-</div>

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -38,10 +38,6 @@
     <body>
         <svg data-src="{{cdn 'img/icon-sprite.svg'}}" class="icons-svg-sprite"></svg>
 
-        {{~#and settings.privacy_cookie settings.is_eu_ip_address}}
-            {{> components/common/cookie}}
-        {{/and}}
-
         {{> components/common/header }}
         {{> components/common/body }}
         {{> components/common/footer }}


### PR DESCRIPTION
#### What?

Removing the "EU Cookie Notification" feature which would show a notice to EU visitors to the site that cookies are used as part of the experience.

This is being removed as BigCommerce has adapted to changing interpretations of GDPR, and have determined that this feature is no longer useful to merchants who are seeking to be compliant with data privacy regulations.

Merchants are recommended to consider our new [Shopper Consent Tracking feature
](https://support.bigcommerce.com/s/article/Store-Settings#security) and consider our other guidance related to local laws:

https://support.bigcommerce.com/s/article/General-Data-Protection-Regulation#learning
https://support.bigcommerce.com/s/article/Implementing-CCPA-with-BigCommerce

As always, merchants are advised to seek their own counsel regarding any data privacy requirements that may apply to their business.