### PR TITLE
feature(storefront): BCTHEME-68 Add tooltips for carousel "Previous" and "Next" buttons

### DIFF
--- a/assets/js/test-unit/theme/carousel.spec.js
+++ b/assets/js/test-unit/theme/carousel.spec.js
@@ -30,8 +30,10 @@ describe('carousel', () => {
 	    var slickSpy = spyOn(multipleSlidesElement, 'slick');
 	    carousel();
 	    expect(slickSpy).toHaveBeenCalledWith({
-			dots: true,
-			customPaging: expect.any(Function)
+            accessibility: false,
+            arrows: true,
+            customPaging: expect.any(Function),
+            dots: true,
 		});
     });
 
@@ -54,7 +56,11 @@ describe('carousel', () => {
 	    spyOn(jQuery.fn, 'find').and.returnValue(multipleSlidesElement);
 	    var slickSpy = spyOn(multipleSlidesElement, 'slick');
 	    carousel();
-	    expect(slickSpy).toHaveBeenCalledWith({ dots: false });   
+	    expect(slickSpy).toHaveBeenCalledWith({
+            accessibility: false,
+            arrows: false,
+            customPaging: expect.any(Function),
+            dots: false,			
+		});   
     });
 });
-

--- a/lang/en.json
+++ b/lang/en.json
@@ -880,5 +880,8 @@
         "maintenance_showstore_link": "Click here to see what your visitors will see.",
         "prelaunch_header": "Your storefront is private. Share your site with preview code:",
         "page_builder_link": "Design this page in Page Builder"
+    },
+    "carousel": {
+        "arrowAriaLabel": "Go to slide [NUMBER] of"
     }
 }

--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -1,16 +1,22 @@
 <section class="heroCarousel"
     data-slick='{
-        "arrows": {{arrows}},
         "mobileFirst": true,
         "slidesToShow": 1,
         "slidesToScroll": 1,
         "autoplay": true,
         "autoplaySpeed": {{carousel.swap_frequency}},
         "lazyLoad": "anticipated",
-        "accessibility": false
+        "slide": ".hero-slide",
+        "prevArrow": ".js-hero-prev-arrow",
+        "nextArrow": ".js-hero-next-arrow"
     }'>
