### PR TITLE
[PERFORMANCE] Optimize polyfills

### DIFF
--- a/assets/js/polyfills.js
+++ b/assets/js/polyfills.js
@@ -1,0 +1,8 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+import 'whatwg-fetch';
+import objectFitImages from 'object-fit-images';
+
+document.addEventListener('DOMContentLoaded', () => {
+    objectFitImages();
+});

--- a/assets/js/theme/global/sweet-alert.js
+++ b/assets/js/theme/global/sweet-alert.js
@@ -1,4 +1,3 @@
-import 'weakmap-polyfill';
 import sweetAlert from 'sweetalert2';
 
 // WeakMap will defined in the global scope if native WeakMap is not supported.

--- a/package-lock.json
+++ b/package-lock.json
@@ -700,22 +700,6 @@
         "regexpu-core": "^4.5.4"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
-      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.10",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
-        }
-      }
-    },
     "@babel/preset-env": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",
@@ -4815,9 +4799,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.1.tgz",
-      "integrity": "sha512-KX/dnuY/J8FtEwbnrzmAjUYgLqtk+cxM86hfG60LGiW3MmltIc2yAmDgBgEkfm0blZhUrdr1Zd84J2Y14mLxzg=="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-js-compat": {
       "version": "3.1.4",
@@ -25031,9 +25015,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regenerator-transform": {
       "version": "0.14.1",
@@ -28820,11 +28804,6 @@
         "typechecker": "^2.0.8"
       }
     },
-    "weakmap-polyfill": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/weakmap-polyfill/-/weakmap-polyfill-2.0.0.tgz",
-      "integrity": "sha1-jyj5NeOFOJatQHR+UljbV42dyN4="
-    },
     "webidl-conversions": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
@@ -29461,6 +29440,11 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
   "author": "BigCommerce",
   "license": "MIT",
   "dependencies": {
-    "@babel/polyfill": "^7.4.4",
     "@bigcommerce/stencil-utils": "^5.0.3",
-    "core-js": "^3.4.1",
+    "core-js": "^3.6.5",
     "creditcards": "^3.0.1",
     "easyzoom": "^2.5.2",
     "foundation-sites": "^5.5.3",
@@ -19,10 +18,11 @@
     "nanobar": "^0.4.2",
     "nod-validate": "^2.0.12",
     "object-fit-images": "^3.2.4",
+    "regenerator-runtime": "^0.13.5",
     "slick-carousel": "^1.8.1",
     "svg-injector": "^1.1.3",
     "sweetalert2": "^9.5.4",
-    "weakmap-polyfill": "^2.0.0"
+    "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/templates/components/common/polyfill-script.html
+++ b/templates/components/common/polyfill-script.html
@@ -1,0 +1,32 @@
+<script>
+    {{!--
+        Check for modern browser features, and load polyfills if browser does not appear to support features
+        we need.
+
+            Polyfill approach is all or nothing - please import needed polyfills in /assets/js/polyfills.js
+
+        Inspired by https://philipwalton.com/articles/loading-polyfills-only-when-needed/
+            --}}
+    function browserSupportsAllFeatures() {
+        return window.Promise
+            && window.fetch
+            && window.URL
+            && window.URLSearchParams
+            && window.WeakMap
+            // object-fit support
+            && ('objectFit' in document.documentElement.style);
+    }
+
+    function loadScript(src) {
+        var js = document.createElement('script');
+        js.src = src;
+        js.onerror = function () {
+            console.error('Failed to load polyfill script ' + src);
+        };
+        document.head.appendChild(js);
+    }
+
+    if (!browserSupportsAllFeatures()) {
+        loadScript('{{cdn 'assets/dist/theme-bundle.polyfills.js'}}');
+    }
+</script>

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -14,6 +14,9 @@
             {{!-- Change document class from no-js to js so we can detect this in css --}}
             document.documentElement.className = document.documentElement.className.replace('no-js', 'js');
         </script>
+
+        {{> components/common/polyfill-script }}
+
         {{!-- Load Lazysizes script ASAP so images will appear --}}
         <script>
             {{!-- Only load visible elements until the onload event fires, after which preload nearby elements. --}}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,8 +1,8 @@
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin,
-      CleanPlugin = require('clean-webpack-plugin'),
-      LodashPlugin = require('lodash-webpack-plugin'),
-      path = require('path'),
-      webpack = require('webpack');
+    CleanPlugin = require('clean-webpack-plugin'),
+    LodashPlugin = require('lodash-webpack-plugin'),
+    path = require('path'),
+    webpack = require('webpack');
 
 // Common configuration, with extensions in webpack.dev.js and webpack.prod.js.
 module.exports = {
@@ -11,6 +11,7 @@ module.exports = {
     entry: {
         main: './assets/js/app.js',
         head_async: ['lazysizes'],
+        polyfills: './assets/js/polyfills.js',
     },
     module: {
         rules: [
@@ -28,9 +29,9 @@ module.exports = {
                             ['@babel/preset-env', {
                                 loose: true, // Enable "loose" transformations for any plugins in this preset that allow them
                                 modules: false, // Don't transform modules; needed for tree-shaking
-                                useBuiltIns: 'usage', // Tree-shake babel-polyfill
+                                useBuiltIns: 'entry',
                                 targets: '> 1%, last 2 versions, Firefox ESR',
-                                corejs: '^3.4.1',
+                                corejs: '^3.6.5',
                             }],
                         ],
                     },
@@ -60,7 +61,7 @@ module.exports = {
             verbose: false,
             watch: false,
         }),
-        new LodashPlugin, // Complements babel-plugin-lodash by shrinking its cherry-picked builds further.
+        new LodashPlugin(), // Complements babel-plugin-lodash by shrinking its cherry-picked builds further.
         new webpack.ProvidePlugin({ // Provide jquery automatically without explicit import
             $: 'jquery',
             jQuery: 'jquery',


### PR DESCRIPTION
#### What?

I'm trying to improve performance by reducing the size of the main JS bundle when loaded on modern browsers.

I've taken [this approach](https://philipwalton.com/articles/loading-polyfills-only-when-needed/), meaning I do some basic feature detection to indicate if the shopper is using a modern browser, and if they aren't, I polyfill the `core-js` library and any other polyfills. This saves a lot of download + parsing of extraneous JS for most users. 

I've polyfilled liberally rather than trying to isolate the extra polyfills necessary based on Cornerstone's usage of ES6 features - this is because I couldn't find a great way to automate this, and it would make the theme harder to maintain if not automated.

~I also bundled in a jQuery version bump to [address a CVE](https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/), and I exposed `$` on the window object - because I see that lots of custom themes feel the need to separately include jQuery, which will be bad for performance. Exposing our existing bundle jQuery gets rid of the need to do this.~ Moving to a new PR: https://github.com/bigcommerce/cornerstone/pull/1671

**Bundle before:**

- 478kb download size
- 1.94 MB parsed size

![image](https://user-images.githubusercontent.com/8922457/81488900-e4097080-9234-11ea-9e71-9aee1122eff8.png)


**Bundle after:**

- 353 kb download size **_(26% improvement)_**
- 1.32MB parsed size **_(32% improvement)_**

![image](https://user-images.githubusercontent.com/8922457/81488910-07342000-9235-11ea-98d7-233419887757.png)
