### PR TITLE
Suppress 3rd party Related Videos on YouTube videos

### DIFF
--- a/templates/components/products/videos.html
+++ b/templates/components/products/videos.html
@@ -23,7 +23,7 @@
                 webkitAllowFullScreen
                 mozallowfullscreen
                 allowFullScreen
-                data-src="//www.youtube.com/embed/{{this.featured.id}}"
+                data-src="//www.youtube.com/embed/{{this.featured.id}}?rel=0"
                 data-video-player>
             </iframe>
         </div>


### PR DESCRIPTION
This change adds to product page YouTube videos a YouTube URL parameter that suppresses 3rd party "Related Videos" at the end of each video's run. During the June Town Hall Q&A, this was named by one user as a problem that forced them to move their videos to Vimeo. With this URL parameter, only same-channel videos will appear as related videos.

YouTube's [IFrame Player API](https://developers.google.com/youtube/player_parameters) explains how this URL parameter works: "...if the rel parameter is set to 0, related videos will come from the same channel as the video that was just played."

For an Ecommerce site, this is an improvement and should reduce the possibility to sending traffic to someone else's store through YouTube 3rd party videos. Since video.html is used by both AMP and non-AMP product pages, this should be effective on both.