### PR TITLE
fix(bctheme): BCTHEME-33 Cornerstone - byte type missing on file uplo…

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -737,6 +737,7 @@
         "quick_view": "Quick view",
         "compare": "Compare",
         "max_filesize": "Maximum file size is",
+        "kilobytes_abbreviation": "KB",
         "filetypes": "file types are",
         "choose_an_option": "Please choose an option",
         "select_one": "Please select one",

--- a/templates/components/products/options/input-file.html
+++ b/templates/components/products/options/input-file.html
@@ -12,6 +12,14 @@
         {{{lang 'products.file_option_set' url=file_url name=original_name}}}
         <label>{{lang 'cart.remove_file'}}<input type="checkbox" name="{{file_remove}}"></label>
     {{/if}}
-    <p class="form-fileDescription">{{#if file_size}}{{lang 'products.max_filesize'}} <strong>{{file_size}}</strong>, {{/if}}{{#if file_types}}{{lang 'products.filetypes'}} <strong>{{file_types}}</strong>{{/if}}</p>
+    <p class="form-fileDescription">
+        {{#if file_size}}
+            {{lang 'products.max_filesize'}}
+            <strong>{{file_size}}{{lang 'products.kilobytes_abbreviation'}}</strong>,
+        {{/if}}
+        {{#if file_types}}
+            {{lang 'products.filetypes'}} <strong>{{file_types}}</strong>
+        {{/if}}
+    </p>
 
 </div>


### PR DESCRIPTION
…ad options when max file size feature is enabled

#### What?

When creating a file upload option for their products, Merchants have the ability to configure a max file upload size that is displayed on their storefront beneath the file upload field. This max file upload size is missing it's corresponding byte type abbreviation (kilobytes [KB]).

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/BCTHEME-33

#### Screenshots (if appropriate)

<img width="559" alt="Screenshot 2020-07-10 at 16 15 30" src="https://user-images.githubusercontent.com/66319629/87158559-98248780-c2c8-11ea-93eb-b9206b57c827.png">

ping @yurytut1993 @golcinho @bc-alexsaiannyi 
