### PR TITLE
fix(bctheme): BCTHEME-41 Products With Multiple Videos, an Option Set…

### DIFF
--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -166,7 +166,6 @@ export default class ProductDetails {
                 view.attr('data-product-variant', productVariant);
             } else {
                 const productName = view.find('.productView-title')[0].innerText.replace(/"/g, '\\$&');
-                console.log(productName);
                 const card = $(`[data-name="${productName}"]`);
                 card.attr('data-product-variant', productVariant);
             }

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -165,7 +165,8 @@ export default class ProductDetails {
             if (view.attr('data-event-type')) {
                 view.attr('data-product-variant', productVariant);
             } else {
-                const productName = view.find('.productView-title')[0].innerText;
+                const productName = view.find('.productView-title')[0].innerText.replace(/"/g, '\\$&');
+                console.log(productName);
                 const card = $(`[data-name="${productName}"]`);
                 card.attr('data-product-variant', productVariant);
             }


### PR DESCRIPTION
… and a Quotation Mark in the Product Name - Clicking on Video Thumbnail Returns User to Top of Page

#### What?

As of Cornerstone version 2.6.0(fixed on 4.7.0), if a product has multiple YouTube videos, has an option set applied, and has a quotation mark in the product name, clicking on the thumbnails for those videos will return the user to the top of the page instead of loading the corresponding video.

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/BCTHEME-41

#### Screenshots (if appropriate)

<img width="996" alt="Screenshot 2020-06-30 at 19 23 13" src="https://user-images.githubusercontent.com/66319629/86151255-2cdbf800-bb07-11ea-8ee1-f676a0a22916.png">

ping @yurytut1993 @junedkazi 
