### PR TITLE
fix(bctheme): BCTHEME-117 Facebook button going out of its container during scrolling in modal

### DIFF
--- a/assets/scss/layouts/products/_productView.scss
+++ b/assets/scss/layouts/products/_productView.scss
@@ -43,6 +43,10 @@
         float: right;
         width: grid-calc(6, $total-columns);
     }
+
+    .productView--quickView & {
+        position: relative;
+    }
 }
 
 .productView-description {


### PR DESCRIPTION

#### What?

@BC-tymurbiedukhin @golcinho @junedkazi 

Facebook button (that is in iframe) is not assigned to its container - in case when we have big description of a product, in Quick View mode, when scrolling modal window all content is moving as expected, but button stays on its place. So I updated styles of the button's block in modal window of Quick View

#### Tickets / Documentation

You can see videos with bug and fix in the [Ticket](https://jira.bigcommerce.com/browse/BCTHEME-117)
