### PR TITLE
feat(payments): INT-2593 Display wallet on drop-down section from cart icon

### DIFF
--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -16,6 +16,42 @@ $cart-thumbnail-height:                 remCalc(100px);
 
 $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-spacing;
 
+//
+// Shared styles for additional checkout buttons
+// -----------------------------------------------------------------------------
+
+%additionalCheckoutButtons {
+    @include clearfix;
+
+    // scss-lint:disable SelectorFormat
+    .FloatRight {
+        @include clearfix;
+
+        // scss-lint:disable SelectorDepth, NestingDepth
+        p {
+            // scss-lint:disable ImportantRule
+            float: none !important;
+            margin: spacing("third") 0;
+            text-align: right;
+        }
+
+        div {
+            float: right;
+        }
+    }
+
+    .CheckoutButton {
+        margin-bottom: spacing("base");
+
+        &:first-child {
+            margin-top: spacing("single");
+        }
+
+        &:last-child {
+            margin-bottom: spacing("single");
+        }
+    }
+}
 
 // Cart layout
 // -----------------------------------------------------------------------------
@@ -508,39 +544,14 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
     }
 }
 
-.cart-additionalCheckoutButtons { // 1
-    @include clearfix;
-
-    // scss-lint:disable SelectorFormat
-    .FloatRight {
-        @include clearfix;
-
-        // scss-lint:disable SelectorDepth, NestingDepth
-        p {
-            // scss-lint:disable ImportantRule
-            float: none !important;
-            margin: spacing("third") 0;
-            text-align: right;
-        }
-
-        div {
-            float: right;
-        }
-    }
-
-    .CheckoutButton {
-        margin-bottom: spacing("base");
-
-        &:first-child {
-            margin-top: spacing("single");
-        }
-
-        &:last-child {
-            margin-bottom: spacing("single");
-        }
-    }
+.cart-additionalCheckoutButtons {
+    @extend %additionalCheckoutButtons;
 }
 
+.previewCart-additionalCheckoutButtons {
+    @extend %additionalCheckoutButtons;
+    padding-right: 1.5rem;
+}
 
 // Cart Preview
 // -----------------------------------------------------------------------------

--- a/templates/components/common/cart-preview.html
+++ b/templates/components/common/cart-preview.html
@@ -65,6 +65,13 @@
                 </div>
             {{/if}}
         </div>
+        {{#if cart.additional_checkout_buttons}}
+            <div class="previewCart-additionalCheckoutButtons">
+                {{#each cart.additional_checkout_buttons}}
+                    {{{this}}}
+                {{/each}}
+            </div>
+        {{/if}}
     {{else}}
         <div class="previewCart-emptyBody">
             {{lang 'cart.checkout.empty_cart'}}


### PR DESCRIPTION
#### What?

Adding additionalCheckoutButtons on the cart-preview and respective scss
In order to displays wallet buttons on the drop-down section from the cart icon on the storefront

#### Tickets / Documentation

[**INT-2593**](https://jira.bigcommerce.com/browse/INT-2593)
[**INT-2370(research)**](https://jira.bigcommerce.com/browse/INT-2370)

[**BCApp PR**](https://github.com/bigcommerce/bigcommerce/pull/35536) needs to be merge first

#### Screenshots 

![image](https://user-images.githubusercontent.com/46006236/84321174-53c29200-ab38-11ea-848d-d8eeb594b181.png)