### PR TITLE
fix(bctheme): BCTHEME-20 Stencil Themes - Non-required options do not…

### DIFF
--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -5,6 +5,7 @@ import ImageGallery from '../product/image-gallery';
 import modalFactory, { showAlertModal } from '../global/modal';
 import _ from 'lodash';
 import Wishlist from '../wishlist';
+import { normalizeFormData } from './utils/api';
 
 export default class ProductDetails {
     constructor($scope, context, productAttributesData = {}) {
@@ -54,25 +55,6 @@ export default class ProductDetails {
         $productOptionsElement.show();
 
         this.previewModal = modalFactory('#previewModal')[0];
-    }
-
-    /**
-     * https://stackoverflow.com/questions/49672992/ajax-request-fails-when-sending-formdata-including-empty-file-input-in-safari
-     * Safari browser with jquery 3.3.1 has an issue uploading empty file parameters. This function removes any empty files from the form params
-     * @param formData: FormData object
-     * @returns FormData object
-     */
-    filterEmptyFilesFromForm(formData) {
-        try {
-            for (const [key, val] of formData) {
-                if (val instanceof File && !val.name && !val.size) {
-                    formData.delete(key);
-                }
-            }
-        } catch (e) {
-            console.error(e); // eslint-disable-line no-console
-        }
-        return formData;
     }
 
     setProductVariant() {
@@ -388,7 +370,7 @@ export default class ProductDetails {
         this.$overlay.show();
 
         // Add item to cart
-        utils.api.cart.itemAdd(this.filterEmptyFilesFromForm(new FormData(form)), (err, response) => {
+        utils.api.cart.itemAdd(normalizeFormData(new FormData(form)), (err, response) => {
             const errorMessage = err || response.data.error;
 
             $addToCartBtn

--- a/assets/js/theme/common/utils/api.js
+++ b/assets/js/theme/common/utils/api.js
@@ -1,0 +1,49 @@
+/**
+ * This function removes any empty string values from the formData
+ * @param formData: FormData object
+ * @returns FormData object
+*/
+export const filterEmptyValuesFromForm = formData => {
+    const res = new FormData();
+
+    try {
+        for (const [key, val] of formData) {
+            if (val !== '') {
+                res.append(key, val);
+            }
+        }
+    } catch (e) {
+        console.log(e); // eslint-disable-line no-console
+    }
+
+    return res;
+};
+
+/**
+ * https://stackoverflow.com/questions/49672992/ajax-request-fails-when-sending-formdata-including-empty-file-input-in-safari
+ * Safari browser with jquery 3.3.1 has an issue uploading empty file parameters. This function removes any empty files from the form params
+ * @param formData: FormData object
+ * @returns FormData object
+ */
+export const filterEmptyFilesFromForm = formData => {
+    const res = new FormData();
+
+    try {
+        for (const [key, val] of formData) {
+            if (!(val instanceof File) || val.name || val.size) {
+                res.append(key, val);
+            }
+        }
+    } catch (e) {
+        console.error(e); // eslint-disable-line no-console
+    }
+
+    return res;
+};
+
+/**
+ * This function removes empty string values and empty files from the formData
+ * @param formData: FormData object
+ * @returns FormData object
+ */
+export const normalizeFormData = formData => filterEmptyValuesFromForm(filterEmptyFilesFromForm(formData));

--- a/assets/scss/layouts/products/_productSwatch.scss
+++ b/assets/scss/layouts/products/_productSwatch.scss
@@ -16,6 +16,11 @@ $second_value : str-slice($value_of_swatch_size, $position_of_x + 1);
     overflow: visible;
 }
 
+.form-option-variant--none {
+    height: 22px;
+    overflow: hidden;
+}
+
 .form-option-variant--color,
 .form-option-variant--pattern {
     height: $second_value +"px";

--- a/templates/components/products/options/product-list.html
+++ b/templates/components/products/options/product-list.html
@@ -15,10 +15,10 @@
                     <input class="form-radio"
                            type="radio"
                            name="attribute[{{id}}]"
-                           value="0"
-                           id="attribute_productlist_0_{{id}}"
-                           checked="{{#if defaultValue '==' 0}}checked{{/if}}" required>
-                    <label class="form-label" for="attribute_productlist_0_{{id}}">{{lang 'products.none'}}</label>
+                           value=""
+                           id="attribute_productlist_{{../id}}_none"
+                           checked="{{#if defaultValue '==' ''}}checked{{/if}}">
+                    <label class="form-label" for="attribute_productlist_{{../id}}_none">{{lang 'products.none'}}</label>
                 </li>
             {{/unless}}
             {{#each values}}

--- a/templates/components/products/options/set-radio.html
+++ b/templates/components/products/options/set-radio.html
@@ -7,6 +7,18 @@
         {{/if}}
     </label>
 
+    {{#unless required}}
+        <input
+            class="form-radio"
+            type="radio"
+            id="attribute_radio_{{../id}}_none"
+            name="attribute[{{../id}}]"
+            value=""
+            checked="{{#if defaultValue '==' ''}}checked{{/if}}"
+        >
+        <label class="form-label" for="attribute_radio_{{../id}}_none">{{lang 'products.none'}}</label>
+    {{/unless}}
+
     {{#each this.values}}
         <input
             class="form-radio"

--- a/templates/components/products/options/set-rectangle.html
+++ b/templates/components/products/options/set-rectangle.html
@@ -6,6 +6,21 @@
             <small>{{lang 'common.required'}}</small>
         {{/if}}
     </label>
+
+    {{#unless required}}
+        <input
+            class="form-radio"
+            type="radio"
+            id="attribute_rectangle__{{../id}}_none"
+            name="attribute[{{../id}}]"
+            value=""
+            checked="{{#if defaultValue '==' ''}}checked{{/if}}"
+        >
+        <label class="form-option" for="attribute_rectangle__{{../id}}_none">
+            <span class="form-option-variant">{{lang 'products.none'}}</span>
+        </label>
+    {{/unless}}
+
     {{#each this.values}}
         <input
             class="form-radio"

--- a/templates/components/products/options/swatch.html
+++ b/templates/components/products/options/swatch.html
@@ -8,6 +8,20 @@
         {{/if}}
     </label>
 
+    {{#unless required}}
+        <input
+            class="form-radio"
+            type="radio"
+            name="attribute[{{../id}}]"
+            value=""
+            id="attribute_swatch_{{../id}}_none"
+            checked="{{#if defaultValue '==' ''}}checked{{/if}}"
+        >
+        <label class="form-option form-option-swatch" for="attribute_swatch_{{../id}}_none">
+            <span class='form-option-variant form-option-variant--none' title="{{lang 'products.none'}}">{{lang 'products.none'}}</span>
+        </label>
+    {{/unless}}
+
     {{#each this.values}}
         <input class="form-radio" type="radio" name="attribute[{{../id}}]" value="{{id}}" id="attribute_swatch_{{../id}}_{{id}}" {{#if selected}}checked data-default{{/if}} {{#if ../required}}required{{/if}}>
         <label class="form-option form-option-swatch" for="attribute_swatch_{{../id}}_{{id}}" data-product-attribute-value="{{id}}">


### PR DESCRIPTION
… have a 'none' choice on the storefront

#### What?

Historically, when product options were set to not required a shopper would have the ability to select 'none' on the option. Stencil themes not provide this choice, so if a shopper selects an option that isn't required, they do not have the ability to de-select it by choosing 'none'. This can be frustrating for shoppers, especially when there are price change rules attached to the non-required option.

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/BCTHEME-20

#### Screenshots (if appropriate)

<img width="505" alt="Screenshot 2020-07-07 at 13 18 20" src="https://user-images.githubusercontent.com/66319629/86767227-58556a00-c054-11ea-9c22-3de37be0d1ee.png">

ping @yurytut1993 @golcinho @junedkazi 