### PR TITLE
fix(storefront:)STRF-8521 add correct alt text on image change in product view

### DIFF
--- a/assets/js/theme/product/image-gallery.js
+++ b/assets/js/theme/product/image-gallery.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 export default class ImageGallery {
     constructor($gallery) {
         this.$mainImage = $gallery.find('[data-image-gallery-main]');
+        this.$mainImageNested = $gallery.find('[data-main-image]');
         this.$selectableImages = $gallery.find('[data-image-gallery-item]');
         this.currentImage = {};
     }
@@ -47,8 +48,8 @@ export default class ImageGallery {
             zoomImageUrl: $target.attr('data-image-gallery-zoom-image-url'),
             mainImageSrcset: $target.attr('data-image-gallery-new-image-srcset'),
             $selectedThumb: $target,
+            mainImageAlt: $target.children().first().attr('alt'),
         };
-
         this.setMainImage(imgObj);
     }
 
@@ -68,6 +69,10 @@ export default class ImageGallery {
 
         this.$mainImage.attr({
             'data-zoom-image': this.currentImage.zoomImageUrl,
+        });
+        this.$mainImageNested.attr({
+            alt: this.currentImage.mainImageAlt,
+            title: this.currentImage.mainImageAlt,
         });
     }
 


### PR DESCRIPTION
#### What?
@BC-tymurbiedukhin @yurytut1993 

This PR fixes issue with viewing a product with multiple images. When User clicks on other available images the alt text doesn't change and continues to display a text for the default image.

#### Tickets / Documentation
- [STRF-8521](https://jira.bigcommerce.com/browse/STRF-8521)


#### Screenshots (if appropriate)
[Alt Text Images Fixed](https://github.com/bigcommerce/cornerstone/files/4987117/alt.text.images_fixed.zip)
