### PR TITLE
fix(storefront): BCTHEME-81 Add aria label for breadcrumbs

### DIFF
--- a/assets/scss/components/foundation/breadcrumbs/_breadcrumbs.scss
+++ b/assets/scss/components/foundation/breadcrumbs/_breadcrumbs.scss
@@ -26,16 +26,24 @@
 .breadcrumb {
     display: inline-block;
     float: none;
+    margin-right: 0.25rem;
 
     &.is-active {
 
         // scss-lint:disable NestingDepth
         > .breadcrumb-label {
-            cursor: text;
+            cursor: pointer;
+            font-weight: 700;
         }
     }
-}
 
-.breadcrumb-label {
-    text-decoration: none;
+    // needs to override common bigcommerce styles for accessibility improvements
+    &:not(:first-child):before {
+        display: inline-block;
+        margin: 0 0.25rem;
+        transform: rotate(15deg);
+        border-right: 0.1em solid $primary-color;
+        height: 0.8em;
+        content: '';
+    }
 }

--- a/templates/components/common/breadcrumbs.html
+++ b/templates/components/common/breadcrumbs.html
@@ -6,9 +6,7 @@
                     <a class="breadcrumb-label"
                        itemprop="item"
                        href="{{url}}"
-                       {{#or @last (if url "==" null)}}
-                           aria-current="page"
-                       {{/or}}
+                       {{#if @last}}aria-current="page"{{/if}}
                     >
                         <span itemprop="name">{{name}}</span>
                     </a>

--- a/templates/components/common/breadcrumbs.html
+++ b/templates/components/common/breadcrumbs.html
@@ -1,15 +1,20 @@
-<ul class="breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">
-    {{#unless theme_settings.hide_breadcrumbs }}
-        {{#each breadcrumbs}}
-            <li class="breadcrumb {{#if @last}}is-active{{/if}}" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-                {{#or @last (if url "==" null)}}
-                    <meta itemprop="item" content="{{url}}">
-                    <span class="breadcrumb-label" itemprop="name">{{name}}</span>
-                {{else}}
-                    <a href="{{url}}" class="breadcrumb-label" itemprop="item"><span itemprop="name">{{name}}</span></a>
-                {{/or}}
-                <meta itemprop="position" content="{{add @index 1}}" />
-            </li>
-        {{/each}}
-    {{/unless}}
-</ul>
+<nav aria-label="Breadcrumb">
+    <ol class="breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">
+        {{#unless theme_settings.hide_breadcrumbs }}
+            {{#each breadcrumbs}}
+                <li class="breadcrumb {{#if @last}}is-active{{/if}}" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+                    <a class="breadcrumb-label"
+                       itemprop="item"
+                       href="{{url}}"
+                       {{#or @last (if url "==" null)}}
+                           aria-current="page"
+                       {{/or}}
+                    >
+                        <span itemprop="name">{{name}}</span>
+                    </a>
+                    <meta itemprop="position" content="{{add @index 1}}" />
+                </li>
+            {{/each}}
+        {{/unless}}
+    </ol>
+</nav>


### PR DESCRIPTION
#### What?

Currently breadcrumbs do not have any labels to identify them as breadcrumbs.
In order to allow screen readers to navigate effectively, regions within pages should be sufficiently labeled.

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-81)
[Accessibility doc](https://www.w3.org/TR/wai-aria-practices/examples/breadcrumb/index.html)

#### Screenshots (if appropriate)

<img width="1680" alt="Screenshot 2020-07-22 at 14 52 14" src="https://user-images.githubusercontent.com/66319629/88173258-f20f4080-cc2a-11ea-8998-faa04c3539c9.png">

