### PR TITLE
fix(storefront): STRF-5678 fixed the check for max length in create account fields

### DIFF
--- a/templates/components/common/forms/text.html
+++ b/templates/components/common/forms/text.html
@@ -2,5 +2,5 @@
     <label class="form-label" for="{{id}}_input">{{label}}
         {{#if required}}<small>{{lang 'common.required' }}</small>{{/if}}
     </label>
-    <input type="text" id="{{id}}_input" data-label="{{label}}" name="{{name}}" {{#if value}} value="{{value}}"{{/if}} {{#if placeholder}} placeholder="{{placeholder}}"{{/if}} class="form-input" aria-required="{{required}}" {{#if private_id}}data-field-type="{{private_id}}"{{/if}}>
+    <input type="text" id="{{id}}_input" data-label="{{label}}" name="{{name}}" {{#if value}} value="{{value}}"{{/if}} {{#if placeholder}} placeholder="{{placeholder}}"{{/if}} class="form-input" aria-required="{{required}}" {{#if private_id}}data-field-type="{{private_id}}"{{/if}} {{#if maxlength}}maxlength="{{maxlength}}"{{/if}}>
 </div>


### PR DESCRIPTION
#### What?

Top 20 bug reports that while user can set the max length for the account sign up fields it is not respected in the storefront

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/STRF-5678

#### Screenshots (if appropriate)

<img width="1446" alt="Screen Shot 2020-03-12 at 2 00 08 PM" src="https://user-images.githubusercontent.com/9043352/76566363-d79dad00-6469-11ea-9454-9ada7563754f.png">

To test:
1. Navigate to Control Panel -> Advanced Settings -> Account Sign up 
2. Change max length on any text field (for example Address 1 field)
3. Navigate to storefront and click on Register
4. Type in the field with defined max length and observe how it is not allowing you enter more characters than specified in max length

ping @bigcommerce/storefront-team @bigcommerce/artemis-dt 
