### PR TITLE
fix(storefront): BCTHEME-65 Make email subscribe messages readable by…

### DIFF
--- a/templates/components/common/alert-error.html
+++ b/templates/components/common/alert-error.html
@@ -3,6 +3,6 @@
         <icon glyph="ic-error" class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"></path></svg></icon>
     </div>
     <p class="alertBox-column alertBox-message">
-        <span>{{{this}}}</span>
+        <span id="alertBox-message-text">{{{this}}}</span>
     </p>
 </div>

--- a/templates/components/common/alert-success.html
+++ b/templates/components/common/alert-success.html
@@ -3,6 +3,6 @@
         <icon glyph="ic-success" class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"></path></svg></icon>
     </div>
     <p class="alertBox-column alertBox-message">
-        <span>{{{this}}}</span>
+        <span id="alertBox-message-text">{{{this}}}</span>
     </p>
 </div>

--- a/templates/components/common/subscription-form.html
+++ b/templates/components/common/subscription-form.html
@@ -9,8 +9,18 @@
         <div class="form-field">
             <label class="form-label is-srOnly" for="nl_email">{{lang 'common.email_address'}}</label>
             <div class="form-prefixPostfix wrap">
-                <input class="form-input" id="nl_email" name="nl_email" type="email" value="{{customer.email}}" placeholder="{{lang 'newsletter.email_placeholder'}}">
-                <input class="button button--primary form-prefixPostfix-button--postfix" type="submit" value="{{lang 'newsletter.subscribe_submit'}}">
+                <input class="form-input"
+                       id="nl_email"
+                       name="nl_email"
+                       type="email"
+                       value="{{customer.email}}"
+                       placeholder="{{lang 'newsletter.email_placeholder'}}"
+                       aria-describedby="alertBox-message-text"
+                >
+                <input class="button button--primary form-prefixPostfix-button--postfix"
+                       type="submit"
+                       value="{{lang 'newsletter.subscribe_submit'}}"
+                >
             </div>
             {{#if settings.show_newsletter_summary }}
                 <div class="footer-newsletter-summary">{{settings.newsletter_summary}}</div>


### PR DESCRIPTION
… screen reader in context

#### What?

Error and validation message should appear both on the screen and be read in context on the email subscribe input box when using a screen reader.

Currently a screen reader will read the error message as it appears in the body but it will not repeat the message contextually within the email input box.

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-65)

#### Screenshots (if appropriate)

<img width="1680" alt="Screenshot 2020-07-21 at 11 56 16" src="https://user-images.githubusercontent.com/66319629/88034590-8f924380-cb49-11ea-9612-3de707c5d753.png">

<img width="1680" alt="Screenshot 2020-07-21 at 11 55 35" src="https://user-images.githubusercontent.com/66319629/88034587-8e611680-cb49-11ea-9e37-7c7173f00435.png">

@bc-as could you verify the expected result on screenshots?