### PR TITLE
feat(search): ES-97 fixed the html special chars issue in facet names

### DIFF
--- a/templates/components/faceted-search/facets/hierarchy-children.html
+++ b/templates/components/faceted-search/facets/hierarchy-children.html
@@ -7,7 +7,7 @@
             rel="nofollow"
             data-id="{{ id }}"
             data-faceted-search-facet>
-                {{title}}
+                {{{sanitize title}}}
                 {{#if ../show_product_counts}}
                     {{#if count}}
                         <span>({{count}})</span>

--- a/templates/components/faceted-search/facets/hierarchy.html
+++ b/templates/components/faceted-search/facets/hierarchy.html
@@ -31,7 +31,7 @@
                         rel="nofollow"
                         data-id="{{ id }}"
                         data-faceted-search-facet>
-                        {{ title }}
+                        {{{ sanitize title }}}
                         {{#if ../show_product_counts}}
                             {{#if count}}
                                 <span>({{ count }})</span>

--- a/templates/components/faceted-search/facets/multi.html
+++ b/templates/components/faceted-search/facets/multi.html
@@ -30,7 +30,7 @@
                         class="navList-action navList-action--checkbox {{#if selected }} is-selected {{/if}}"
                         rel="nofollow"
                         data-faceted-search-facet>
-                        {{ sanitize title }}
+                        {{{ sanitize title }}}
                         {{#if ../show_product_counts}}
                             <span>({{ count }})</span>
                         {{/if}}

--- a/templates/components/faceted-search/selected-facets.html
+++ b/templates/components/faceted-search/selected-facets.html
@@ -15,7 +15,7 @@
                         {{#if facet '===' 'rating'}}
                             {{lang 'search.faceted.selected.rating-label' rating=title}}
                         {{else}}
-                            {{ title }}
+                            {{{ sanitize title }}}
                         {{/if}}
 
                         <svg class="icon">


### PR DESCRIPTION
#### What?
As part of fixing the encoding issues for ES-97, we found that html characters are being displayed in stencil theme. This fix will address it.

#### Tickets / Documentation
- [https://jira.bigcommerce.com/browse/ES-97](ES-97)


#### Screenshots (if appropriate)

Broken "RefineBy" facet names
---------------------------------
![image](https://user-images.githubusercontent.com/39140274/74293692-634bde80-4cf0-11ea-81e6-7d2259abae02.png)


Fixed "RefineBy" facet names
-------------------------------
![image](https://user-images.githubusercontent.com/39140274/74293739-84143400-4cf0-11ea-8f5d-a5339b5b59d7.png)

