### PR TITLE
fix(search): ES-1322 fixed the collapse and expand issue for custom filter without no special characters

### DIFF
--- a/templates/components/faceted-search/facets/hierarchy.html
+++ b/templates/components/faceted-search/facets/hierarchy.html
@@ -3,7 +3,7 @@
     <div
         class="accordion-navigation toggleLink {{#unless ../start_collapsed }} is-open {{/unless}}"
         role="button"
-        data-collapsible="#facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}">
+        data-collapsible="#facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}">
         <h5 class="accordion-title">
             {{ title }}
         </h5>
@@ -21,8 +21,8 @@
         </div>
     </div>
 
-    <div id="facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
-        <ul id="facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}" class="navList" data-facet="{{facet}}" data-has-more-results="{{ has_more_results }}">
+    <div id="facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
+        <ul id="facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}" class="navList" data-facet="{{facet}}" data-has-more-results="{{ has_more_results }}">
             {{#each items}}
                 <li class="navList-item">
                     <a
@@ -46,7 +46,7 @@
         </ul>
 
         {{#if show_more_toggle}}
-            <a href="#facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}" role="button" class="toggleLink">
+            <a href="#facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}" role="button" class="toggleLink">
                 <span class="toggleLink-text toggleLink-text--off">{{lang 'search.faceted.show-more'}}</span>
             </a>
         {{/if}}

--- a/templates/components/faceted-search/facets/multi.html
+++ b/templates/components/faceted-search/facets/multi.html
@@ -3,7 +3,7 @@
     <div
         class="accordion-navigation toggleLink {{#unless ../start_collapsed }} is-open {{/unless}}"
         role="button"
-        data-collapsible="#facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}">
+        data-collapsible="#facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}">
         <h5 class="accordion-title">
             {{ title }}
         </h5>
@@ -21,8 +21,8 @@
         </div>
     </div>
 
-    <div id="facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
-        <ul id="facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}" data-facet="{{facet}}" class="navList" data-has-more-results="{{ has_more_results }}">
+    <div id="facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
+        <ul id="facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}" data-facet="{{facet}}" class="navList" data-has-more-results="{{ has_more_results }}">
             {{#each items}}
                 <li class="navList-item">
                     <a
@@ -46,7 +46,7 @@
         </ul>
 
         {{#if show_more_toggle}}
-            <a href="#facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{facet}}{{/replace}}" role="button" class="toggleLink">
+            <a href="#facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}" role="button" class="toggleLink">
                 <span class="toggleLink-text toggleLink-text--off">{{lang 'search.faceted.show-more'}}</span>
             </a>
         {{/if}}


### PR DESCRIPTION
#### What?
Custom filter without '&' is not collapsable

Since custom filter without `&` and if it has `empty space` between the words (`Ex: Custom Size`), the `data-collapsible` element is broken in the html source. With this fix, 

#### Tickets / Documentation
- [https://jira.bigcommerce.com/browse/ES-1322](ES-1322)

#### Screenshots (if appropriate)
1. All the filters are collapsed
![image](https://user-images.githubusercontent.com/39140274/84715914-bba51e00-af26-11ea-948a-556d0c3d3ee5.png)

2. Standard filters are expanded 
![image](https://user-images.githubusercontent.com/39140274/84716182-48e87280-af27-11ea-8bdb-7ad0ac28f33a.png)

3. Both custom filters are expanded
![image](https://user-images.githubusercontent.com/39140274/84715950-cd86c100-af26-11ea-921a-0d58ca743233.png)

4. One custom collapsed (custom filter without `&` in it) and other one is expanded (custom filter with `&` in it)
![image](https://user-images.githubusercontent.com/39140274/84716076-0fb00280-af27-11ea-8a25-baed4fc199b2.png)

5. One custom collapsed (custom filter with`&` in it) and other one is expanded (custom filter without `&` in it)
![image](https://user-images.githubusercontent.com/39140274/84716108-25bdc300-af27-11ea-90e4-c5ec323a5068.png)


