### PR TITLE
fix(storefront): Fix main logo display on mobile with expanded menu

### DIFF
--- a/assets/scss/layouts/header/_header.scss
+++ b/assets/scss/layouts/header/_header.scss
@@ -59,7 +59,7 @@
     font-size: 0;   // 1
     margin: 0 remCalc($header-toggle-width); // 2
     text-align: center;
-    height: inherit;
+    height: $header-height;
 
     @include breakpoint("small") { // 4
         margin-left: remCalc($header-toggle-width * 1.5);


### PR DESCRIPTION
#### What?

Actual result: On mobile logo centering in screen when nav menu is expanded
Expected result: On mobile logo centering in header when nav menu is expanded

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-166)

#### Screenshots (if appropriate)

<img width="496" alt="Screenshot 2020-08-05 at 14 32 37" src="https://user-images.githubusercontent.com/66319629/89408142-a3809c80-d728-11ea-8feb-80767703250d.png">
