### PR TITLE
fix(storefront): STRF-7436 Line breaks entered in Return Instructions…

### DIFF
--- a/templates/pages/account/return-saved.html
+++ b/templates/pages/account/return-saved.html
@@ -9,7 +9,7 @@
         </p>
         {{#if return.instructions}}
             <h3>{{lang 'account.returns.instructions'}}</h3>
-            <p>{{return.instructions}}</p>
+            <p>{{nl2br return.instructions}}</p>
         {{/if}}
     </div>
 </div>


### PR DESCRIPTION
… are stripped from formatting on storefront

#### What?

It appears that the line breaks in the return instructions are being stripped from the formatting on storefront. 

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

https://jira.bigcommerce.com/browse/STRF-7436

#### Screenshots (if appropriate)

<img width="325" alt="Screenshot 2020-06-15 at 14 23 58" src="https://user-images.githubusercontent.com/66319629/84652453-50eae700-af14-11ea-8fc8-6bbb96aceec2.png">

ping @junedkazi @PascalZajac 