### PR TITLE
fix(bctheme): BCTHEME-8 Cornerstone v 4.1.1 - Product Image dimension…

### DIFF
--- a/assets/scss/components/foundation/lazyLoad/_lazyLoad.scss
+++ b/assets/scss/components/foundation/lazyLoad/_lazyLoad.scss
@@ -16,3 +16,15 @@
         padding-bottom: get-padding(stencilString($size-param));
     }
 }
+
+@mixin cart-item-lazy-load-img-placeholder() {
+    &:after {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+    }
+}

--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -13,6 +13,8 @@ $cart-item-spacing:                     spacing("single");
 
 $cart-thumbnail-maxWidth:               remCalc(100px);
 $cart-thumbnail-height:                 remCalc(100px);
+$cart-thumbnail-maxHeight:              14rem;
+$cart-thumbnail-paddingVertical:        0.5rem;
 
 $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-spacing;
 
@@ -99,7 +101,7 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
 
 .cart-item-figure {
     float: left;
-    height: $cart-thumbnail-height;
+    text-align: center;
     margin-bottom: $cart-item-spacing;
     width: grid-calc(4, $total-columns);
     position: relative;
@@ -114,9 +116,10 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
     @include breakpoint("medium") {
         float: none;
         width: grid-calc(1, $total-columns);
+        padding: $cart-thumbnail-paddingVertical 0;
     }
 
-    @include lazy-loaded-padding('productthumb_size');
+    @include cart-item-lazy-load-img-placeholder;
 }
 
 .cart-item-fixed-image {
@@ -124,9 +127,8 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
 }
 
 .cart-item-image {
+    max-height: $cart-thumbnail-maxHeight;
     max-width: get-width(stencilString('productthumb_size'));
-
-    @include lazy-loaded-img;
 
     @include breakpoint("medium") {
         margin-left:0;
@@ -173,10 +175,6 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
         &:last-child {
             text-align: right;
         }
-    }
-
-    + .cart-item-info {
-        margin-top: spacing("half");
     }
 }
 
@@ -580,6 +578,7 @@ $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-sp
     position: relative;
 
     img {
+        max-height: 90%;
         @include lazy-loaded-img;
     }
 


### PR DESCRIPTION
…s not constrained proportionally on Cart page which can lead to element overlapping

#### What?

On the latest version of Cornerstone, larger product images are failing to be constrained proportionally to their parent div on the Cart page. This can lead to element overlapping with other line-items in the cart.

Expanding this ticket to mention that these symptoms are also present in the Cart Quick-View modal.

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/BCTHEME-8

#### Screenshots (if appropriate)

<img width="320" alt="Screenshot 2020-07-13 at 12 27 07" src="https://user-images.githubusercontent.com/66319629/87288570-33ee0780-c504-11ea-8d92-7a69234fe150.png">
<img width="602" alt="Screenshot 2020-07-13 at 12 22 40" src="https://user-images.githubusercontent.com/66319629/87288374-ee313f00-c503-11ea-9911-305eb1f2a5d7.png">
<img width="819" alt="Screenshot 2020-07-13 at 12 22 51" src="https://user-images.githubusercontent.com/66319629/87288376-ef626c00-c503-11ea-85a8-f50510221890.png">
<img width="1294" alt="Screenshot 2020-07-13 at 12 23 08" src="https://user-images.githubusercontent.com/66319629/87288378-ef626c00-c503-11ea-870e-a3098e920124.png">

ping @yurytut1993 @bc-alexsaiannyi @junedkazi @golcinho 