### PR TITLE
fix(bctheme): BCTHEME-36 Product List Options Do Not Have a Max Height

### DIFF
--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -372,6 +372,8 @@
     border: $productOptions-list-border;
     list-style: none;
     margin: 0;
+    max-height: 400px;
+    overflow-y: scroll;
 }
 
 .productOptions-list-item {

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -373,7 +373,7 @@
     list-style: none;
     margin: 0;
     max-height: 400px;
-    overflow-y: scroll;
+    overflow-y: auto;
 }
 
 .productOptions-list-item {


### PR DESCRIPTION
#### What?

On Stencil themes, product list options do not have a set max height. This affects merchants that add a large amount of items to their product list options as it increases the length of the product page and pushes the add to cart button far down the page.

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/BCTHEME-36

#### Screenshots (if appropriate)

![Screenshot 2020-07-01 at 15 11 44](https://user-images.githubusercontent.com/66319629/86243234-ad096880-bbae-11ea-9386-bec6092fae25.png)

ping @yurytut1993 @junedkazi 