### PR TITLE
feat(search): ES-466 Facets with & symbol works now

### DIFF
--- a/templates/components/faceted-search/facets/hierarchy.html
+++ b/templates/components/faceted-search/facets/hierarchy.html
@@ -3,7 +3,7 @@
     <div
         class="accordion-navigation toggleLink {{#unless ../start_collapsed }} is-open {{/unless}}"
         role="button"
-        data-collapsible="#facetedSearch-content--{{hyphenate facet }}">
+        data-collapsible="#facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{/replace}}">
         <h5 class="accordion-title">
             {{ title }}
         </h5>
@@ -21,8 +21,8 @@
         </div>
     </div>
 
-    <div id="facetedSearch-content--{{hyphenate facet }}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
-        <ul id="facetedSearch-navList--{{hyphenate facet }}" class="navList" data-facet="{{facet}}" data-has-more-results="{{ has_more_results }}">
+    <div id="facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{/replace}}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
+        <ul id="facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{/replace}}" class="navList" data-facet="{{facet}}" data-has-more-results="{{ has_more_results }}">
             {{#each items}}
                 <li class="navList-item">
                     <a
@@ -46,7 +46,7 @@
         </ul>
 
         {{#if show_more_toggle}}
-            <a href="#facetedSearch-navList--{{hyphenate facet }}" role="button" class="toggleLink">
+            <a href="#facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{/replace}}" role="button" class="toggleLink">
                 <span class="toggleLink-text toggleLink-text--off">{{lang 'search.faceted.show-more'}}</span>
             </a>
         {{/if}}

--- a/templates/components/faceted-search/facets/multi.html
+++ b/templates/components/faceted-search/facets/multi.html
@@ -3,7 +3,7 @@
     <div
         class="accordion-navigation toggleLink {{#unless ../start_collapsed }} is-open {{/unless}}"
         role="button"
-        data-collapsible="#facetedSearch-content--{{hyphenate facet }}">
+        data-collapsible="#facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{/replace}}">
         <h5 class="accordion-title">
             {{ title }}
         </h5>
@@ -21,8 +21,8 @@
         </div>
     </div>
 
-    <div id="facetedSearch-content--{{hyphenate facet }}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
-        <ul id="facetedSearch-navList--{{hyphenate facet }}" data-facet="{{facet}}" class="navList" data-has-more-results="{{ has_more_results }}">
+    <div id="facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{/replace}}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
+        <ul id="facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{/replace}}" data-facet="{{facet}}" class="navList" data-has-more-results="{{ has_more_results }}">
             {{#each items}}
                 <li class="navList-item">
                     <a
@@ -46,7 +46,7 @@
         </ul>
 
         {{#if show_more_toggle}}
-            <a href="#facetedSearch-navList--{{hyphenate facet }}" role="button" class="toggleLink">
+            <a href="#facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{/replace}}" role="button" class="toggleLink">
                 <span class="toggleLink-text toggleLink-text--off">{{lang 'search.faceted.show-more'}}</span>
             </a>
         {{/if}}

--- a/templates/components/faceted-search/show-more-facets.html
+++ b/templates/components/faceted-search/show-more-facets.html
@@ -17,7 +17,7 @@
                         data-id="{{ id }}"
                         data-faceted-search-facet
                         >
-                            {{title}}
+                            {{{title}}}
                             {{#if ../show_product_counts}}
                                 {{#if count}}
                                     <span>({{count}})</span>


### PR DESCRIPTION
#### What?
Faceted search filters that include ampersand (&) breaks 'Show More' links. 

With this fix, now we can have Facets with `&` symbol and `Show More` link works fine.

#### Tickets / Documentation

- [ES-466](https://jira.bigcommerce.com/browse/ES-466)

#### Testing Steps:
1. Login to CP
2. Navigate to Products
3. Edit few Products and add a `Custom Field` (with same name like _ Custom & Color _) and with different values for each product and save the Products.
4.  Navigate to Products->Product Filtering
5. Enable the newly created facet.
6. Click the settings of this facet filter and change the value for `show` to 5 items and save
6. Go to SF and click on the `Show More` link for this new filter and the popup window shows all the filter values.

#### Screenshots (if appropriate)

1. List of all Facets:
![image](https://user-images.githubusercontent.com/39140274/78189183-6b89e580-7426-11ea-80a5-3d0ed52a0c1a.png)

2. Facet with `&` in the name & value
![image](https://user-images.githubusercontent.com/39140274/78189074-3da4a100-7426-11ea-9c98-c2f731310bff.png)

3. `Show More`  link displays the popup with filterable values
![image](https://user-images.githubusercontent.com/39140274/78189101-4ac19000-7426-11ea-9980-f99759708489.png)

4. Other Facet's `Show More` link works fine too.. 
![image](https://user-images.githubusercontent.com/39140274/78189208-7775a780-7426-11ea-88b2-75d948cf4bf9.png)


@bigcommerce/artemis-dt  @lord2800 @kwang30 
