### PR TITLE
fix(Storefront): BCTHEME-3 Horizontal scrolling on some resolutions

### DIFF
--- a/assets/scss/layouts/footer/_footer.scss
+++ b/assets/scss/layouts/footer/_footer.scss
@@ -71,12 +71,14 @@
     @include breakpoint("small") {
         left: 50%;
         position: inherit;
+        width: 50%;
     }
 
     @include breakpoint("medium") {
         left: 0;
         padding: 0;
         text-align: right;
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
#### What?

@junedkazi 
Horizontal scrolling on some resolutions, for example, on iPad.
When social links in the footer turned on and they aligned to the right, unnecessary horizontal scroll appears. It was so because of position styles of social links block (was shifted to the right) and his width.  

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [Link 1](http://example.com)
- ...

#### Screenshots (if appropriate)

Attach images or add image links here.

![Example Image](http://placehold.it/300x200)
