### PR TITLE
Add rel="noopener" to social links

### DIFF
--- a/templates/components/common/social-links.html
+++ b/templates/components/common/social-links.html
@@ -2,7 +2,7 @@
     <ul class="socialLinks socialLinks--alt">
         {{#each social_media}}
             <li class="socialLinks-item">
-                <a class="icon icon--{{display_name}}" href="{{url}}" target="_blank">
+                <a class="icon icon--{{display_name}}" href="{{url}}" target="_blank" rel="noopener">
                     <svg><use xlink:href="#icon-{{display_name}}" /></svg>
                 </a>
             </li>


### PR DESCRIPTION
#### What?

This PR adds an rel=“noopener” attribute to the social media links to help avoid any performance or security issues when using the target=“_blank” attribute. See https://web.dev/external-anchors-use-rel-noopener/