### PR TITLE
fix(BC Themes): BCTHEME-12 Cornerstone: Enabling Facebook Likes causes iframe overlap in WYSIWYG

### DIFF
--- a/assets/scss/layouts/products/_productView.scss
+++ b/assets/scss/layouts/products/_productView.scss
@@ -49,6 +49,8 @@
     @include grid-column(12);
     padding-left: spacing("base");
     padding-right: spacing("base");
+    position: relative;
+    z-index: 1;
 
     @include breakpoint("large") {
         clear: right;


### PR DESCRIPTION

#### What?

Cornerstone: Enabling Facebook Likes causes iframe overlap in WYSIWYG.
Facebook Likes causes iframe with like button overlap Description section. Because of that you can not interact with product description text and and follow links in this description.

As I understood from the https://developers.facebook.com/docs/plugins/like-button styles  of a like button can be modified from the third side. So changing the styles of its iframe may cause unpredictable style effects.  So I decided that overriding iframe styles is not the best decision. It is more reliable to set z-index for description under the like button  to shift this description in higher layer and make it clickable.

#### Tickets / Documentation

Here is [task](https://jira.bigcommerce.com/browse/BCTHEME-12) where we have screenshot with a bug. And also I added video with bug reproducing and video with fix  
