### PR TITLE
fix(storefront): BCTHEME-132 Visually hidden cart link read by screen…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Visually hidden cart link read by screen reader. [#1770](https://github.com/bigcommerce/cornerstone/pull/1770)
 
 ## 4.9.0 (08-05-2020)
 

--- a/assets/js/theme/global/cart-preview.js
+++ b/assets/js/theme/global/cart-preview.js
@@ -16,6 +16,11 @@ export default function (secureBaseUrl, cartId) {
     const $body = $('body');
 
     $body.on('cart-quantity-update', (event, quantity) => {
+        if (!quantity) {
+            $cart.addClass('navUser-item--cart__hidden-s');
+        } else {
+            $cart.removeClass('navUser-item--cart__hidden-s');
+        }
         $('.cart-quantity')
             .text(quantity)
             .toggleClass('countPill--positive', quantity > 0);

--- a/assets/scss/components/stencil/navUser/_navUser.scss
+++ b/assets/scss/components/stencil/navUser/_navUser.scss
@@ -162,6 +162,13 @@
 .navUser-item--cart {
     display: block;
 
+    // removing cart link for small screens when quantity is 0
+    &__hidden-s {
+        @media (max-width: $screen-small) {
+            display: none;
+        }
+    }
+
     .navUser-action {
         color: stencilColor("navUser-color");
 


### PR DESCRIPTION
… reader

#### What?

When navigating through the "hamburger menu" the visually hidden "Cart" link is read by the screen reader.
Elements that are non-infomative and hidden should not be read by the screen reader.

#### Tickets / Documentation

[Jira Ticket](https://jira.bigcommerce.com/browse/BCTHEME-132)

#### Screenshots (if appropriate)

<img width="545" alt="Screenshot 2020-08-06 at 14 34 47" src="https://user-images.githubusercontent.com/66319629/89527684-6b459080-d7f2-11ea-8391-48bcdccbb055.png">

