### PR TITLE
fix(payments): PAYPAL-528 SPB - change the shape

### DIFF
--- a/config.json
+++ b/config.json
@@ -311,7 +311,7 @@
     "pdp-custom-fields-tab-label": "Additional Information",
     "paymentbuttons-paypal-layout": "vertical",
     "paymentbuttons-paypal-color": "gold",
-    "paymentbuttons-paypal-shape": "pill",
+    "paymentbuttons-paypal-shape": "rect",
     "paymentbuttons-paypal-size": "responsive",
     "paymentbuttons-paypal-label": "checkout",
     "paymentbuttons-paypal-tagline": false,


### PR DESCRIPTION
#### What?

Change the default layout shape for PayPal smart buttons from `pill` shape to `rect` (which is similar to shape of Checkout Button)

#### Tickets / Documentation

[https://developer.paypal.com/docs/archive/checkout/how-to/customize-button](https://developer.paypal.com/docs/archive/checkout/how-to/customize-button/#button-styles)

#### Screenshots

Settings
<img width="875" alt="Screenshot 2020-07-06 at 16 56 38" src="https://user-images.githubusercontent.com/54856617/86601783-6b136480-bfaa-11ea-8f91-be2bee6e38eb.png">

Before
<img width="364" alt="Screenshot 2020-07-06 at 16 59 14" src="https://user-images.githubusercontent.com/54856617/86601876-8d0ce700-bfaa-11ea-908f-df335a4fbdc8.png">

After
<img width="325" alt="Screenshot 2020-07-06 at 16 58 45" src="https://user-images.githubusercontent.com/54856617/86601893-9433f500-bfaa-11ea-8b65-8870bea23b5a.png">

