### PR TITLE
Optimize themeSettings injection

### DIFF
--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -271,7 +271,7 @@ export default class ProductDetails {
         if (_.isPlainObject(image)) {
             const zoomImageUrl = utils.tools.imageSrcset.getSrcset(
                 image.data,
-                { '1x': this.context.themeSettings.zoom_size },
+                { '1x': this.context.zoomSize },
                 /*
                     Should match zoom size used for data-zoom-image in
                     components/products/product-view.html
@@ -284,7 +284,7 @@ export default class ProductDetails {
 
             const mainImageUrl = utils.tools.imageSrcset.getSrcset(
                 image.data,
-                { '1x': this.context.themeSettings.product_size },
+                { '1x': this.context.productSize },
                 /*
                     Should match fallback image size used for the main product image in
                     components/products/product-view.html

--- a/assets/js/theme/global.js
+++ b/assets/js/theme/global.js
@@ -18,7 +18,7 @@ import objectFitImages from './global/object-fit-polyfill';
 export default class Global extends PageManager {
     onReady() {
         const {
-            channelId, cartId, productId, categoryId, secureBaseUrl, maintenanceModeSettings, adminBarLanguage, themeSettings,
+            channelId, cartId, productId, categoryId, secureBaseUrl, maintenanceModeSettings, adminBarLanguage, showAdminBar,
         } = this.context;
         cartPreview(secureBaseUrl, cartId);
         quickSearch();
@@ -29,7 +29,7 @@ export default class Global extends PageManager {
         menu();
         mobileMenuToggle();
         privacyCookieNotification();
-        if (themeSettings['show-admin-bar']) {
+        if (showAdminBar) {
             adminBar(secureBaseUrl, channelId, maintenanceModeSettings, JSON.parse(adminBarLanguage), productId, categoryId);
         }
         loadingProgressBar();

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -30,7 +30,7 @@
 
         {{{head.scripts}}}
 
-        {{~inject 'themeSettings' theme_settings}}
+        {{~inject 'showAdminBar' theme_settings.show-admin-bar}}
         {{~inject 'genericError' (lang 'common.generic_error')}}
         {{~inject 'maintenanceModeSettings' settings.maintenance}}
         {{~inject 'adminBarLanguage' (langJson 'admin')}}

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -10,6 +10,9 @@ product:
         limit: {{theme_settings.productpage_similar_by_views_count}}
 ---
 {{inject "productId" product.id}}
+{{inject "zoomSize" theme_settings.zoom_size}}
+{{inject "productSize" theme_settings.product_size}}
+
 {{#partial "page"}}
 
     {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}


### PR DESCRIPTION
#### What?

We currently inject the entire `theme_settings` context object which is wasteful, especially since we only use 3 keys from it. I've optimized this import to be [only what's used.](https://github.com/bigcommerce/cornerstone/search?q=themeSettings&unscoped_q=themeSettings)

#### Screenshots (if appropriate)

Before:
![image](https://user-images.githubusercontent.com/8922457/87999102-7e9cf000-cabf-11ea-89be-6e1200da89a6.png)

After:
![image](https://user-images.githubusercontent.com/8922457/87999078-6b8a2000-cabf-11ea-87aa-78658a8e298d.png)

