### PR TITLE
fix(storefront): BCTHEME-126 'Write a Review' should have role 'button'

### DIFF
--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -200,14 +200,8 @@
     margin-left: spacing("half");
     vertical-align: middle;
 
-    + .productView-reviewLink {
-        display: block;
-        margin-left: auto;
-
-        @include breakpoint("small") {
-            display: inline-block;
-            margin-left: spacing("half");
-        }
+    &--new {
+        padding: 0;
     }
 
     > a {

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -50,12 +50,14 @@
                     </span>
                 {{/if}}
                 {{#if settings.show_product_reviews}}
-                    <span class="productView-reviewLink">
+                    <button class="productView-reviewLink">
                         <a href="{{product.url}}{{#if is_ajax}}#write_review{{/if}}"
-                           {{#unless is_ajax }}data-reveal-id="modal-review-form"{{/unless}}>
+                           {{#unless is_ajax}}data-reveal-id="modal-review-form"{{/unless}}
+                           role="button"
+                        >
                            {{lang 'products.reviews.new'}}
                         </a>
-                    </span>
+                    </button>
                     {{> components/products/modals/writeReview}}
                 {{/if}}
             </div>

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -50,7 +50,7 @@
                     </span>
                 {{/if}}
                 {{#if settings.show_product_reviews}}
-                    <button class="productView-reviewLink">
+                    <button class="productView-reviewLink productView-reviewLink--new">
                         <a href="{{product.url}}{{#if is_ajax}}#write_review{{/if}}"
                            {{#unless is_ajax}}data-reveal-id="modal-review-form"{{/unless}}
                            role="button"


### PR DESCRIPTION
#### What?

On PDPs the "Write a Review" link should be labeled as a "button" rather than a "link".

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-126)

#### Screenshots (if appropriate)

<img width="375" alt="Screenshot 2020-07-23 at 14 19 25" src="https://user-images.githubusercontent.com/66319629/88281050-aa062180-ccef-11ea-9c0f-030bb5881b73.png">
