### PR TITLE
feature(storefront): BCTHEME-133 Improper footer heading hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Draft
 
+- Improper footer heading hierarchy. [#1760](https://github.com/bigcommerce/cornerstone/pull/1760/files)
+
 ## 4.9.0 (07-28-2020)
 - Added correct alt text on image change in product view. [#1747](https://github.com/bigcommerce/cornerstone/pull/1747)
 - Description tab is hidden in case of empty product descrioption. [#1746](https://github.com/bigcommerce/cornerstone/pull/1746)

--- a/assets/scss/layouts/footer/_footer.scss
+++ b/assets/scss/layouts/footer/_footer.scss
@@ -16,6 +16,16 @@
     background-color: $footer-background;
     border-top: container("border");
     padding: spacing("double") 0;
+    position: relative;
+}
+
+.footer-title-sr-only {
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
 }
 
 .footer-info {

--- a/lang/en.json
+++ b/lang/en.json
@@ -4,6 +4,7 @@
         "skip_to_main": "Skip to main content"
     },
     "footer": {
+        "title": "Footer Start",
         "brands": "Popular Brands",
         "navigate": "Navigate",
         "info": "Info",

--- a/templates/components/common/footer.html
+++ b/templates/components/common/footer.html
@@ -19,19 +19,20 @@
 
 {{/if}}
 <footer class="footer" role="contentinfo">
+    <h2 class="footer-title-sr-only">{{lang 'footer.title'}}</h2>
     <div class="container">
         {{#if theme_settings.social_icon_placement_bottom '!==' 'bottom_none'}}
             <article class="footer-info-col
                 footer-info-col--social
                 footer-info-col--{{#if theme_settings.social_icon_placement_bottom '===' 'bottom_left'}}left{{else}}right{{/if}}"
                 data-section-type="footer-webPages">
-                    <h5 class="footer-info-heading">{{lang 'social.connect'}}</h5>
+                    <h3 class="footer-info-heading">{{lang 'social.connect'}}</h3>
                     {{> components/common/social-links}}
             </article>
         {{/if}}
         <section class="footer-info">
             <article class="footer-info-col footer-info-col--small" data-section-type="footer-webPages">
-                <h5 class="footer-info-heading">{{lang 'footer.navigate'}}</h5>
+                <h3 class="footer-info-heading">{{lang 'footer.navigate'}}</h3>
                 <ul class="footer-info-list">
                     {{#each pages}}
                         <li>
@@ -45,7 +46,7 @@
             </article>
 
             <article class="footer-info-col footer-info-col--small" data-section-type="footer-categories">
-                <h5 class="footer-info-heading">{{lang 'footer.categories'}}</h5>
+                <h3 class="footer-info-heading">{{lang 'footer.categories'}}</h3>
                 <ul class="footer-info-list">
                     {{#each categories}}
                         <li>
@@ -57,7 +58,7 @@
 
             {{#and theme_settings.shop_by_brand_show_footer shop_by_brand.length}}
             <article class="footer-info-col footer-info-col--small" data-section-type="footer-brands">
-                <h5 class="footer-info-heading">{{lang 'footer.brands'}}</h5>
+                <h3 class="footer-info-heading">{{lang 'footer.brands'}}</h3>
                 <ul class="footer-info-list">
                     {{#each shop_by_brand}}
                         <li>
@@ -71,7 +72,7 @@
 
             {{#if settings.address}}
             <article class="footer-info-col footer-info-col--small" data-section-type="storeInfo">
-                <h5 class="footer-info-heading">{{lang 'footer.info'}}</h5>
+                <h3 class="footer-info-heading">{{lang 'footer.info'}}</h3>
                 <address>{{nl2br settings.address}}</address>
                 {{#if settings.phone_number}}
                     <strong>{{lang 'footer.call_us' phone_number=settings.phone_number}}</strong>

--- a/templates/components/common/subscription-form.html
+++ b/templates/components/common/subscription-form.html
@@ -1,4 +1,4 @@
-<h5 class="footer-info-heading">{{lang 'newsletter.subscribe'}}</h5>
+<h3 class="footer-info-heading">{{lang 'newsletter.subscribe'}}</h3>
 <p>{{lang 'newsletter.subscribe_intro'}}</p>
 
 <form class="form" action="{{urls.subscribe.action}}" method="post">


### PR DESCRIPTION
#### What?

@BC-tymurbiedukhin @bc-alexsaiannyi 

Added visually hidden h2 in footer for screen readers. Now users can understand that they navigate through footer block. 
Also I changed footer section headers from h5 to h3 for more proper semantics 

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-133)

#### Screenshots (if appropriate)

h2
![Screenshot 2020-08-04 at 15 05 13](https://user-images.githubusercontent.com/66325265/89298830-86879300-d66e-11ea-8aa8-884cd4b3c396.png)

h3
![Screenshot 2020-08-04 at 15 05 24](https://user-images.githubusercontent.com/66325265/89299358-32c97980-d66f-11ea-85ed-c0ecafc77ad5.png)
