### PR TITLE
fix(storefront): BCTHEME-63 As a Shopper I want to open the wishlist …

### DIFF
--- a/templates/components/common/wishlist-dropdown.html
+++ b/templates/components/common/wishlist-dropdown.html
@@ -1,5 +1,10 @@
 <form action="{{product.add_to_wishlist_url}}" class="form form-wishlist form-action" data-wishlist-add method="post">
-    <a aria-controls="wishlist-dropdown" aria-expanded="false" class="button dropdown-menu-button" data-dropdown="wishlist-dropdown">
+    <a aria-controls="wishlist-dropdown"
+       aria-expanded="false"
+       class="button dropdown-menu-button"
+       data-dropdown="wishlist-dropdown"
+       href="#"
+    >
         <span>{{lang 'account.wishlists.add_item'}}</span>
         <i aria-hidden="true" class="icon">
             <svg>
@@ -7,13 +12,18 @@
             </svg>
         </i>
     </a>
-    <ul aria-hidden="true" class="dropdown-menu" data-dropdown-content id="wishlist-dropdown" tabindex="-1">
-        {{#if customer.wishlists}} {{#each customer.wishlists}}
-        <li>
-            <input class="button {{#if this.num_items '!==' '0'}}button--has-items{{/if}}" formaction="{{this.add_url}}&product_id={{../product.id}}"
-                type="submit" value="{{this.name}}">
-        </li>
-        {{/each}} {{else}}
+    <ul aria-hidden="true" class="dropdown-menu" data-dropdown-content id="wishlist-dropdown">
+        {{#if customer.wishlists}}
+            {{#each customer.wishlists}}
+                <li>
+                    <input class="button {{#if this.num_items '!==' '0'}}button--has-items{{/if}}"
+                           formaction="{{this.add_url}}&product_id={{../product.id}}"
+                           type="submit"
+                           value="{{this.name}}"
+                    >
+                </li>
+            {{/each}}
+        {{else}}
         <li>
             <input class="button" type="submit" value="{{lang 'account.wishlists.add_to_default'}}">
         </li>


### PR DESCRIPTION
…menu using the keyboard

#### What?

As a shopper
I want to open the wishlist menu using the keyboard
So that I can add products to my wishlist without having to use a mouse or cursor

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-63)

#### Screenshots (if appropriate)

<img width="1037" alt="Screenshot 2020-07-21 at 15 28 11" src="https://user-images.githubusercontent.com/66319629/88055129-215c7980-cb67-11ea-997b-3b2ab0dbc003.png">

@bc-as could you please confirm expected result?