### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigcommerce-cornerstone",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9624,8 +9624,7 @@
           "requires": {
             "boom": "2.x.x",
             "hoek": "2.x.x",
-            "joi": "6.x.x",
-            "wreck": "5.x.x"
+            "joi": "6.x.x"
           }
         },
         "heavy": {
@@ -9635,8 +9634,7 @@
           "dev": true,
           "requires": {
             "boom": "2.x.x",
-            "hoek": "2.x.x",
-            "joi": "5.x.x"
+            "hoek": "2.x.x"
           }
         },
         "hoek": {


### PR DESCRIPTION
#### What?

This was created by running npm install in the root of the repo

node version: 10.17.0
as required by stencil-cli

npm version: 6.11.3

I noticed that there is a section in the README that states that node version 8 and npm version 6.4.1 should be used. Is this accurate since stencil-cli requires node 10? If not I can raise a PR to update this as well.