### PR TITLE
fix(storefront): BCTHEME-125 Cart remove 'X' should be a button

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -72,6 +72,7 @@
         "freeshipping": "Free Shipping",
         "reconfigure_product": "Configure '{name}'",
         "shipping_peritem": "Per Item Shipping",
+        "remove_item": "Remove item from cart",
         "confirm_delete": "Are you sure you want to delete this item?",
         "coupons": {
             "empty_error": "Please enter your coupon code.",

--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -122,17 +122,15 @@
                     {{else}}
                         {{> components/common/login-for-pricing}}
                     {{/or}}
-                    {{#if can_modify}}
-                        <a class="cart-remove icon" data-cart-itemid="{{id}}" href="#" data-confirm-delete="{{lang 'cart.confirm_delete'}}">
+                    {{#or can_modify (if type '==' 'GiftCertificate')}}
+                        <button class="cart-remove icon"
+                                data-cart-itemid="{{id}}"
+                                data-confirm-delete="{{lang 'cart.confirm_delete'}}"
+                                aria-label="{{lang 'cart.remove_item'}}"
+                        >
                             <svg><use xlink:href="#icon-close"></use></svg>
-                        </a>
-                    {{else}}
-                        {{#if type '==' 'GiftCertificate'}}
-                            <a class="cart-remove icon" data-cart-itemid="{{id}}" href="#" data-confirm-delete="{{lang 'cart.confirm_delete'}}">
-                                <svg><use xlink:href="#icon-close"></use></svg>
-                            </a>
-                        {{/if}}
-                    {{/if}}
+                        </button>
+                    {{/or}}
                 </td>
             </tr>
         {{/each}}


### PR DESCRIPTION
#### What?

On the cart page, the remove item "x" should be a button rather than the current implementation as a link.
Additionally, this button should have an appropriate label.

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-125)

#### Screenshots (if appropriate)

<img width="1071" alt="Screenshot 2020-08-05 at 09 52 49" src="https://user-images.githubusercontent.com/66319629/89381544-0448ae80-d702-11ea-8faf-63784ac9064f.png">
