### PR TITLE
feature(bctheme): BCTHEME-56 Long Product Descriptions Cause Large White Space Under Product Image

### DIFF
--- a/assets/scss/layouts/products/_productView.scss
+++ b/assets/scss/layouts/products/_productView.scss
@@ -52,12 +52,6 @@
     position: relative;
     z-index: 1;
 
-    @include breakpoint("large") {
-        clear: right;
-        float: right;
-        width: grid-calc(6, $total-columns);
-    }
-
     .productView-title {
         border-bottom: container("border");
         margin-bottom: spacing("base");


### PR DESCRIPTION
#### What?

To avoid space on the left side of the screen when we have a huge description on a product, as suggested in the task, I made description block on the whole screen. So I just removed styles that make this block on the half of the screen width on large displays

#### Tickets / Documentation
[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-56)

#### Screenshots (if appropriate)

before
![before-bc-56](https://user-images.githubusercontent.com/66325265/87305675-8be63780-c51f-11ea-9d04-774d6c5523ed.png)

after
![after-bc-56](https://user-images.githubusercontent.com/66325265/87305695-930d4580-c51f-11ea-906b-e84b41a6e230.png)
