### PR TITLE
fix(storefront): BCTHEME-148 On PDP description tab needs to be hidde…

### DIFF
--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -251,13 +251,15 @@
         {{> components/common/share}}
     </section>
 
-    <article class="productView-description"{{#if schema}} itemprop="description"{{/if}}>
-        {{#if theme_settings.show_product_details_tabs}}
-            {{> components/products/description-tabs}}
-        {{else}}
-            {{> components/products/description}}
-        {{/if}}
-    </article>
+    {{#if product.description}}
+        <article class="productView-description"{{#if schema}} itemprop="description"{{/if}}>
+            {{#if theme_settings.show_product_details_tabs}}
+                {{> components/products/description-tabs}}
+            {{else}}
+                {{> components/products/description}}
+            {{/if}}
+        </article>
+    {{/if}}
 </div>
 
 <div id="previewModal" class="modal modal--large" data-reveal>


### PR DESCRIPTION
…n if there is no product description

#### What?

Product description article is hidden until product description will be set

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-148)

#### Screenshots (if appropriate)

<img width="1072" alt="Screenshot 2020-07-28 at 10 53 38" src="https://user-images.githubusercontent.com/66319629/88635967-03d86400-d0c1-11ea-9fc4-61b7441e8499.png">
