### PR TITLE
feature(bctheme): BCTHEME-45 Update CornerStone to Utilize Existence of sale_price property for Determining Product/Variant Sale Status

### DIFF
--- a/templates/components/amp/products/card.html
+++ b/templates/components/amp/products/card.html
@@ -1,6 +1,6 @@
 <article class="card {{#if alternate}}card--alternate{{/if}}">
     <figure class="card-figure">
-        {{#or price.non_sale_price_with_tax price.non_sale_price_without_tax}}
+        {{#or price.sale_price_with_tax.value price.sale_price_without_tax.value}}
             {{#if theme_settings.product_sale_badges}}
                 <div class="sale-sash">
                     <span class="sale-text">On Sale!</span>

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -1,7 +1,4 @@
 <article class="card {{#if alternate}}card--alternate{{/if}}" {{#if settings.data_tag_enabled}} data-event-type="{{event}}" data-entity-id="{{id}}" data-position="{{position}}" data-name="{{name}}" data-product-category="{{#each category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}" data-product-brand="{{brand.name}}" data-product-price="{{#if price.with_tax}}{{price.with_tax.value}}{{else}}{{price.without_tax.value}}{{/if}}"  {{/if}}>
-    <div>
-        {{JSONstringify price }}
-    </div>
     <figure class="card-figure">
         {{#or price.sale_price_with_tax.value price.sale_price_without_tax.value}}
         {{#if theme_settings.product_sale_badges '===' 'sash'}}

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -1,7 +1,7 @@
 <article class="card {{#if alternate}}card--alternate{{/if}}" {{#if settings.data_tag_enabled}} data-event-type="{{event}}" data-entity-id="{{id}}" data-position="{{position}}" data-name="{{name}}" data-product-category="{{#each category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}" data-product-brand="{{brand.name}}" data-product-price="{{#if price.with_tax}}{{price.with_tax.value}}{{else}}{{price.without_tax.value}}{{/if}}"  {{/if}}>
     <figure class="card-figure">
         {{#or price.sale_price_with_tax.value price.sale_price_without_tax.value}}
-        {{#if theme_settings.product_sale_badges '===' 'sash'}}
+            {{#if theme_settings.product_sale_badges '===' 'sash'}}
                 <div class="sale-flag-sash">
                     <span class="sale-text">On Sale!</span>
                 </div>

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -1,7 +1,10 @@
 <article class="card {{#if alternate}}card--alternate{{/if}}" {{#if settings.data_tag_enabled}} data-event-type="{{event}}" data-entity-id="{{id}}" data-position="{{position}}" data-name="{{name}}" data-product-category="{{#each category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}" data-product-brand="{{brand.name}}" data-product-price="{{#if price.with_tax}}{{price.with_tax.value}}{{else}}{{price.without_tax.value}}{{/if}}"  {{/if}}>
+    <div>
+        {{JSONstringify price }}
+    </div>
     <figure class="card-figure">
-        {{#or price.non_sale_price_with_tax price.non_sale_price_without_tax}}
-            {{#if theme_settings.product_sale_badges '===' 'sash'}}
+        {{#or price.sale_price_with_tax.value price.sale_price_without_tax.value}}
+        {{#if theme_settings.product_sale_badges '===' 'sash'}}
                 <div class="sale-flag-sash">
                     <span class="sale-text">On Sale!</span>
                 </div>

--- a/templates/components/products/list-item.html
+++ b/templates/components/products/list-item.html
@@ -5,20 +5,20 @@
 {{/if}}
     <figure class="listItem-figure">
         {{#or price.sale_price_with_tax.value price.sale_price_without_tax.value}}
-        {{#if theme_settings.product_sale_badges '===' 'sash'}}
-            <div class="sale-flag-sash">
-                <span class="sale-text">On Sale!</span>
-            </div>
-        {{else if theme_settings.product_sale_badges '===' 'topleft'}}
-            <div class="sale-flag-side">
-                <span class="sale-text">On Sale!</span>
-            </div>
-        {{else if theme_settings.product_sale_badges '===' 'burst'}}
-            <div class="starwrap">
-                <div class="sale-text-burst">On Sale!</div>
-                <div class="sale-flag-star"></div>
-            </div>
-        {{/if}}
+            {{#if theme_settings.product_sale_badges '===' 'sash'}}
+                <div class="sale-flag-sash">
+                    <span class="sale-text">On Sale!</span>
+                </div>
+            {{else if theme_settings.product_sale_badges '===' 'topleft'}}
+                <div class="sale-flag-side">
+                    <span class="sale-text">On Sale!</span>
+                </div>
+            {{else if theme_settings.product_sale_badges '===' 'burst'}}
+                <div class="starwrap">
+                    <div class="sale-text-burst">On Sale!</div>
+                    <div class="sale-flag-star"></div>
+                </div>
+            {{/if}}
         {{/or}}    
         {{> components/common/responsive-img
             image=image

--- a/templates/components/products/list-item.html
+++ b/templates/components/products/list-item.html
@@ -4,7 +4,7 @@
     <article class="listItem">
 {{/if}}
     <figure class="listItem-figure">
-        {{#or price.non_sale_price_with_tax price.non_sale_price_without_tax}}
+        {{#or price.sale_price_with_tax.value price.sale_price_without_tax.value}}
         {{#if theme_settings.product_sale_badges '===' 'sash'}}
             <div class="sale-flag-sash">
                 <span class="sale-text">On Sale!</span>


### PR DESCRIPTION
#### What?

@BC-tymurbiedukhin @golcinho @bc-alexsaiannyi @junedkazi 

Update CornerStone to Utilize Existence of sale_price property for Determining Product/Variant Sale Status.
I have changed the way how we check product status - on sale or not. And when sale properties (sale_price_with_tax & sale_price_without_tax) are not exist or their value equal to 0 - product status is NOT on sale. In other case we should add a sale badge


#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-45)
