### PR TITLE
fix(STRF): STRF-7591 Storefront - “&” displays as “\&amp;” under acco…

### DIFF
--- a/templates/pages/account/orders/details.html
+++ b/templates/pages/account/orders/details.html
@@ -55,12 +55,12 @@
                 <section class="account-sidebar-block">
                     <h3 class="account-heading">{{lang 'account.orders.details.ship_to'}}</h3>
                     <ul class="account-order-address">
-                        <li>{{order.shipping_address.full_name}}</li>
-                        <li>{{order.shipping_address.company}}</li>
-                        <li>{{order.shipping_address.address_lines.[0]}}</li>
-                        <li>{{order.shipping_address.address_lines.[1]}}</li>
-                        <li>{{order.shipping_address.city}}, {{order.shipping_address.state}} {{order.shipping_address.zip}}</li>
-                        <li>{{order.shipping_address.country}}</li>
+                        <li>{{{ sanitize order.shipping_address.full_name}}}</li>
+                        <li>{{{ sanitize order.shipping_address.company}}}</li>
+                        <li>{{{ sanitize order.shipping_address.address_lines.[0]}}}</li>
+                        <li>{{{ sanitize order.shipping_address.address_lines.[1]}}}</li>
+                        <li>{{{ sanitize order.shipping_address.city}}}, {{{ sanitize order.shipping_address.state}}} {{{ sanitize order.shipping_address.zip}}}</li>
+                        <li>{{{ sanitize order.shipping_address.country}}}</li>
                     </ul>
                 </section>
             {{else}}
@@ -77,12 +77,12 @@
             <section class="account-sidebar-block">
                 <h3 class="account-heading">{{lang 'account.orders.details.bill_to'}}</h3>
                 <ul class="account-order-address">
-                    <li>{{order.billing_address.full_name}}</li>
-                    <li>{{order.billing_address.company}}</li>
-                    <li>{{order.billing_address.address_lines.[0]}}</li>
-                    <li>{{order.billing_address.address_lines.[1]}}</li>
-                    <li>{{order.billing_address.city}}, {{order.billing_address.state}} {{order.billing_address.zip}}</li>
-                    <li>{{order.billing_address.country}}</li>
+                    <li>{{{ sanitize order.billing_address.full_name}}}</li>
+                    <li>{{{ sanitize order.billing_address.company}}}</li>
+                    <li>{{{ sanitize order.billing_address.address_lines.[0]}}}</li>
+                    <li>{{{ sanitize order.billing_address.address_lines.[1]}}}</li>
+                    <li>{{{ sanitize order.billing_address.city}}}, {{{ sanitize order.billing_address.state}}} {{{ sanitize order.billing_address.zip}}}</li>
+                    <li>{{{ sanitize order.billing_address.country}}}</li>
                 </ul>
             </section>
 


### PR DESCRIPTION
…unt > orders > Ship/Bill to

#### What?

“&” using escape character “&amp” instead of literal character.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.
https://jira.bigcommerce.com/browse/STRF-7591

#### Screenshots (if appropriate)

<img width="520" alt="Screenshot 2020-06-15 at 12 43 10" src="https://user-images.githubusercontent.com/66319629/84643264-46c1ec00-af06-11ea-8d37-d3826165ad72.png">

ping @junedkazi @PascalZajac 
