### PR TITLE
fix(storefront):BCTHEME-43: fix overlaping on footer columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Draft
 
+- Fixed overlaping at footer columns when long texts (without spaces) are entered [#1753](https://jira.bigcommerce.com/browse/BCTHEME-43)
+
 ## 4.9.0 (07-28-2020)
 - Added correct alt text on image change in product view. [#1747](https://github.com/bigcommerce/cornerstone/pull/1747)
 - Description tab is hidden in case of empty product descrioption. [#1746](https://github.com/bigcommerce/cornerstone/pull/1746)

--- a/assets/scss/layouts/footer/_footer.scss
+++ b/assets/scss/layouts/footer/_footer.scss
@@ -32,7 +32,9 @@
     margin-bottom: spacing("double");
     text-align: center;
     vertical-align: top;
-
+    // TODO: specifically use vendor only for IE11 since overflow-wrap is not supported here 
+    -ms-word-break: break-all;
+    overflow-wrap: break-word;
     @include breakpoint("small") {
         text-align: left;
         width: width("6/12");


### PR DESCRIPTION
#### What?

@BC-tymurbiedukhin @yurytut1993 

This PR fixes overlaping in footer columns that can appear when entering long texts without spaces. Also ms vendor prefix was added since overflow-wrap doesn't work in IE11.

#### Tickets / Documentation

- [BC-THEME43](https://jira.bigcommerce.com/browse/BCTHEME-43)

#### Screenshots (if appropriate)

Attach images or add image links here.

![Chrome fixed](https://user-images.githubusercontent.com/67792608/88938367-fae8bd80-d28d-11ea-9bab-6fa8e8bdfabf.png)
![IE 11 fixed](https://user-images.githubusercontent.com/67792608/88938372-fc19ea80-d28d-11ea-8153-2943305dfe7e.png)
![Firefox fixed](https://user-images.githubusercontent.com/67792608/88938379-fcb28100-d28d-11ea-8572-2bed47ffc0fd.png)
![Safari fixed](https://user-images.githubusercontent.com/67792608/88938383-fd4b1780-d28d-11ea-9602-4e46ca6eb7f1.png)
