### PR TITLE
feature(storefront): BCTHEME-142 Unnecessary heading on product cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Draft
 
+Unnecessary heading on product cards. [#1768](https://github.com/bigcommerce/cornerstone/pull/1768)
+
 ## 4.9.0 (07-28-2020)
 - Added correct alt text on image change in product view. [#1747](https://github.com/bigcommerce/cornerstone/pull/1747)
 - Description tab is hidden in case of empty product descrioption. [#1746](https://github.com/bigcommerce/cornerstone/pull/1746)

--- a/templates/components/amp/products/card.html
+++ b/templates/components/amp/products/card.html
@@ -22,9 +22,9 @@
         {{#if brand.name}}
             <p class="card-text" data-test-info-type="brandName">{{brand.name}}</p>
         {{/if}}
-        <h4 class="card-title">
+        <span class="card-title">
             <a data-vars-product-link="{{url}}" data-vars-product-id="{{id}}" data-vars-product-name="{{name}}" href="{{url}}">{{name}}</a>
-        </h4>
+        </span>
 
         <div class="card-text" data-test-info-type="price">
             {{#or customer (if theme_settings.restrict_to_login '!==' true)}}

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -74,9 +74,9 @@
         {{#if brand.name}}
             <p class="card-text" data-test-info-type="brandName">{{brand.name}}</p>
         {{/if}}
-        <h4 class="card-title">
+        <span class="card-title">
             <a href="{{url}}" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}}>{{name}}</a>
-        </h4>
+        </span>
 
         <div class="card-text" data-test-info-type="price">
             {{#or customer (if theme_settings.restrict_to_login '!==' true)}}

--- a/templates/pages/brands.html
+++ b/templates/pages/brands.html
@@ -27,9 +27,9 @@ brands:
                         </a>
                     </figure>
                     <div class="card-body">
-                        <h4 class="card-title">
+                        <span class="card-title">
                             <a href="{{url}}">{{name}}</a>
-                        </h4>
+                        </span>
                     </div>
                 </article>
             </li>

--- a/templates/pages/compare.html
+++ b/templates/pages/compare.html
@@ -32,9 +32,9 @@
                             {{#if brand.name}}
                                 <p class="card-text"><a href="{{brand.url}}">{{ brand.name }}</a></p>
                             {{/if}}
-                            <h4 class="card-title">
+                            <span class="card-title">
                                 <a href="{{url}}">{{ name }}</a>
-                            </h4>
+                            </span>
                             {{#or ../customer (if ../theme_settings.restrict_to_login '!==' true)}}
                                 {{#if price_range}}
                                     {{> components/products/price-range}}


### PR DESCRIPTION
#### What?

We have product link wrapped in h4 tag which is unnecessary. It can be possible just to remove h4, but I decided to change h4 to span for saving style class which was setted on h4, and now it is setted on span.

Also I should mention that typography styles little bit changed after disabling h4. But we don't have heading already - so we don't need heading styles. I think it is correct - now product name link has similar typography styles with other links in cornerstone. 

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-142)

#### Screenshots (if appropriate)

main page grid cards
![grid_cards](https://user-images.githubusercontent.com/66325265/89518206-4269cf00-d7e3-11ea-870e-f1bb4a93459e.png)

compare page cards
![compare_cards](https://user-images.githubusercontent.com/66325265/89518233-4bf33700-d7e3-11ea-98bd-d75f02341304.png)

brand page cards
![brand_cards](https://user-images.githubusercontent.com/66325265/89518267-59a8bc80-d7e3-11ea-9587-f012fcbee333.png)

