### PR TITLE
fix(catalog): BCTHEME-40 Cornerstone - Product Reviews Not Showing If…

### DIFF
--- a/config.json
+++ b/config.json
@@ -81,7 +81,7 @@
     "show_accept_googlepay": false,
     "show_accept_klarna": false,
     "show_product_details_tabs": true,
-    "show_product_reviews_tabs": false,
+    "show_product_reviews": true,
     "show_custom_fields_tabs": false,
     "show_product_weight": true,
     "show_product_dimensions": false,

--- a/schema.json
+++ b/schema.json
@@ -1381,13 +1381,13 @@
         "type": "checkbox",
         "label": "i18n.ShowProductReviews",
         "force_reload": true,
-        "id": "show_product_reviews_tabs"
+        "id": "show_product_reviews"
       },
       {
         "type": "select",
         "label": "i18n.NumberOfProductReviews",
         "id": "productpage_reviews_count",
-        "reference": "show_product_reviews_tabs",
+        "reference": "show_product_reviews",
         "reference_default": false,
         "force_reload": true,
         "options": [

--- a/templates/components/products/description-tabs.html
+++ b/templates/components/products/description-tabs.html
@@ -12,7 +12,7 @@
             <a class="tab-title" href="#tab-{{dashcase (lowercase (sanitize theme_settings.pdp-custom-fields-tab-label))}}">{{sanitize theme_settings.pdp-custom-fields-tab-label}}</a>
         </li>
     {{/all}}
-    {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs product.reviews.total}}
+    {{#all settings.show_product_reviews theme_settings.show_product_reviews product.reviews.total}}
         <li class="tab">
             <a class="tab-title productView-reviewTabLink" href="#tab-reviews">{{lang 'products.reviews.header' total=product.reviews.total}}</a>
         </li>
@@ -37,7 +37,7 @@
          </dl>
       </div>
    {{/all}}
-   {{#all settings.show_product_reviews theme_settings.show_product_reviews_tabs}}
+   {{#all settings.show_product_reviews theme_settings.show_product_reviews}}
        <div class="tab-content" id="tab-reviews">
            {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
        </div>

--- a/templates/components/products/reviews.html
+++ b/templates/components/products/reviews.html
@@ -2,7 +2,7 @@
 <section class="toggle productReviews" id="product-reviews" data-product-reviews>
     <h4 class="toggle-title">
         {{lang 'products.reviews.header' total=reviews.total}}
-        {{#if theme_settings.show_product_reviews_tabs '!==' true}}
+        {{#if theme_settings.show_product_reviews}}
             <a class="toggleLink is-open" data-collapsible href="#productReviews-content">
                 <span class="toggleLink-text toggleLink-text--on">
                     {{lang 'products.reviews.hide'}}

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -27,7 +27,7 @@ product:
             {{> components/products/videos product.videos}}
         {{/if}}
 
-        {{#all settings.show_product_reviews (if theme_settings.show_product_reviews_tabs '!==' true)}}
+        {{#all settings.show_product_reviews theme_settings.show_product_reviews (if theme_settings.show_product_details_tabs '!==' true)}}
             {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
         {{/all}}
 


### PR DESCRIPTION
… Tabs Disabled

#### What?

On the most recent version of Cornerstone, 3.2.2, if you have tabs disabled and reviews set to show in the theme editor, the product reviews will not be displayed.

In theme setting we have two checkboxes "Show descriptions tabs"(let it be D) and "Show product reviews"(let it be R). And we have to handle any combinations of these checkbox enabling ('+' means turned on, '-' means turned off)

Previous logic:
+D+R = both description and reviews tabs
+D-R = description tab and expandable review section
-D-R = text description and expandable review section
-D+R = only text description (that is an issue because when R checkbox is enabled we can’t see any reviews)

Current logic:
+D+R = both description and review tabs,
+D-R = description tab,
-D-R = text description,
-D+R = text description + expandable review section

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/BCTHEME-40

#### Screenshots (if appropriate)

<img width="1279" alt="Screenshot 2020-06-23 at 20 58 28" src="https://user-images.githubusercontent.com/66319629/85438236-758a3300-b594-11ea-82ae-41b16da9120c.png">
<img width="1287" alt="Screenshot 2020-06-23 at 20 58 43" src="https://user-images.githubusercontent.com/66319629/85438244-76bb6000-b594-11ea-923b-eea9c82ac83b.png">
<img width="1373" alt="Screenshot 2020-06-23 at 20 59 01" src="https://user-images.githubusercontent.com/66319629/85438250-7753f680-b594-11ea-9cf7-80c702e6ab27.png">
<img width="1343" alt="Screenshot 2020-06-23 at 20 59 15" src="https://user-images.githubusercontent.com/66319629/85438257-77ec8d00-b594-11ea-93a7-400fd4933539.png">

ping @junedkazi @yurytut1993 