### PR TITLE
cart content make gift certificate alt and title translatable

### DIFF
--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -12,7 +12,7 @@
             <tr class="cart-item" data-item-row>
                 <td class="cart-item-block cart-item-figure">
                     {{#if type '==' 'GiftCertificate'}}
-                        <img class="cart-item-fixed-image" src="{{cdn ../../theme_settings.default_image_gift_certificate}}" alt="GiftCertificate" title="GiftCertificate">
+                        <img class="cart-item-fixed-image" src="{{cdn ../../theme_settings.default_image_gift_certificate}}" alt="{{lang 'cart.gift_certificate'}}" title="{{lang 'cart.gift_certificate'}}">
                     {{else}}
                         {{> components/common/responsive-img
                             image=image


### PR DESCRIPTION
#### What?

In `templates/components/cart/content.html` the gift certificate image `alt` and `title` tags are not translatable.
This PR fixes that

