### PR TITLE
fix(Storefrront): BCTHEME-28 Misalignment of Product Listings on Category pages when using the list Display Style

### DIFF
--- a/assets/scss/layouts/products/_productList.scss
+++ b/assets/scss/layouts/products/_productList.scss
@@ -27,6 +27,7 @@
     @include breakpoint("small") {
         @include grid-row($behavior: "nest");
         display: table;
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
#### What?
Misalignment of Product Listings on Category pages when using the list Display Style.
When your products renders in list mode and you have product without description, this products buttons are shifted to the left on desktop and have misaligning on mobile. It was fixed with setting 100% with to the list item 

#### Tickets / Documentation

- [jira ticket](https://jira.bigcommerce.com/browse/BCTHEME-28)

#### Screenshots (if appropriate)

desktop bug (second product)
<img width="1438" alt="desktop_bug" src="https://user-images.githubusercontent.com/66325265/85539712-d3635d00-b61e-11ea-9286-22c4dc1c0712.png">

desktop fix  (second product)
<img width="1438" alt="desktop_fix" src="https://user-images.githubusercontent.com/66325265/85539882-0148a180-b61f-11ea-9733-4f6f31fa11fd.png">

mobile bug (second product)
<img width="794" alt="mobile_bug" src="https://user-images.githubusercontent.com/66325265/85539913-09a0dc80-b61f-11ea-9c39-4e7c013e51c4.png">

mobile fix  (second product)
<img width="794" alt="mobile_fix" src="https://user-images.githubusercontent.com/66325265/85539944-14f40800-b61f-11ea-9499-8dc177f70a8f.png">
