### PR TITLE
fix(customers): CHECKOUT-4828 Special characters to render properly on the cart modal pop up

### DIFF
--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -40,7 +40,7 @@
                                     {{#if is_file}}
                                         <a href="/viewfile.php?attributeId={{../id}}&cartitem={{../../id}}">{{value}}</a>
                                     {{else}}
-                                        {{value}}
+                                        {{{ sanitize value}}}
                                     {{/if}}
                                 </dd>
                             {{/each}}

--- a/templates/components/cart/preview.html
+++ b/templates/components/cart/preview.html
@@ -88,7 +88,7 @@
                                 {{name}}
                             </dt>
                             <dd class="productView-info-value">
-                                {{value}}
+                                {{{ sanitize value}}}
                             </dd>
                         </dl>
                     {{/each}}

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -146,7 +146,7 @@
                 {{#if theme_settings.show_custom_fields_tabs '!==' true}}
                     {{#each product.custom_fields}}
                         <dt class="productView-info-name">{{name}}:</dt>
-                        <dd class="productView-info-value">{{{value}}}</dd>
+                        <dd class="productView-info-value">{{{ sanitize value}}}</dd>
                     {{/each}}
                 {{/if}}
             </dl>


### PR DESCRIPTION
#### What?
Due to a recent change input fields on products are sanitised. This means that in cornerstone the expected values weren't rendered as expected

#### Tickets / Documentation
https://jira.bigcommerce.com/browse/CHECKOUT-4828

Add links to any relevant tickets and documentation.

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/9570178/79535865-fd9a1b00-80c1-11ea-9f86-06ced1ade8b3.png)


@bigcommerce/checkout @bigcommerce/storefront-team @abhijethbc 
