### PR TITLE
Revert "Account form classes"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9631,20 +9631,6 @@
             "boom": "2.x.x",
             "hoek": "2.x.x",
             "joi": "5.x.x"
-          },
-          "dependencies": {
-            "joi": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
-              "integrity": "sha1-FSrQfbjunGQBmX/1/SwSiWBwv1g=",
-              "dev": true,
-              "requires": {
-                "hoek": "^2.2.x",
-                "isemail": "1.x.x",
-                "moment": "2.x.x",
-                "topo": "1.x.x"
-              }
-            }
           }
         },
         "hoek": {

--- a/templates/components/common/forms/checkbox.html
+++ b/templates/components/common/forms/checkbox.html
@@ -1,4 +1,4 @@
-<div class="form-field {{class_name}}" id="{{id}}" data-validation="{{validation}}" {{#if private_id}}data-type="{{private_id}}"{{/if}} {{#if style}}style="{{style}}{{#if size}}width:{{size}}px;{{/if}}"{{else}}{{#if size}}style="width:{{size}}px;"{{/if}}{{/if}}>
+<div class="form-field" id="{{id}}" data-validation="{{validation}}" {{#if private_id}}data-type="{{private_id}}"{{/if}}>
     <label class="form-label" for="{{id}}">{{label}}
         {{#if required}}
             <small>{{lang 'common.required' }}</small>

--- a/templates/components/common/forms/date.html
+++ b/templates/components/common/forms/date.html
@@ -1,4 +1,4 @@
-<div class="form-field {{class_name}}" id="{{id}}" data-validation="{{validation}}" {{#if private_id}}data-type="{{private_id}}"{{/if}} {{#if style}}style="{{style}}{{#if size}}width:{{size}}px;{{/if}}"{{else}}{{#if size}}style="width:{{size}}px;"{{/if}}{{/if}}>
+<div class="form-field" id="{{id}}" data-validation="{{validation}}" {{#if private_id}}data-type="{{private_id}}"{{/if}}>
     <label class="form-label" for="{{id}}" >{{label}}
     {{#if required}}<small>{{lang 'common.required' }}</small>{{/if}}</label>
     <div class="form-row form-row--third">

--- a/templates/components/common/forms/multiline.html
+++ b/templates/components/common/forms/multiline.html
@@ -1,4 +1,4 @@
-<div class="form-field {{class_name}}" id="{{id}}" data-validation="{{validation}}" {{#if style}}style="{{style}}{{#if size}}width:{{size}}px;{{/if}}"{{else}}{{#if size}}style="width:{{size}}px;"{{/if}}{{/if}}>
+<div class="form-field" id="{{id}}" data-validation="{{validation}}">
     <label class="form-label" for="{{id}}_input">{{label}}
         {{#if required}}
             <small>{{lang 'common.required' }}</small>

--- a/templates/components/common/forms/number.html
+++ b/templates/components/common/forms/number.html
@@ -1,4 +1,4 @@
-<div class="form-field" id="{{id}}" data-validation="{{validation}}" {{#if style}}style="{{style}}{{#if size}}width:{{size}}px;{{/if}}"{{else}}{{#if size}}style="width:{{size}}px;"{{/if}}{{/if}}>
+<div class="form-field" id="{{id}}" data-validation="{{validation}}">
     <label class="form-label" for="{{id}}_input">{{label}}
         {{#if required}}<small>{{lang 'common.required' }}</small>{{/if}}
     </label>

--- a/templates/components/common/forms/password.html
+++ b/templates/components/common/forms/password.html
@@ -1,4 +1,4 @@
-<div class="form-field {{class_name}}" id="{{id}}" data-validation="{{validation}}" {{#if private_id}}data-type="{{private_id}}"{{/if}} {{#if style}}style="{{style}}{{#if size}}width:{{size}}px;{{/if}}"{{else}}{{#if size}}style="width:{{size}}px;"{{/if}}{{/if}}>
+<div class="form-field" id="{{id}}" data-validation="{{validation}}" {{#if private_id}}data-type="{{private_id}}"{{/if}}>
     <label class="form-label" for="{{id}}_input">{{label}}
         {{#if required}}
             <small>{{lang 'common.required' }}</small>

--- a/templates/components/common/forms/radio.html
+++ b/templates/components/common/forms/radio.html
@@ -1,4 +1,4 @@
-<div class="form-field {{class_name}}" id="{{id}}" data-validation="{{validation}}" {{#if style}}style="{{style}}{{#if size}}width:{{size}}px;{{/if}}"{{else}}{{#if size}}style="width:{{size}}px;"{{/if}}{{/if}}>
+<div class="form-field" id="{{id}}" data-validation="{{validation}}">
     <label class="form-label">{{label}}
         {{#if required}}
             <small>{{lang 'common.required' }}</small>

--- a/templates/components/common/forms/select.html
+++ b/templates/components/common/forms/select.html
@@ -1,5 +1,5 @@
-<div class="form-field {{class_name}}" id="{{id}}" data-validation="{{validation}}" {{#if private_id}} data-type="{{private_id}}"
-    {{/if}} {{#if style}}style="{{style}}{{#if size}}width:{{size}}px;{{/if}}"{{else}}{{#if size}}style="width:{{size}}px;"{{/if}}{{/if}}>
+<div class="form-field" id="{{id}}" data-validation="{{validation}}" {{#if private_id}} data-type="{{private_id}}"
+    {{/if}}>
     <label class="form-label" for="{{id}}_select">{{label}}
         {{#if required}}<small>{{lang 'common.required' }}</small>{{/if}}
     </label>

--- a/templates/components/common/forms/selectortext.html
+++ b/templates/components/common/forms/selectortext.html
@@ -1,4 +1,4 @@
-<div class="form-field {{class_name}}" id="{{id}}" data-validation="{{validation}}" {{#if private_id}}data-type="{{private_id}}"{{/if}} {{#if style}}style="{{style}}{{#if size}}width:{{size}}px;{{/if}}"{{else}}{{#if size}}style="width:{{size}}px;"{{/if}}{{/if}}>
+<div class="form-field" id="{{id}}" data-validation="{{validation}}" {{#if private_id}}data-type="{{private_id}}"{{/if}}>
     <noscript>
         <label class="form-label" for="{{id}}_input">{{label}}
             {{#if required}}<small>{{lang 'common.required' }}</small>{{/if}}

--- a/templates/components/common/forms/text.html
+++ b/templates/components/common/forms/text.html
@@ -1,4 +1,4 @@
-<div class="form-field {{class_name}}" id="{{id}}" data-validation="{{validation}}" {{#if private_id}}data-type="{{private_id}}"{{/if}} {{#if style}}style="{{style}}{{#if size}}width:{{size}}px;{{/if}}"{{else}}{{#if size}}style="width:{{size}}px;"{{/if}}{{/if}}>
+<div class="form-field" id="{{id}}" data-validation="{{validation}}" {{#if private_id}}data-type="{{private_id}}"{{/if}}>
     <label class="form-label" for="{{id}}_input">{{label}}
         {{#if required}}<small>{{lang 'common.required' }}</small>{{/if}}
     </label>


### PR DESCRIPTION
Reverts bigcommerce/cornerstone#1655

Going to revert this for now since it is causing issues with the zipcode field. This will require some backend changes to support this change. 

We will come back to this change once the backend changes are in place.

@bigcommerce/storefront-team 