### PR TITLE
fix(catalog): CATALOG-5689 Special characters are not rendered for th…

### DIFF
--- a/templates/components/products/reviews.html
+++ b/templates/components/products/reviews.html
@@ -27,7 +27,7 @@
                         {{#if name}}
                             <meta itemprop="author" content="{{name}}">
                             <p class="productReview-author">
-                                {{lang 'products.reviews.post_on_by' date=date name=name }}
+                                {{{lang 'products.reviews.post_on_by' date=date name=(sanitize name) }}}
                             </p>
                         {{else}}
                             <p class="productReview-author">


### PR DESCRIPTION
## What?

Special characters in the author field for product reviews are displaying html entities. The entities that are occurring are generally for single quote and ampersand. 

## Tickets / Documentation

Add links to any relevant tickets and documentation.
- https://jira.bigcommerce.com/browse/CATALOG-5689

<img width="367" alt="Screenshot 2020-06-12 at 15 06 01" src="https://user-images.githubusercontent.com/66319629/84502150-7b446680-acc0-11ea-97c5-b0f5050e878b.png">

ping @junedkazi @PascalZajac (have no access to select reviewer)