### PR TITLE
Move clear link outside of Faceted Search navigation button

### DIFF
--- a/assets/scss/components/foundation/accordion/_accordion.scss
+++ b/assets/scss/components/foundation/accordion/_accordion.scss
@@ -63,9 +63,11 @@
     }
 
     .accordion-navigation {
+        padding-right: 70px;
         @include breakpoint("medium") {
             background-position: right 0 top 50%;
             border: 0;
+            padding-right: 50px;
         }
     }
 
@@ -139,15 +141,25 @@
     position: absolute;
     right: $accordion-navigation-paddingHorizontal;
     top: $accordion-navigation-paddingVertical;
-
-    > a {
-        color: stencilColor("color-textSecondary");
-        vertical-align: middle;
-
-        // scss-lint:disable NestingDepth
-        &:hover {
-            color: stencilColor("color-textSecondary--hover");
-        }
-        // scss-lint:enable NestingDepth
+}
+.accordion-nav-clear-holder {
+    position: relative;
+}
+.facetedSearch-clearLink {
+    position: absolute;
+    right: 40px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: stencilColor("color-textSecondary");
+    @include breakpoint("medium") {
+        right: 20px;
+        top: 3px;
+        transform: none;
     }
+
+    // scss-lint:disable NestingDepth
+    &:hover {
+        color: stencilColor("color-textSecondary--hover");
+    }
+    // scss-lint:enable NestingDepth
 }

--- a/assets/scss/components/foundation/accordion/_accordion.scss
+++ b/assets/scss/components/foundation/accordion/_accordion.scss
@@ -142,9 +142,11 @@
     right: $accordion-navigation-paddingHorizontal;
     top: $accordion-navigation-paddingVertical;
 }
+
 .accordion-nav-clear-holder {
     position: relative;
 }
