### PR TITLE
feat(storefront): BCTHEME-127 Product ratings on PDPs should have ari…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Added additional focusable element for rating announcing. [#1769](https://github.com/bigcommerce/cornerstone/pull/1769)
 
 ## 4.9.0 (08-05-2020)
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -701,6 +701,7 @@
             "rating_label": "Rating",
             "select_rating": "Select Rating",
             "anonymous_poster": "Unknown",
+            "rating_aria_label": "Product rating is {current_rating} of {max_rating}",
             "rating": {
                 "1": "1 star (worst)",
                 "2": "2 stars",

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -38,7 +38,12 @@
                             <meta itemprop="reviewCount" content="{{product.num_reviews}}">
                         {{/if}}
                     {{/if}}
-                    {{> components/products/ratings rating=product.rating}}
+                    <span title="{{lang 'products.reviews.rating_aria_label' current_rating=product.rating max_rating=5}}"
+                          tabindex="0"
+                          role="text"
+                    >
+                        {{> components/products/ratings rating=product.rating}}
+                    </span>
                     <span class="productView-reviewLink">
                         {{#if product.num_reviews '>' 0}}
                             <a href="{{product.url}}#product-reviews">


### PR DESCRIPTION
…a-hidden=true

#### What?

Added additional focusable element for rating announcing

#### Tickets / Documentation

[Jira Ticket](https://jira.bigcommerce.com/browse/BCTHEME-127)

#### Screenshots (if appropriate)

<img width="1126" alt="Screenshot 2020-08-06 at 12 51 50" src="https://user-images.githubusercontent.com/66319629/89518706-f79c8700-d7e3-11ea-87bd-33614fda742c.png">
