### PR TITLE
fix(Storefront): STRF-5072 Cornerstone not showing Sale badge 

### DIFF
--- a/assets/scss/layouts/products/_productList.scss
+++ b/assets/scss/layouts/products/_productList.scss
@@ -64,16 +64,13 @@
 
 .listItem-figure {
     margin: 0 0 spacing("single");
-
+    position: relative;
+    
     @include breakpoint("small") {
         margin-bottom: 0;
         padding-left: spacing("half");
         padding-right: spacing("half");
         width: grid-calc(3, $total-columns);
-    }
-
-    @include breakpoint("large") {
-        position: relative;
     }
 
     .listItem-button {
@@ -87,6 +84,7 @@
             transform-style: preserve-3d;
         }
     }
+    
 }
 
 .listItem-figureBody {

--- a/assets/scss/layouts/products/_productSaleBadges.scss
+++ b/assets/scss/layouts/products/_productSaleBadges.scss
@@ -36,6 +36,23 @@
     width: rem-calc(50px);
 }
 
+.listItem-figure {
+
+    .starwrap {
+        transform: scale(0.7);
+
+        @include breakpoint("small") {
+            top: 0;
+            transform: scale(0.6);
+        }
+
+        @include breakpoint("large") {
+            top: 10px;
+            transform: scale(0.7);
+        }
+    }
+}
+
 .sale-text-burst {
     color: stencilColor("color_text_product_sale_badges");
     font-weight: 600;
@@ -92,6 +109,23 @@
     transition: 800ms ease;
     width: rem-calc(119px);
     z-index: zIndex("lower");
+}
+
+.listItem-figure {
+    
+    .sale-flag-sash {
+        left: -25px;
+
+        @include breakpoint("small") {
+            top: 15px;
+        }
+
+        @include breakpoint("large") {
+            left: -15px;
+            top: 25px;
+        }
+
+    }
 }
 
 .product:hover .sale-flag-sash {

--- a/templates/components/products/list-item.html
+++ b/templates/components/products/list-item.html
@@ -4,6 +4,22 @@
     <article class="listItem">
 {{/if}}
     <figure class="listItem-figure">
+        {{#or price.non_sale_price_with_tax price.non_sale_price_without_tax}}
+        {{#if theme_settings.product_sale_badges '===' 'sash'}}
+            <div class="sale-flag-sash">
+                <span class="sale-text">On Sale!</span>
+            </div>
+        {{else if theme_settings.product_sale_badges '===' 'topleft'}}
+            <div class="sale-flag-side">
+                <span class="sale-text">On Sale!</span>
+            </div>
+        {{else if theme_settings.product_sale_badges '===' 'burst'}}
+            <div class="starwrap">
+                <div class="sale-text-burst">On Sale!</div>
+                <div class="sale-flag-star"></div>
+            </div>
+        {{/if}}
+        {{/or}}    
         {{> components/common/responsive-img
             image=image
             class="listItem-image"


### PR DESCRIPTION
#### What?

@bc-themes 
Fixed Cornerstone not showing Sale badge in list view. 
In your page builder you have theme styles. In Global section you need to scroll opened modal window to Products paragraph. Here you can select display style list or grid. When grid is selected Sale Badges are seen on products that have a discount. But if you select list, product items will not have Sale Badges.
For now it is fixed - the user can see Sale Badges on items this discount in list view and in a grid view.
I added code that checks is this item on sale and need badge in html file of product list item. Also I updated styles for badges displaing in product list item
 
#### Tickets / Documentation

Add links to any relevant tickets and documentation.
https://jira.bigcommerce.com/browse/STRF-5072

#### Screenshots (if appropriate)

Attach images or add image links here.

<img width="921" alt="Screenshot 2020-06-16 at 14 59 28" src="https://user-images.githubusercontent.com/66325265/84781971-2a9a7980-aff0-11ea-8a1d-bc1e80909945.png">
<img width="436" alt="Screenshot 2020-06-16 at 15 00 48" src="https://user-images.githubusercontent.com/66325265/84781986-2ec69700-aff0-11ea-8fe9-d619a36bcfa5.png">