+
 .facetedSearch-clearLink {
     position: absolute;
     right: 40px;

--- a/templates/components/faceted-search/faceted-search-navigation.html
+++ b/templates/components/faceted-search/faceted-search-navigation.html
@@ -1,0 +1,22 @@
+<div class="accordion-nav-clear-holder">
+    <div
+        class="accordion-navigation toggleLink{{#unless start_collapsed}} is-open{{/unless}}"
+        role="button"
+        data-collapsible="#facetedSearch-content--{{dashcase facet}}">
+        <h5 class="accordion-title">
+            {{title}}
+        </h5>
+
+        <div class="accordion-navigation-actions">
+            <svg class="icon accordion-indicator toggleLink-text toggleLink-text--off">
+                <use xlink:href="#icon-add" />
+            </svg>
+            <svg class="icon accordion-indicator toggleLink-text toggleLink-text--on">
+                <use xlink:href="#icon-remove" />
+            </svg>
+        </div>
+    </div>
+    {{#if selected}}
+        <a href="{{remove_url}}" class="facetedSearch-clearLink" data-faceted-search-facet>{{lang 'search.faceted.clear'}}</a>
+    {{/if}}
+</div>

--- a/templates/components/faceted-search/facets/hierarchy-children.html
+++ b/templates/components/faceted-search/facets/hierarchy-children.html
@@ -3,9 +3,9 @@
         <li class="navList-item">
             <a
             href="{{url}}"
-            class="navList-action navList-action--checkbox {{#if selected }} is-selected {{/if}} {{#if has_sub_categories }} has-children {{/if}}"
+            class="navList-action navList-action--checkbox{{#if selected}} is-selected{{/if}}{{#if has_sub_categories}} has-children{{/if}}"
             rel="nofollow"
-            data-id="{{ id }}"
+            data-id="{{id}}"
             data-faceted-search-facet>
                 {{{sanitize title}}}
                 {{#if ../show_product_counts}}

--- a/templates/components/faceted-search/facets/hierarchy.html
+++ b/templates/components/faceted-search/facets/hierarchy.html
@@ -1,40 +1,21 @@
 {{#if items}}
 <div class="accordion-block">
-    <div
-        class="accordion-navigation toggleLink {{#unless ../start_collapsed }} is-open {{/unless}}"
-        role="button"
-        data-collapsible="#facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}">
-        <h5 class="accordion-title">
-            {{ title }}
-        </h5>
+    {{> components/faceted-search/faceted-search-navigation}}
 
-        <div class="accordion-navigation-actions">
-            {{#if selected}}
-                <a href="{{ remove_url }}" class="facetedSearch-clearLink" data-faceted-search-facet>{{lang 'search.faceted.clear'}}</a>
-            {{/if}}
-            <svg class="icon accordion-indicator toggleLink-text toggleLink-text--off">
-                <use xlink:href="#icon-add" />
-            </svg>
-            <svg class="icon accordion-indicator toggleLink-text toggleLink-text--on">
-                <use xlink:href="#icon-remove" />
-            </svg>
-        </div>
-    </div>
-
-    <div id="facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
-        <ul id="facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}" class="navList" data-facet="{{facet}}" data-has-more-results="{{ has_more_results }}">
+    <div id="facetedSearch-content--{{dashcase facet}}" class="accordion-content{{#unless start_collapsed}} is-open{{/unless}}">
+        <ul id="facetedSearch-navList--{{dashcase facet}}" class="navList" data-facet="{{facet}}" data-has-more-results="{{has_more_results}}">
             {{#each items}}
                 <li class="navList-item">
                     <a
-                        href="{{ url }}"
-                        class="navList-action navList-action--checkbox {{#if selected }} is-selected {{/if}} {{#if has_sub_categories }} has-children {{/if}}"
+                        href="{{url}}"
+                        class="navList-action navList-action--checkbox{{#if selected }} is-selected{{/if}}{{#if has_sub_categories}} has-children{{/if}}"
                         rel="nofollow"
-                        data-id="{{ id }}"
+                        data-id="{{id}}"
                         data-faceted-search-facet>
-                        {{{ sanitize title }}}
+                        {{{sanitize title}}}
                         {{#if ../show_product_counts}}
                             {{#if count}}
-                                <span>({{ count }})</span>
+                                <span>({{count}})</span>
                             {{/if}}
                         {{/if}}
                     </a>
@@ -46,7 +27,7 @@
         </ul>
 
         {{#if show_more_toggle}}
-            <a href="#facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}" role="button" class="toggleLink">
+            <a href="#facetedSearch-navList--{{dashcase facet}}" role="button" class="toggleLink">
                 <span class="toggleLink-text toggleLink-text--off">{{lang 'search.faceted.show-more'}}</span>
             </a>
         {{/if}}

--- a/templates/components/faceted-search/facets/multi.html
+++ b/templates/components/faceted-search/facets/multi.html
@@ -1,38 +1,19 @@
 {{#if items}}
 <div class="accordion-block">
-    <div
-        class="accordion-navigation toggleLink {{#unless ../start_collapsed }} is-open {{/unless}}"
-        role="button"
-        data-collapsible="#facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}">
-        <h5 class="accordion-title">
-            {{ title }}
-        </h5>
+    {{> components/faceted-search/faceted-search-navigation}}
 
-        <div class="accordion-navigation-actions">
-            {{#if selected}}
-                <a href="{{ remove_url }}" class="facetedSearch-clearLink" data-faceted-search-facet>{{lang 'search.faceted.clear'}}</a>
-            {{/if}}
-            <svg class="icon accordion-indicator toggleLink-text toggleLink-text--off">
-                <use xlink:href="#icon-add" />
-            </svg>
-            <svg class="icon accordion-indicator toggleLink-text toggleLink-text--on">
-                <use xlink:href="#icon-remove" />
-            </svg>
-        </div>
-    </div>
-
-    <div id="facetedSearch-content--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}" class="accordion-content {{#unless ../start_collapsed }} is-open {{/unless}}">
-        <ul id="facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}" data-facet="{{facet}}" class="navList" data-has-more-results="{{ has_more_results }}">
+    <div id="facetedSearch-content--{{dashcase facet}}" class="accordion-content{{#unless start_collapsed}} is-open{{/unless}}">
+        <ul id="facetedSearch-navList--{{dashcase facet}}" data-facet="{{facet}}" class="navList" data-has-more-results="{{has_more_results}}">
             {{#each items}}
                 <li class="navList-item">
                     <a
-                        href="{{ url }}"
-                        class="navList-action navList-action--checkbox {{#if selected }} is-selected {{/if}}"
+                        href="{{url}}"
+                        class="navList-action navList-action--checkbox{{#if selected}} is-selected{{/if}}"
                         rel="nofollow"
                         data-faceted-search-facet>
-                        {{{ sanitize title }}}
+                        {{{sanitize title}}}
                         {{#if ../show_product_counts}}
-                            <span>({{ count }})</span>
+                            <span>({{count}})</span>
                         {{/if}}
 
                         <span class="navList-action-close" aria-hidden="true">
@@ -46,7 +27,7 @@
         </ul>
 
         {{#if show_more_toggle}}
-            <a href="#facetedSearch-navList--{{#replace '&' (hyphenate facet) }}{{else}}{{hyphenate facet}}{{/replace}}" role="button" class="toggleLink">
+            <a href="#facetedSearch-navList--{{dashcase facet}}" role="button" class="toggleLink">
                 <span class="toggleLink-text toggleLink-text--off">{{lang 'search.faceted.show-more'}}</span>
             </a>
         {{/if}}

--- a/templates/components/faceted-search/facets/range.html
+++ b/templates/components/faceted-search/facets/range.html
@@ -1,29 +1,10 @@
 <div class="accordion-block">
-    <div
-        class="accordion-navigation toggleLink {{#unless start_collapsed }} is-open {{/unless}}"
-        role="button"
-        data-collapsible="#facetedSearch-content--{{hyphenate facet }}">
-        <h5 class="accordion-title">
-            {{ title }}
-        </h5>
+    {{> components/faceted-search/faceted-search-navigation}}
 
-        <div class="accordion-navigation-actions">
-            {{#if selected}}
-                <a href="{{ remove_url }}" class="facetedSearch-clearLink" data-faceted-search-facet>{{lang 'search.faceted.clear'}}</a>
-            {{/if}}
-            <svg class="icon accordion-indicator toggleLink-text toggleLink-text--off">
-                <use xlink:href="#icon-add" />
-            </svg>
-            <svg class="icon accordion-indicator toggleLink-text toggleLink-text--on">
-                <use xlink:href="#icon-remove" />
-            </svg>
-        </div>
-    </div>
-
-    <div id="facetedSearch-content--{{hyphenate facet }}" class="accordion-content {{#unless start_collapsed }} is-open {{/unless}}">
+    <div id="facetedSearch-content--{{dashcase facet}}" class="accordion-content{{#unless start_collapsed}} is-open{{/unless}}">
         <form id="facet-range-form" class="form" method="get" data-faceted-search-range novalidate>
             {{#each current_selected_items}}
-                <input type="hidden" name="{{ param_name }}[]" value="{{ param_value }}"/>
+                <input type="hidden" name="{{param_name}}[]" value="{{param_value}}"/>
             {{/each}}
             <input type="hidden" name="search_query" value="{{search_query}}">
             {{#if this.sort}}
@@ -39,7 +20,7 @@
                             class="form-input form-input--small"
                             required
                             type="number"
-                            value="{{ min_price }}"
+                            value="{{min_price}}"
                         />
                     </div>
 
@@ -51,7 +32,7 @@
                             class="form-input form-input--small"
                             required
                             type="number"
-                            value="{{ max_price }}"
+                            value="{{max_price}}"
                         />
                     </div>
 

--- a/templates/components/faceted-search/facets/rating.html
+++ b/templates/components/faceted-search/facets/rating.html
@@ -1,32 +1,13 @@
 {{#if items}}
 <div class="accordion-block">
-    <div
-        class="accordion-navigation toggleLink {{#unless ../start_collapsed }} is-open {{/unless}}"
-        role="button"
-        data-collapsible="#facetedSearch-content--{{hyphenate facet }}">
-        <h5 class="accordion-title">
-            {{ title }}
-        </h5>
+    {{> components/faceted-search/faceted-search-navigation}}
 
-        <div class="accordion-navigation-actions">
-            {{#if selected}}
-                <a href="{{ remove_url }}" class="facetedSearch-clearLink" data-faceted-search-facet>{{lang 'search.faceted.clear'}}</a>
-            {{/if}}
-            <svg class="icon accordion-indicator toggleLink-text toggleLink-text--off">
-                <use xlink:href="#icon-add" />
-            </svg>
-            <svg class="icon accordion-indicator toggleLink-text toggleLink-text--on">
-                <use xlink:href="#icon-remove" />
-            </svg>
-        </div>
-    </div>
-
-    <div id="facetedSearch-content--{{hyphenate facet }}" class="accordion-content facetedSearch-content--{{hyphenate facet}} {{#unless ../start_collapsed }} is-open {{/unless}}">
+    <div id="facetedSearch-content--{{dashcase facet}}" class="accordion-content facetedSearch-content--{{dashcase facet}}{{#unless start_collapsed}} is-open{{/unless}}">
         <ul class="navList">
             {{#each items}}
                 <li class="navList-item">
-                    <a href="{{ url }}"
-                       class="navList-action {{#if selected }} is-selected {{/if}}"
+                    <a href="{{url}}"
+                       class="navList-action{{#if selected}} is-selected{{/if}}"
                        rel="nofollow"
                        data-faceted-search-facet>
                         <span class="rating--small">
@@ -34,7 +15,7 @@
                         </span>
                         {{lang 'search.faceted.rating.and-up'}}
                         {{#if ../show_product_counts}}
-                            <span>({{ count }})</span>
+                            <span>({{count}})</span>
                         {{/if}}
                     </a>
                 </li>

--- a/templates/components/faceted-search/index.html
+++ b/templates/components/faceted-search/index.html
@@ -1,14 +1,12 @@
 <div id="facetedSearch" class="facetedSearch sidebarBlock">
-    {{> components/faceted-search/selected-facets this.selected}}
+    {{> components/faceted-search/selected-facets selected}}
 
     <a href="#facetedSearch-navList" role="button" class="facetedSearch-toggle toggleLink" data-collapsible>
         <span class="facetedSearch-toggle-text">
             {{#if facets.length '>' 2}}
-                {{lang 'search.faceted.browse-by'}} {{ join (pluck facets 'title') ', ' limit=2 }} &amp; {{ toLowerCase (lang 'search.faceted.more') }}
-            {{/if}}
-
-            {{#if facets.length '<=' 2}}
-                {{lang 'search.faceted.browse-by'}} {{ join (pluck facets 'title') ', ' lastSeparator=' & ' }}
+                {{lang 'search.faceted.browse-by'}} {{join (pluck facets 'title') ', ' limit=2}} &amp; {{toLowerCase (lang 'search.faceted.more')}}
+            {{else}}
+                {{lang 'search.faceted.browse-by'}} {{join (pluck facets 'title') ', ' lastSeparator=' & '}}
             {{/if}}
         </span>
 

--- a/templates/components/faceted-search/selected-facets.html
+++ b/templates/components/faceted-search/selected-facets.html
@@ -3,19 +3,19 @@
         {{lang 'search.faceted.selected.title'}}
     </h5>
 
-    {{#if this.items}}
+    {{#if items}}
         <ul class="inlineList inlineList--labels">
-            {{#each this.items}}
+            {{#each items}}
                 <li>
                     <a
-                        href="{{ url }}"
+                        href="{{url}}"
                         class="facetLabel"
                         rel="nofollow"
                         data-faceted-search-facet>
                         {{#if facet '===' 'rating'}}
                             {{lang 'search.faceted.selected.rating-label' rating=title}}
                         {{else}}
-                            {{{ sanitize title }}}
+                            {{{sanitize title}}}
                         {{/if}}
 
                         <svg class="icon">
@@ -30,7 +30,7 @@
     {{/if}}
 
     {{#if remove_all_url}}
-        <a href="{{ remove_all_url }}" data-faceted-search-facet>
+        <a href="{{remove_all_url}}" data-faceted-search-facet>
             {{lang 'search.faceted.selected.clear-all'}}
         </a>
     {{/if}}

--- a/templates/components/faceted-search/show-more-facets.html
+++ b/templates/components/faceted-search/show-more-facets.html
@@ -3,7 +3,7 @@
         {{all_facets}}
     </h1>
     <div class="form-field" id="facetedSearch-filterItems">
-        <input class="form-input" type="search" placeholder={{lang 'forms.search.search'}}>
+        <input class="form-input" type="search" placeholder="{{lang 'forms.search.search'}}">
     </div>
     <ul class="navList facetedSearch-optionColumns">
         {{#each facets}}
@@ -12,9 +12,9 @@
                     <li class="navList-item">
                         <a
                         href="{{url}}"
-                        class="navList-action {{#if selected }} is-active {{/if}}"
+                        class="navList-action{{#if selected}} is-active{{/if}}"
                         rel="nofollow"
-                        data-id="{{ id }}"
+                        data-id="{{id}}"
                         data-faceted-search-facet
                         >
                             {{{title}}}


### PR DESCRIPTION
#### What?

The current HTML markup for the link to clear faceted search element's items is invalid as it is located inside a button. This update moves the clear link outside the navigation button, so it no longer violates W3C markup standards (see below for a screenshot of the error message). This update also adds padding so the title of the filter does not overlap with the clear button.

Additionally, this update componentizes the faceted search navigation. Previously, the faceted search navigation code was repeated in the exact same code across 3 different templates.

Lastly, this update cleans up some extraneous whitespace (for consistency with the rest of the codebase) and otherwise questionable code.

The only visible change to the theme is, as stated above, the padding adjustment to prevent the overlap of the faceted search filter title and the clear button.

#### Tickets / Documentation

N/A

#### Screenshots (if appropriate)

![W3C Validator error message](https://user-images.githubusercontent.com/47044676/88958891-f7394480-d255-11ea-9b24-58cb2232d725.png)

