### PR TITLE
feature(bctheme): BCTHEME-50 ability to load subcategories and expand them if there are other categories beneath it

### DIFF
--- a/assets/scss/components/stencil/navPages/_navPages.scss
+++ b/assets/scss/components/stencil/navPages/_navPages.scss
@@ -240,7 +240,7 @@
 
 .navPages-action-moreIcon {
     @include square(8px);
-    margin-left: spacing("quarter");
+    margin-left: spacing("half");
     transform: rotate(-90deg);
 
     @include breakpoint("medium") {
@@ -381,14 +381,24 @@
 }
 
 .navPage-subMenu-action {
-    padding: spacing("half") 0;
+    display: flex;
+    padding: 0;
+    align-items: center;
 
     @include breakpoint("medium") {
         padding: spacing("half") 0 (spacing("half") + spacing("quarter"));
     }
 
     .collapsible-icon-wrapper {
-        position: relative;
+        height: 100%;
+        width: 100%;
+        box-sizing: content-box;
+        padding: spacing("half") 0;
+        display: inline-block;
+
+        @include breakpoint("medium") {
+            display: none;
+        }    
     }
 }
 

--- a/assets/scss/components/stencil/navPages/_navPages.scss
+++ b/assets/scss/components/stencil/navPages/_navPages.scss
@@ -250,6 +250,10 @@
     .has-subMenu.is-open & {
         transform: rotate(0);
     }
+
+    .collapsible-icon-wrapper.is-open & {
+        transform: rotate(0);
+    }
 }
 
 
@@ -381,6 +385,10 @@
 
     @include breakpoint("medium") {
         padding: spacing("half") 0 (spacing("half") + spacing("quarter"));
+    }
+
+    .collapsible-icon-wrapper {
+        position: relative;
     }
 }
 

--- a/assets/scss/components/stencil/navPages/_navPages.scss
+++ b/assets/scss/components/stencil/navPages/_navPages.scss
@@ -417,7 +417,7 @@
 .navPage-subMenu-action {
     padding: spacing("half") 0;
 
-    &:not(.navPages-action-depth-max) {
+    .navPages-list:not(.navPages-list-depth-max) & {
         padding: 0 0 0 spacing("single");
 
         @include breakpoint("medium") {

--- a/assets/scss/components/stencil/navPages/_navPages.scss
+++ b/assets/scss/components/stencil/navPages/_navPages.scss
@@ -381,9 +381,17 @@
 }
 
 .navPage-subMenu-action {
-    display: flex;
-    padding: 0;
-    align-items: center;
+    padding: spacing("half") 0;
+
+    &.has-subMenu:not(.navPages-action-depth-max) {
+        display: flex;
+        padding: 0;
+        align-items: center;
+
+        @include breakpoint("medium") {
+            padding: spacing("half") 0 (spacing("half") + spacing("quarter"));
+        }
+    }
 
     @include breakpoint("medium") {
         padding: spacing("half") 0 (spacing("half") + spacing("quarter"));

--- a/assets/scss/components/stencil/navPages/_navPages.scss
+++ b/assets/scss/components/stencil/navPages/_navPages.scss
@@ -247,11 +247,9 @@
         transform: none;
     }
 
-    .has-subMenu.is-open & {
-        transform: rotate(0);
-    }
-
-    .collapsible-icon-wrapper.is-open & {
+    .has-subMenu.is-open &,
+    .collapsible-icon-wrapper.is-open &
+    {
         transform: rotate(0);
     }
 }
@@ -406,7 +404,7 @@
 
         @include breakpoint("medium") {
             display: none;
-        }    
+        }
     }
 }
 

--- a/assets/scss/components/stencil/navPages/_navPages.scss
+++ b/assets/scss/components/stencil/navPages/_navPages.scss
@@ -289,8 +289,8 @@
         display: block;
     }
 
-    .navPage-subMenu-action:not(.navPages-action-depth-max) & {
-        margin-left: spacing("double");
+    .navPage-subMenu-action:not(.navPages-action-depth-max) + & {
+        margin-left: spacing("double"); // 
 
         @include breakpoint("medium") {
             margin-left: 0;
@@ -417,7 +417,7 @@
         padding: 0 0 0 spacing("single");
 
         @include breakpoint("medium") {
-            padding: spacing("half") 0 (spacing("half") + spacing("quarter"));
+            padding: spacing("half") spacing("single") (spacing("half") + spacing("quarter"));
         }
     }
 

--- a/assets/scss/components/stencil/navPages/_navPages.scss
+++ b/assets/scss/components/stencil/navPages/_navPages.scss
@@ -260,6 +260,16 @@
     {
         transform: rotate(0);
     }
+
+    .navPages-list:not(.navPages-list-depth-max) & {
+        @include square(11px);
+        margin: 0 spacing("single");
+
+        @include breakpoint("medium") {
+            @include square(8px);
+            margin: 0 0 0 spacing("half");
+        }    
+    }
 }
 
 
@@ -277,6 +287,14 @@
 
     &.is-open {
         display: block;
+    }
+
+    .navPage-subMenu-action:not(.navPages-action-depth-max) & {
+        margin-left: spacing("double");
+
+        @include breakpoint("medium") {
+            margin-left: 0;
+        }
     }
 }
 
