### PR TITLE
fix(storefront): BCTGHEME-150 fix missing logo on mobile and tablets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed issue with missing logo on mobile and tablet. [#1767](https://github.com/bigcommerce/cornerstone/pull/1767)
 
 ## 4.9.0 (07-28-2020)
 - Added correct alt text on image change in product view. [#1747](https://github.com/bigcommerce/cornerstone/pull/1747)

--- a/assets/scss/layouts/header/_header.scss
+++ b/assets/scss/layouts/header/_header.scss
@@ -167,6 +167,7 @@
 
 .header-logo-image-container {
     position: relative;
+    width: 100%;
 }
 
 .header-logo-image-container:after {


### PR DESCRIPTION
#### What?

@BC-tymurbiedukhin @yurytut1993 

This PR fixed issue with missing logo on Mobile devices and tablets.

#### Tickets / Documentation

- [BCTHEME-150](https://jira.bigcommerce.com/browse/BCTHEME-150)

#### Screenshots (if appropriate)

![Screenshot 2020-08-06 at 12 07 10](https://user-images.githubusercontent.com/67792608/89514777-f583f980-d7de-11ea-9b99-827e5159e37b.png)
![Screenshot 2020-08-06 at 12 07 41](https://user-images.githubusercontent.com/67792608/89514821-07fe3300-d7df-11ea-9746-7a8f25f397fa.png)
![Screenshot 2020-08-06 at 12 08 45](https://user-images.githubusercontent.com/67792608/89514825-0896c980-d7df-11ea-8f25-82a5ae25b453.png)
![Screenshot 2020-08-06 at 12 09 15](https://user-images.githubusercontent.com/67792608/89514828-092f6000-d7df-11ea-98cc-8c2f2fea4930.png)
![Screenshot 2020-08-06 at 12 10 13](https://user-images.githubusercontent.com/67792608/89514832-09c7f680-d7df-11ea-84e0-5123f537eb59.png)