+    {{#if arrows}}
+    {{#if carousel.slides.length '>' 1}}
+    <button aria-label="{{lang 'carousel.arrowAriaLabel'}} {{carousel.slides.length}}" class="js-hero-prev-arrow slick-prev slick-arrow">hero-prev-arrow</button>
+    {{/if}}
+    {{/if}}
     {{#each carousel.slides}}
-    <a href="{{url}}">
+    <a class="hero-slide" href="{{url}}">
         <div class="heroCarousel-slide {{#if ../theme_settings.homepage_stretch_carousel_images}}stretch{{/if}} {{#if @first}}heroCarousel-slide--first{{/if}}">
             <div class="heroCarousel-image-wrapper">
             {{#if @first}}
@@ -43,4 +49,9 @@
         </div>
     </a>
     {{/each}}
+    {{#if arrows}}
+    {{#if carousel.slides.length '>' 1}}
+    <button aria-label="{{lang 'carousel.arrowAriaLabel'}} {{carousel.slides.length}}" class="js-hero-next-arrow slick-next slick-arrow">hero-next-arrow</button>
+    {{/if}}
+    {{/if}}
 </section>

--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -6,17 +6,15 @@
         "autoplay": true,
         "autoplaySpeed": {{carousel.swap_frequency}},
         "lazyLoad": "anticipated",
-        "slide": ".hero-slide",
+        "slide": ".js-hero-slide",
         "prevArrow": ".js-hero-prev-arrow",
         "nextArrow": ".js-hero-next-arrow"
     }'>
-    {{#if arrows}}
-    {{#if carousel.slides.length '>' 1}}
+    {{#and arrows (if carousel.slides.length '>' 1)}}
     <button aria-label="{{lang 'carousel.arrowAriaLabel'}} {{carousel.slides.length}}" class="js-hero-prev-arrow slick-prev slick-arrow">hero-prev-arrow</button>
-    {{/if}}
-    {{/if}}
+    {{/and}}
     {{#each carousel.slides}}
-    <a class="hero-slide" href="{{url}}">
+    <a class="js-hero-slide" href="{{url}}">
         <div class="heroCarousel-slide {{#if ../theme_settings.homepage_stretch_carousel_images}}stretch{{/if}} {{#if @first}}heroCarousel-slide--first{{/if}}">
             <div class="heroCarousel-image-wrapper">
             {{#if @first}}
@@ -49,9 +47,7 @@
         </div>
     </a>
     {{/each}}
-    {{#if arrows}}
-    {{#if carousel.slides.length '>' 1}}
+    {{#and arrows (if carousel.slides.length '>' 1)}}
     <button aria-label="{{lang 'carousel.arrowAriaLabel'}} {{carousel.slides.length}}" class="js-hero-next-arrow slick-next slick-arrow">hero-next-arrow</button>
-    {{/if}}
-    {{/if}}
+    {{/and}}
 </section>

--- a/templates/components/products/carousel.html
+++ b/templates/components/products/carousel.html
@@ -2,31 +2,38 @@
     data-list-name="{{list}}"
     data-slick='{
         "dots": true,
-        "infinite": false,
         "mobileFirst": true,
         "slidesToShow": 2,
-        "slidesToScroll": 2,
+        "slidesToScroll": 1,
+        "slide": ".product-slide",
+        "prevArrow": ".js-product-prev-arrow",
+        "nextArrow": ".js-product-next-arrow",
         "responsive": [
             {
                 "breakpoint": 800,
                 "settings": {
                     "slidesToShow": {{ columns }},
-                    "slidesToScroll": 3
+                    "slidesToScroll": 1
                 }
             },
             {
                 "breakpoint": 550,
                 "settings": {
                     "slidesToShow": 3,
-                    "slidesToScroll": 3
+                    "slidesToScroll": 1
                 }
             }
         ]
-    }'
->
+    }'>
+    {{#if products.length '>' 1}}
+    <button aria-label="{{lang 'carousel.arrowAriaLabel'}} {{products.length}}" class="js-product-prev-arrow slick-prev slick-arrow"></button>
+    {{/if}}
     {{#each products}}
-    <div class="productCarousel-slide">
+    <div class="productCarousel-slide product-slide">
         {{> components/products/card settings=../settings theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
     </div>
     {{/each}}
+    {{#if products.length '>' 1}}
+    <button aria-label="{{lang 'carousel.arrowAriaLabel'}} {{products.length}}" class="js-product-next-arrow slick-next slick-arrow"></button>
+    {{/if}}
 </section>

--- a/templates/components/products/carousel.html
+++ b/templates/components/products/carousel.html
@@ -5,7 +5,7 @@
         "mobileFirst": true,
         "slidesToShow": 2,
         "slidesToScroll": 1,
-        "slide": ".product-slide",
+        "slide": ".js-product-slide",
         "prevArrow": ".js-product-prev-arrow",
         "nextArrow": ".js-product-next-arrow",
         "responsive": [
@@ -29,7 +29,7 @@
     <button aria-label="{{lang 'carousel.arrowAriaLabel'}} {{products.length}}" class="js-product-prev-arrow slick-prev slick-arrow"></button>
     {{/if}}
     {{#each products}}
-    <div class="productCarousel-slide product-slide">
+    <div class="productCarousel-slide js-product-slide">
         {{> components/products/card settings=../settings theme_settings=../theme_settings customer=../customer event="list" position=(add @index 1)}}
     </div>
     {{/each}}


### PR DESCRIPTION
#### What?

@BC-tymurbiedukhin  @bc-alexsaiannyi 

Carousel now has arrows with dynamic aria-labels. It tells the user on what exactly slide he will go when click on arrow, and how many slides in carousel. Also refactored code

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-68)

#### Screenshots (if appropriate)

left arrow init
![left_arrow_4_of_four](https://user-images.githubusercontent.com/66325265/88802783-3adb7200-d1b4-11ea-851f-dc43a22da11e.png)

right arrow init
![right_arrow_2_of_four](https://user-images.githubusercontent.com/66325265/88802801-42028000-d1b4-11ea-8339-5584c37178c6.png)

left arrow after slide forward
![left_arrow_1_of_four](https://user-images.githubusercontent.com/66325265/88802853-4f1f6f00-d1b4-11ea-95df-93b7d78f5cdc.png)

right arrow after slide forward
![right_arrow_3_of_four](https://user-images.githubusercontent.com/66325265/88808823-04095a00-d1bc-11ea-9e26-f3b93235fbbb.png)

Also I changed behaviour of products carousel a little bit (at the bottom of the homepage). Now click on arrow triggers moving slides by one. And carousel in a loop now. This is necessary for correct aria-labels of arrows. Or maybe we can use 
"Previous" and "Next" for aria-labels in this carousel

product carousel now   
![multiple_slides_after](https://user-images.githubusercontent.com/66325265/88807450-67928800-d1ba-11ea-80f8-7c46d662fce3.png)

product carousel before
![multiple_slides_before](https://user-images.githubusercontent.com/66325265/88808786-f9e75b80-d1bb-11ea-9490-9d85868197ec.png)

