### PR TITLE
fix(catalog): CATALOG-5557 Special characters are not rendered for product review

### DIFF
--- a/templates/components/products/reviews.html
+++ b/templates/components/products/reviews.html
@@ -35,7 +35,7 @@
                             </p>
                         {{/if}}
                     </header>
-                    <p itemprop="reviewBody" class="productReview-body">{{nl2br text}}</p>
+                    <p itemprop="reviewBody" class="productReview-body">{{{ sanitize text }}}</p>
                 </article>
             </li>
             {{/each}}

--- a/templates/components/products/reviews.html
+++ b/templates/components/products/reviews.html
@@ -23,7 +23,7 @@
                             {{> components/products/ratings rating=rating}}
                             <span class="productReview-ratingNumber" itemprop="ratingValue">{{ rating }}</span>
                         </span>
-                        <h5 itemprop="name" class="productReview-title">{{ title }}</h5>
+                        <h5 itemprop="name" class="productReview-title">{{{ sanitize title }}}</h5>
                         {{#if name}}
                             <meta itemprop="author" content="{{name}}">
                             <p class="productReview-author">


### PR DESCRIPTION
Special characters are not rendered for product review titles and text on storefront

#### What?
Special characters in product review titles and texts are displaying html entities. The entities that are occurring are generally for single quotes and ampersand.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.
https://jira.bigcommerce.com/browse/CATALOG-5557

#### Screenshots
<img width="299" alt="Screen Shot 2020-04-30 at 2 39 30 PM" src="https://user-images.githubusercontent.com/56338408/80706170-836d8b80-8af0-11ea-8b77-7fa149536e68.png">


