### PR TITLE
fix(storefront): BCTHEME-129 Quick search aria hidden element should …

### DIFF
--- a/assets/scss/components/stencil/navUser/_navUser.scss
+++ b/assets/scss/components/stencil/navUser/_navUser.scss
@@ -277,12 +277,14 @@
 .dropdown--quickSearch {
     background-color: $dropdown--quickSearch-backgroundColor;
     padding: spacing("single") 0;
+    display: none;
 
     @include breakpoint("small") {
         padding: spacing("double");
     }
 
     &.is-open {
+        display: initial;
         // scss-lint:disable ImportantRule
         left: 0 !important; // 1
         outline: none;


### PR DESCRIPTION
…not be focusable

#### What?

The quick search hidden search box currently has the attribute aria-hidden to indicate that it is visually hidden, however, this causes it to be ignored by screen readers.
The search box should use the attribute display:none to properly hide this element.

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-129)

#### Screenshots (if appropriate)

Video is attached in ticket
