### PR TITLE
fix(Cornerstone): BCTHEME-2 Sale badge "Burst" does not change colour on hover

### DIFF
--- a/assets/scss/layouts/products/_productSaleBadges.scss
+++ b/assets/scss/layouts/products/_productSaleBadges.scss
@@ -64,6 +64,16 @@
     z-index: zIndex("high");
 }
 
+.product:hover .starwrap {
+    
+    .sale-flag-star,
+    .sale-flag-star:before,
+    .sale-flag-star:after {
+        background: stencilColor("color_hover_product_sale_badges");
+        transition: 800ms ease;        
+    }    
+}
+
 // -----------------------------------------------------------------------------
 // TOP LEFT BADGE
 // -----------------------------------------------------------------------------

--- a/assets/scss/layouts/products/_productSaleBadges.scss
+++ b/assets/scss/layouts/products/_productSaleBadges.scss
@@ -17,6 +17,7 @@
     top: 0;
     transform: scaleX(1) scaleY(1) scaleZ(1);
     transform-origin: 50% 50% 0;
+    transition: background-color 800ms ease;
     width: rem-calc(50px);
     z-index: zIndex("lower");
 }
@@ -70,7 +71,6 @@
     .sale-flag-star:before,
     .sale-flag-star:after {
         background: stencilColor("color_hover_product_sale_badges");
-        transition: 800ms ease;        
     }    
 }
 
@@ -90,13 +90,12 @@
     padding-right: spacing("half");
     padding-top: spacing("eighth") / 2;
     position: absolute;
-    transition: 800ms ease;
+    transition: background-color 800ms ease;
     z-index: zIndex("lower");
 }
 
 .product:hover .sale-flag-side {
     background: stencilColor("color_hover_product_sale_badges");
-    transition: 800ms ease;
 }
 
 // -----------------------------------------------------------------------------
@@ -116,7 +115,7 @@
     text-align: center;
     top: 25px;
     transform: rotate(-45deg);
-    transition: 800ms ease;
+    transition: background-color 800ms ease;
     width: rem-calc(119px);
     z-index: zIndex("lower");
 }
@@ -140,7 +139,6 @@
 
 .product:hover .sale-flag-sash {
     background: stencilColor("color_hover_product_sale_badges");
-    transition: 800ms ease;
 }
 
 .product {


### PR DESCRIPTION
#### What?
Cornerstone has 3 types of sale badge - sash, topleft and burst. On hover product with sale badge it must change color that user can setup in storefront panel (color_hover_product_sale_badges settings option in config.json). sash & topleft affecting this value, but burst not. I have added styles for burst sale badge and now hover works on all sale badges

@BC-tymurbiedukhin  @golcinho @junedkazi 

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-2)
