### PR TITLE
Search Results: fix navigation issues

### DIFF
--- a/templates/components/search/content-count.html
+++ b/templates/components/search/content-count.html
@@ -1,0 +1,3 @@
+<span data-url="{{forms.search.content_url}}" data-count="{{pagination.content_results.total}}">
+    {{lang 'search.results.content_count' count=pagination.content_results.total}}
+</span>

--- a/templates/components/search/content-listing.html
+++ b/templates/components/search/content-listing.html
@@ -1,0 +1,10 @@
+{{#if content_results}}
+    {{> components/search/content-sort-box sort=pagination.content_results.sort}}
+    <ul>
+        {{#each content_results}}
+            <strong><a href="{{url}}">{{{title}}}</a></strong>({{type}})
+            <p>{{{content}}}</p>
+        {{/each}}
+    </ul>
+    {{> components/common/paginator pagination.content_results reload=true}}
+{{/if}}

--- a/templates/components/search/product-count.html
+++ b/templates/components/search/product-count.html
@@ -1,1 +1,3 @@
-{{lang 'search.results.product_count' count=pagination.product_results.total}}
+<span data-url="{{forms.search.product_url}}" data-count="{{pagination.product_results.total}}">
+    {{lang 'search.results.product_count' count=pagination.product_results.total}}
+</span>

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -29,8 +29,8 @@ product_results:
                 </a>
             </li>
             <li class="navBar-item">
-                <a class="navBar-action" href="{{forms.search.content_url}}" data-content-results-toggle>
-                    {{lang 'search.results.content_count' count=pagination.content_results.total}}
+                <a id="search-results-content-count" class="navBar-action" href="{{forms.search.content_url}}" data-content-results-toggle>
+                    {{>components/search/content-count}}
                 </a>
             </li>
             {{#unless product_results.faceted_search_enabled}}
@@ -53,16 +53,12 @@ product_results:
 </section>
 
 <section class="page">
-    {{#if product_results.products}}
-        {{#if product_results.faceted_search_enabled}}
-            <aside class="page-sidebar{{#if forms.search.section '!=' 'product'}} u-hiddenVisually{{/if}}" id="faceted-search-container">
-                {{> components/faceted-search/index product_results}}
-            </aside>
-        {{/if}}
-        <main class="page-content">
-    {{else}}
-        <main class="page-content page-content--centered">
+    {{#if product_results.faceted_search_enabled}}
+        <aside class="page-sidebar{{#if forms.search.section '!=' 'product'}} u-hiddenVisually{{/if}}" id="faceted-search-container">
+            {{> components/faceted-search/index product_results}}
+        </aside>
     {{/if}}
+    <main class="page-content">
         {{#if forms.search.has_suggestions}}
             <div class="panel panel--large">
                 <div class="panel-body">
@@ -126,18 +122,9 @@ product_results:
             </div>
         {{/if}}
 
-        {{#if content_results}}
-            <div id="search-results-content" {{#if forms.search.section '!=' 'content'}}class="u-hiddenVisually"{{/if}}>
-                {{> components/search/content-sort-box sort=pagination.content_results.sort}}
-                <ul>
-                    {{#each content_results}}
-                        <strong><a href="{{url}}">{{{title}}}</a></strong>({{type}})
-                        <p>{{{content}}}</p>
-                    {{/each}}
-                </ul>
-                {{> components/common/paginator pagination.content_results reload=true}}
-            </div>
-        {{/if}}
+        <div id="search-results-content" {{#if forms.search.section '!=' 'content'}}class="u-hiddenVisually"{{/if}}>
+            {{> components/search/content-listing}}
+        </div>
 
         <div id="product-listing-container" {{#if forms.search.section '!=' 'product'}}class="u-hiddenVisually"{{/if}}>
             {{> components/search/product-listing}}


### PR DESCRIPTION
#### What?

This PR contains a number of bug fixes related to the Search Results page navigation.

If fixes #1170 and #1312 by separating the current navigation **page** between "Products" and "News & Information" tabs. It becomes possible, for example, to be at "page 3" in one tab, and at "page 1" in the other tab.

It also improves the fix to #1442, provided by commit 5322976e. Now, the back button also works when there is a switch between "Products" and "News & Information" tabs, when navigating backwards.

And it also fixes the dynamic loading of search results for the "News & Information" tab. The AJAX load/update only worked for the "Products" tab. Now, it works also for the "News & Information" tab.

It also fixes the annoying "re-load" of the search results immediately after the first load of the search results page.

While working in this PR, another search results navigation issue was found, but the problem is at `stencil-utils`. It has been reported at https://github.com/bigcommerce/stencil-utils/pull/110#issuecomment-586749147 and a PR for the fix has been submitted at https://github.com/bigcommerce/stencil-utils/pull/117

-------------------------------------------

##### Technical Details

In this section, I will explain the code changes in this PR.

:one: [Changes to `search.html` template](https://github.com/jbruni/cornerstone/commit/1d95e3b3450171f598528ec297594103dae8e41c#diff-d1a81eff432508a1eff09cf7a636130e):

- We already had `{{> components/search/product-listing}}` for the products results and `{{> components/search/product-count}}` for the products count, as partials for the **Products** tab.

- Now, we introduce `{{> components/search/content-listing}}` and `{{> components/search/content-count}}` partials for the **News & Information** tab results and count.

- Note that we **_always want to render the container elements_**, in order to support toggling between a "zero results page" and a "page with results". We can't keep rendering the containers conditionally (only if there are results) at this upper level (`search.html`)... if the containers are not rendered, when receiving non-empty search results from a future AJAX call, we are not be able to update the DOM.

:two: [New `content-count.html` partial](https://github.com/jbruni/cornerstone/commit/1d95e3b3450171f598528ec297594103dae8e41c#diff-844a40c0ef56c7b0826890d381978209) and [changes to `product-count.html` partial](https://github.com/jbruni/cornerstone/commit/1d95e3b3450171f598528ec297594103dae8e41c#diff-84773ea3021829e48ce4b49c2a51c0df):

- As part of the strategy of keeping the page number of each tab separated, we update only the respective section (`content` or `product`) when updating the DOM. In other words: when the `product` section is updated, the `content` section will NOT be updated; and when the `content` section is updated, the `product` section will NOT be updated. Makes sense.

- To achieve the expected results, we output the search `url` and `count` values as `data` attributes in a dummy wrapper `span` element, for later retrieval and usage in the JavaScript code.

:three: [New `content-listing.html` partial](https://github.com/jbruni/cornerstone/commit/1d95e3b3450171f598528ec297594103dae8e41c#diff-1d01b2f36dea1b5f96c8da7c616d4469):

- This has been extracted from `search.html` to its own partial, so it is possible to update it dynamically.

:four: [Changes to `search.js` code](https://github.com/jbruni/cornerstone/commit/1d95e3b3450171f598528ec297594103dae8e41c#diff-c6f8ca603e58d1d49d5479308da4fac0):

- Let's see the changes to `initFacetedSearch()` first:
    1. We add jQuery wrappers to the "News & Information" listing and count elements.
    2. We include the new `content-*` components in the list of partials to retrieve.
    3. In the callback which processes the AJAX call results, there are three changes:
        - We added updates for the two new `content-*` partials;
        - We only update the `content` or `product` elements, according to the requested section (instead of updating everything);
        - We call the `showProducts` or `showContent` method, to switch to the proper tab; this ensures the proper tab is displayed after using the **back button** to browse backwards.

- The changes to `showProducts` and `showContent` are similar. Note that these functions do two things: update the UI, showing the product or content tab; and they also trigger the dynamic load/update of results.
    1. We introduced a boolean `navigate` parameter (with default to `true`, to keep the previous behaviour). This way, it is possible to "separate" the two things that these functions do. If we want to switch the UI tab only, without doing AJAX request to load contents, we can do it by passing `false` as argument to the `navigate` parameter.
    2. When `navigate` is `true`, instead of using the `window.location.href`, which can point to a different tab, we are looking into the `data-url` and `data-count` attributes introduced to the `*-count` partials. The query string parameter for `section` will be always correct. And, if the `count` is zero, we force the query string parameter `page` to `1`. (The use case here is when the initial load was for a page greater than `1`, and the tab didn't contain results for that page.)

-------------------------------------------

These are the minimal changes to make the existing navigation in a working state. There is room for further improvements.

#### Tickets / Documentation

- Issue #1312  
- Issue #1170 
- Issue #1442 
- Commit 5322976e
- stencil-utils issue https://github.com/bigcommerce/stencil-utils/pull/110#issuecomment-586749147
- stencil-utils PR https://github.com/bigcommerce/stencil-utils/pull/117

#### Screenshots (if appropriate)

N/A