@@ -312,6 +330,12 @@
 
     &.is-open {
         display: block;
+    }
+
+    .navPages-list:not(.navPages-list-depth-max) .navPages-action.has-subMenu + & {
+        .navPage-subMenu-list {
+            margin-right: 0;
+        }
     }
 }
 
@@ -389,8 +413,8 @@
 .navPage-subMenu-action {
     padding: spacing("half") 0;
 
-    &.has-subMenu:not(.navPages-action-depth-max) {
-        padding: 0;
+    &:not(.navPages-action-depth-max) {
+        padding: 0 0 0 spacing("single");
 
         @include breakpoint("medium") {
             padding: spacing("half") 0 (spacing("half") + spacing("quarter"));

--- a/assets/scss/components/stencil/navPages/_navPages.scss
+++ b/assets/scss/components/stencil/navPages/_navPages.scss
@@ -194,6 +194,14 @@
     text-decoration: none;
     text-transform: uppercase;
 
+    &.has-subMenu {
+        .navPages-list:not(.navPages-list-depth-max) & {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;        
+        }
+    }
+
     @include breakpoint("medium") {
         display: inline-block;
         padding: spacing("half") (spacing("half") + spacing("quarter")) (spacing("half") + spacing("quarter"));
@@ -382,9 +390,7 @@
     padding: spacing("half") 0;
 
     &.has-subMenu:not(.navPages-action-depth-max) {
-        display: flex;
         padding: 0;
-        align-items: center;
 
         @include breakpoint("medium") {
             padding: spacing("half") 0 (spacing("half") + spacing("quarter"));
@@ -401,6 +407,7 @@
         box-sizing: content-box;
         padding: spacing("half") 0;
         display: inline-block;
+        text-align: right;
 
         @include breakpoint("medium") {
             display: none;

--- a/assets/scss/components/stencil/navPages/_navPages.scss
+++ b/assets/scss/components/stencil/navPages/_navPages.scss
@@ -198,7 +198,7 @@
         .navPages-list:not(.navPages-list-depth-max) & {
             display: flex;
             justify-content: space-between;
-            align-items: center;        
+            align-items: center;
         }
     }
 

--- a/assets/scss/components/stencil/navPages/_navPages.scss
+++ b/assets/scss/components/stencil/navPages/_navPages.scss
@@ -335,6 +335,10 @@
     .navPages-list:not(.navPages-list-depth-max) .navPages-action.has-subMenu + & {
         .navPage-subMenu-list {
             margin-right: 0;
+
+            @include breakpoint("medium") {
+                margin-right: auto;
+            }    
         }
     }
 }
@@ -417,7 +421,7 @@
         padding: 0 0 0 spacing("single");
 
         @include breakpoint("medium") {
-            padding: spacing("half") spacing("single") (spacing("half") + spacing("quarter"));
+            padding: spacing("half") 0 (spacing("half") + spacing("quarter"));
         }
     }
 

--- a/templates/components/common/navigation-dropdown.html
+++ b/templates/components/common/navigation-dropdown.html
@@ -7,7 +7,7 @@
             <li class="navPage-subMenu-item-child">
                 {{#if children}}
                     <a class="navPage-subMenu-action navPages-action navPages-action-depth-max has-subMenu{{#if is_active}} activePage{{/if}}" href="{{url}}" data-collapsible="navPages-{{id}}">
-                        {{name}} <i class="icon navPages-action-moreIcon" aria-hidden="true"><svg><use xlink:href="#icon-chevron-down" /></svg></i>
+                        {{name}}<i class="icon navPages-action-moreIcon" aria-hidden="true"><svg><use xlink:href="#icon-chevron-down" /></svg></i>
                     </a>
                     {{> components/common/navigation-dropdown}}
                 {{else}}

--- a/templates/components/common/navigation-list-alternate.html
+++ b/templates/components/common/navigation-list-alternate.html
@@ -1,6 +1,6 @@
 {{#if children}}
     <a class="navPages-action navPages-action-depth-max has-subMenu is-root{{#if is_active}} activePage{{/if}}" href="{{url}}" data-collapsible="navPages-{{id}}">
-        {{name}} <i class="icon navPages-action-moreIcon" aria-hidden="true"><svg><use xlink:href="#icon-chevron-down" /></svg></i>
+        {{name}}<i class="icon navPages-action-moreIcon" aria-hidden="true"><svg><use xlink:href="#icon-chevron-down" /></svg></i>
     </a>
     {{> components/common/navigation-dropdown}}
 {{else}}

--- a/templates/components/common/navigation-list.html
+++ b/templates/components/common/navigation-list.html
@@ -11,13 +11,16 @@
             <li class="navPage-subMenu-item">
                 {{#if children}}
                     <a
-                        class="navPage-subMenu-action navPages-action has-subMenu{{#if is_active}} activePage{{/if}}"
+                        class="navPage-subMenu-action NESTED navPages-action has-subMenu{{#if is_active}} activePage{{/if}}"
                         href="{{url}}"
-                        data-collapsible="navPages-{{id}}"
-                        data-collapsible-disabled-breakpoint="medium"
-                        data-collapsible-disabled-state="open"
-                        data-collapsible-enabled-state="closed">
-                        {{name}} <i class="icon navPages-action-moreIcon" aria-hidden="true"><svg><use xlink:href="#icon-chevron-down" /></svg></i>
+>
+                        {{name}} <span class="collapsible-icon-wrapper"
+                                    data-collapsible="navPages-{{id}}"
+                                    data-collapsible-disabled-breakpoint="medium"
+                                    data-collapsible-disabled-state="open"
+                                    data-collapsible-enabled-state="closed">
+                                        <i class="icon navPages-action-moreIcon" aria-hidden="true"><svg><use xlink:href="#icon-chevron-down" /></svg></i>
+                                </span>
                     </a>
                     <ul class="navPage-childList" id="navPages-{{id}}">
                         {{#each children}}

--- a/templates/components/common/navigation-list.html
+++ b/templates/components/common/navigation-list.html
@@ -11,7 +11,7 @@
             <li class="navPage-subMenu-item">
                 {{#if children}}
                     <a
-                        class="navPage-subMenu-action NESTED navPages-action has-subMenu{{#if is_active}} activePage{{/if}}"
+                        class="navPage-subMenu-action navPages-action has-subMenu{{#if is_active}} activePage{{/if}}"
                         href="{{url}}"
 >
                         {{name}}<span class="collapsible-icon-wrapper"

--- a/templates/components/common/navigation-list.html
+++ b/templates/components/common/navigation-list.html
@@ -1,6 +1,6 @@
 {{#if children}}
 <a class="navPages-action has-subMenu{{#if is_active}} activePage{{/if}}" href="{{url}}" data-collapsible="navPages-{{id}}">
-    {{name}} <i class="icon navPages-action-moreIcon" aria-hidden="true"><svg><use xlink:href="#icon-chevron-down" /></svg></i>
+    {{name}}<i class="icon navPages-action-moreIcon" aria-hidden="true"><svg><use xlink:href="#icon-chevron-down" /></svg></i>
 </a>
 <div class="navPage-subMenu" id="navPages-{{id}}" aria-hidden="true" tabindex="-1">
     <ul class="navPage-subMenu-list">
@@ -14,7 +14,7 @@
                         class="navPage-subMenu-action NESTED navPages-action has-subMenu{{#if is_active}} activePage{{/if}}"
                         href="{{url}}"
 >
-                        {{name}} <span class="collapsible-icon-wrapper"
+                        {{name}}<span class="collapsible-icon-wrapper"
                                     data-collapsible="navPages-{{id}}"
                                     data-collapsible-disabled-breakpoint="medium"
                                     data-collapsible-disabled-state="open"


### PR DESCRIPTION
#### What?

@BC-tymurbiedukhin @junedkazi @golcinho 

In Cornerstone we have mobile menu with nested categories if they exist. For now we can not go to the subcategory page if it has its own subcategories (has arrow to dropdown). I have created a wrapper for arrow and replaced data attributes from link on this wrapper. Javascript uses this attributes to open/close nested subcategories. 

So now link is responsible for redirect and arrow responsible for open/close nested subcategories. Also I updated icon wrapper styles to stretch it to the end of the row for comfortable toggling nested categories. 

Styles wrote carefully and not affecting alternate menu styles (by default in config.json navigation_design option value is simple).

#### Tickets / Documentation

In [Ticket](https://jira.bigcommerce.com/browse/BCTHEME-50) you can see 2 videos (before_menu_links_update and after_menu_links_update) to better understand the result
