### PR TITLE
Reset cart quantity to 0 if we get a 404 for the cart

### DIFF
--- a/assets/js/theme/global/cart-preview.js
+++ b/assets/js/theme/global/cart-preview.js
@@ -69,7 +69,12 @@ export default function (secureBaseUrl, cartId) {
         const cartQtyPromise = new Promise((resolve, reject) => {
             utils.api.cart.getCartQuantity({ baseUrl: secureBaseUrl, cartId }, (err, qty) => {
                 if (err) {
-                    reject(err);
+                    // If this appears to be a 404 for the cart ID, set cart quantity to 0
+                    if (err === 'Not Found') {
+                        resolve(0);
+                    } else {
+                        reject(err);
+                    }
                 }
                 resolve(qty);
             });


### PR DESCRIPTION
#### What?

If we get a 404 for the cart, set the quantity to 0 for the cart preview.

Fixes a bug where the quantity will not update back to 0 after a successful checkout.

#### Tickets / Documentation


- [STRF-8295](https://jira.bigcommerce.com/browse/STRF-8295)

