### PR TITLE
fix(storefront)BCTHEME-154: fix issue with add product to cart on IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed failing to add product to cart on IE11 [#1762](https://github.com/bigcommerce/cornerstone/pull/1762)
 
 ## 4.9.0 (07-28-2020)
 - Added correct alt text on image change in product view. [#1747](https://github.com/bigcommerce/cornerstone/pull/1747)

--- a/assets/js/polyfills.js
+++ b/assets/js/polyfills.js
@@ -3,6 +3,8 @@ import 'regenerator-runtime/runtime';
 import 'whatwg-fetch';
 import objectFitImages from 'object-fit-images';
 
+require('formdata-polyfill');
+
 document.addEventListener('DOMContentLoaded', () => {
     objectFitImages();
 });

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -6,6 +6,7 @@ import modalFactory, { showAlertModal } from '../global/modal';
 import _ from 'lodash';
 import Wishlist from '../wishlist';
 import { normalizeFormData } from './utils/api';
+import { isBrowserIE, convertIntoArray } from './utils/ie-helpers';
 
 export default class ProductDetails {
     constructor($scope, context, productAttributesData = {}) {
@@ -108,15 +109,20 @@ export default class ProductDetails {
             if (type === 'set-rectangle' || type === 'set-radio' || type === 'swatch' || type === 'input-checkbox' || type === 'product-list') {
                 const checked = value.querySelector(':checked');
                 if (checked) {
+                    const getSelectedOptionLabel = () => {
+                        const productVariantslist = convertIntoArray(value.children);
+                        const matchLabelForCheckedInput = inpt => inpt.dataset.productAttributeValue === checked.value;
+                        return productVariantslist.filter(matchLabelForCheckedInput)[0];
+                    };
                     if (type === 'set-rectangle' || type === 'set-radio' || type === 'product-list') {
-                        const label = checked.labels[0].innerText;
+                        const label = isBrowserIE ? getSelectedOptionLabel().innerText.trim() : checked.labels[0].innerText;
                         if (label) {
                             options.push(`${optionTitle}:${label}`);
                         }
                     }
 
                     if (type === 'swatch') {
-                        const label = checked.labels[0].children[0];
+                        const label = isBrowserIE ? getSelectedOptionLabel().children[0] : checked.labels[0].children[0];
                         if (label) {
                             options.push(`${optionTitle}:${label.title}`);
                         }

--- a/assets/js/theme/common/utils/ie-helpers.js
+++ b/assets/js/theme/common/utils/ie-helpers.js
@@ -1,0 +1,3 @@
+export const isBrowserIE = navigator.userAgent.includes('Trident');
+
+export const convertIntoArray = collection => Array.prototype.slice.call(collection);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6019,6 +6019,11 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formdata-polyfill": {
+      "version": "3.0.20",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-3.0.20.tgz",
+      "integrity": "sha512-TAaxIEwTBdoH1TWndtUH1T0/GisUHwmOKcV5hjkR/iTatHBJSOHb563FP86Lra5nXo3iNdhK7HPwMl5Ihg71pg=="
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -10621,7 +10626,7 @@
       }
     },
     "jstree": {
-      "version": "github:vakata/jstree#308b85722d86294f1504eca2cec475e6f73b3e13",
+      "version": "github:vakata/jstree#19bad17697386873b8643e89e1c157238a9dc3f4",
       "from": "github:vakata/jstree",
       "requires": {
         "jquery": ">=1.9.1"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "creditcards": "^3.0.1",
     "easyzoom": "^2.5.3",
     "focus-within-polyfill": "^5.0.9",
+    "formdata-polyfill": "^3.0.20",
     "foundation-sites": "^5.5.3",
     "jquery": "^3.5.1",
     "jquery.tabbable": "^1.0.1",


### PR DESCRIPTION
#### What?

@BC-tymurbiedukhin @yurytut1993 

This PR fixes 2 issue that prevent a User to add product to cart on IE11:
- [HTMLInputElement.labels](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/labels) that are used is not supported in IE11 which leads to mentioned in ticket description error
-FormData Object is badly supported in IE11 as well so [polyfill](https://www.npmjs.com/package/formdata-polyfill) has been added to secure things in IE.

#### Tickets / Documentation

- [BCTHEME-154](https://jira.bigcommerce.com/browse/BCTHEME-154)

#### Screenshots (if appropriate)

[BCT154_IE11 Add to Cart Fix](https://github.com/bigcommerce/cornerstone/files/5023338/BCT154_IE11.Add.to.Cart.fix.zip)
