### PR TITLE
Bump lazysizes to 5.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14662,9 +14662,9 @@
       "dev": true
     },
     "lazysizes": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/lazysizes/-/lazysizes-5.2.0.tgz",
-      "integrity": "sha512-931KnHwsdCm7U7/S0GDj6FSkPvQ3ugGw65J5Plp2Mq1gBTPl9VShU+cIIX6uRr+dit+APDLmvx1FwjDll5bHLQ=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/lazysizes/-/lazysizes-5.2.1.tgz",
+      "integrity": "sha512-607dEMlbcnkny2lGYVqoA/rQO+WGpWh/BISeS1eLfT8nHQw6E+R8ybJoKKGVlZ2czKPTATrsU95f+nkwix0fXw=="
     },
     "lazystream": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "foundation-sites": "^5.5.3",
     "jquery": "^3.5.1",
     "jstree": "vakata/jstree",
-    "lazysizes": "5.2.0",
+    "lazysizes": "5.2.1",
     "lodash": "^4.17.4",
     "nanobar": "^0.4.2",
     "nod-validate": "^2.0.12",


### PR DESCRIPTION
#### What?

Latest lazysizes updates dependencies and resolves a security issue.

#### Tickets / Documentation

https://snyk.io/vuln/SNYK-JS-LAZYSIZES-567144