### PR TITLE
feat(search): STRF-8350 Fixed the special characters display issue in the search results page

### DIFF
--- a/templates/components/search/heading.html
+++ b/templates/components/search/heading.html
@@ -1,3 +1,3 @@
 <h1 class="page-heading">
-    {{lang 'search.results.count' count=result_count search_query=forms.search.query}}
+    {{{lang 'search.results.count' count=result_count search_query=(sanitize forms.search.query) }}}
 </h1>

--- a/templates/components/search/quick-results.html
+++ b/templates/components/search/quick-results.html
@@ -13,6 +13,6 @@
     </ul>
 {{else}}
     <p class="quickSearchMessage">
-        {{lang 'search.results.quick_count' count=pagination.product_results.total search_query=forms.search.query}}
+        {{{lang 'search.results.quick_count' count=pagination.product_results.total search_query=(sanitize forms.search.query) }}}
     </p>
 {{/if}}

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -72,7 +72,7 @@ product_results:
                             <div class="search-suggestion">
                                 <p>
                                     {{lang 'forms.search.your_search_for'}}
-                                    "<strong>{{forms.search.query}}</strong>"
+                                    "<strong>{{{sanitize forms.search.query}}}</strong>"
                                     {{lang 'forms.search.no_match'}}
                                 </p>
                             </div>


### PR DESCRIPTION
#### What?
Special Characters are displaying as Unicode when using the Storefront Search as shown in the below ticket. 

This is because search term was not escaped before displaying. With this fix, search query is properly escaped/sanitized before displaying in the SF. 

#### Tickets / Documentation
- [STRF-8350](https://jira.bigcommerce.com/browse/STRF-8350)

#### Testing Steps
1. Login to CP
2. Navigate to Storefront
3. Upload the theme file (**Cornerstone-4.5.0_Fix_8350**) with the fix attached to the above ticket (**STRF-8350**) and apply it
4. Search in the Storefront with a term which has special character in it like ```test's```  or ```test"s```
5. Search results page will not display any unicode/un-escaped characters

#### Screenshots (if appropriate)

1. searched with single quote (')
![image](https://user-images.githubusercontent.com/39140274/80018582-0fe1d380-848b-11ea-9fd1-81d86c418ce1.png)

2. searched with double quote (")
![image](https://user-images.githubusercontent.com/39140274/80018802-71a23d80-848b-11ea-9c28-8d916315e5a3.png)

3. quick search modal also showing escaped search term
![image](https://user-images.githubusercontent.com/39140274/80031500-9ce25800-849e-11ea-91eb-f2e11b0b07ff.png)

ping @bigcommerce/artemis-dt  @bigcommerce/storefront-team 
