### PR TITLE
feat(search): ES-1192 fixed the replace helper to expand and collapse the product filters

### DIFF
--- a/templates/components/faceted-search/facets/hierarchy.html
+++ b/templates/components/faceted-search/facets/hierarchy.html
@@ -3,7 +3,7 @@
     <div
         class="accordion-navigation toggleLink {{#unless ../start_collapsed }} is-open {{/unless}}"
         role="button"
-        data-collapsible="#facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{/replace}}">
+        data-collapsible="#facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}">
         <h5 class="accordion-title">
             {{ title }}
         </h5>
@@ -21,8 +21,8 @@
         </div>
     </div>
 
-    <div id="facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{/replace}}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
-        <ul id="facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{/replace}}" class="navList" data-facet="{{facet}}" data-has-more-results="{{ has_more_results }}">
+    <div id="facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
+        <ul id="facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}" class="navList" data-facet="{{facet}}" data-has-more-results="{{ has_more_results }}">
             {{#each items}}
                 <li class="navList-item">
                     <a
@@ -46,7 +46,7 @@
         </ul>
 
         {{#if show_more_toggle}}
-            <a href="#facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{/replace}}" role="button" class="toggleLink">
+            <a href="#facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}" role="button" class="toggleLink">
                 <span class="toggleLink-text toggleLink-text--off">{{lang 'search.faceted.show-more'}}</span>
             </a>
         {{/if}}

--- a/templates/components/faceted-search/facets/multi.html
+++ b/templates/components/faceted-search/facets/multi.html
@@ -3,7 +3,7 @@
     <div
         class="accordion-navigation toggleLink {{#unless ../start_collapsed }} is-open {{/unless}}"
         role="button"
-        data-collapsible="#facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{/replace}}">
+        data-collapsible="#facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}">
         <h5 class="accordion-title">
             {{ title }}
         </h5>
@@ -21,8 +21,8 @@
         </div>
     </div>
 
-    <div id="facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{/replace}}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
-        <ul id="facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{/replace}}" data-facet="{{facet}}" class="navList" data-has-more-results="{{ has_more_results }}">
+    <div id="facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
+        <ul id="facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}" data-facet="{{facet}}" class="navList" data-has-more-results="{{ has_more_results }}">
             {{#each items}}
                 <li class="navList-item">
                     <a
@@ -46,7 +46,7 @@
         </ul>
 
         {{#if show_more_toggle}}
-            <a href="#facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{/replace}}" role="button" class="toggleLink">
+            <a href="#facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}" role="button" class="toggleLink">
                 <span class="toggleLink-text toggleLink-text--off">{{lang 'search.faceted.show-more'}}</span>
             </a>
         {{/if}}


### PR DESCRIPTION
#### What?
Product filters are not expanded or collapsed in category listing, brand listing & search results page when product filters for SF are turned on. 

### Why
Currently, we are not able to expand/collapse the filters since, `replace` helper returns empty string when the input does not have the special character `&` in it. Thus collapsible divs are having same id and thus its broken this feature in the product filters. 

In the below image, both the `data-collapsible` in the html source is same for both `Catrgory` & `Brand` filters.

![image](https://user-images.githubusercontent.com/39140274/84537376-74a7f600-aca4-11ea-9822-c69a09b88da3.png)


#### Tickets / Documentation

- [https://jira.bigcommerce.com/browse/ES-1192](ES-1192)

#### Screenshots (if appropriate)

Steps:
1. Login to CP
2. Use the theme file (`Cornerstone-4.6.1_fix_ES-1192.zip`) uploaded in the above issue
3. Upload & Publish the theme by navigating to Storefront
4. Navigate to Products, choose any product 
5. Create a `custom field` with special character `&` in it. Ex: `Custom & Filter`  and save the product.
6. Navigate to Products -> Product Filters and enable product filters
7. Make sure to enable above created custom filter and save.
8. Go to SF and check by expand & collapsing all the product filters.
9. All the filters should be collapsible or expandable.

Images:

1. Before collapasing any filter

![image](https://user-images.githubusercontent.com/39140274/84531345-54bf0500-ac99-11ea-8ddf-3d5b2c7c11c9.png)

2. Category filter collapsed

![image](https://user-images.githubusercontent.com/39140274/84531422-74562d80-ac99-11ea-964d-adce0e1bc7bf.png)

3. Category & Brand filters collapsed

![image](https://user-images.githubusercontent.com/39140274/84531473-88019400-ac99-11ea-9c22-81e7953d0bf6.png)

4. Category Expanded, but Brand collapsed

![image](https://user-images.githubusercontent.com/39140274/84531539-9e0f5480-ac99-11ea-9939-cf0ab26fd881.png)

5. Other & Custom filter expanded 
![image](https://user-images.githubusercontent.com/39140274/84531613-b41d1500-ac99-11ea-9dd1-672fbbbcfd9a.png)

6. Other collapsed and Custom expanded
![image](https://user-images.githubusercontent.com/39140274/84531729-dd3da580-ac99-11ea-85ca-056d840dedcf.png)

7. Both Other & Custom filters collapsed
![image](https://user-images.githubusercontent.com/39140274/84531764-e9296780-ac99-11ea-92e1-ac08e2663b9e.png)

8. Other Expanded again & Custom filter collapsed 
![image](https://user-images.githubusercontent.com/39140274/84531805-fba3a100-ac99-11ea-807a-409cbe352be0.png)

9. Both Other & Custom expanded again
![image](https://user-images.githubusercontent.com/39140274/84531856-1249f800-ac9a-11ea-9296-ed5c7a33283d.png)

10. All the filters collapsed
![image](https://user-images.githubusercontent.com/39140274/84531926-3279b700-ac9a-11ea-855a-51825032c5d4.png)





