### PR TITLE
fix(storefront)bctheme-109: add separately handling fee on cart

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -54,6 +54,7 @@
             "enter_code": "Coupon code / Gift certificate",
             "gift_wrapping": "Gift wrapping",
             "shipping": "Shipping",
+            "handling": "Handling",
             "grand_total": "Grand total",
             "select": "Select",
             "update": "Update shipping cost"

--- a/templates/components/cart/totals.html
+++ b/templates/components/cart/totals.html
@@ -28,6 +28,14 @@
             </div>
             {{> components/cart/shipping-estimator cart.shipping_handling}}
         </li>
+        <li class="cart-total">
+            <div class="cart-total-label">
+                <strong>{{lang 'cart.checkout.handling'}}:</strong>
+            </div>
+            <div class="cart-total-value">
+                <span>${{cart.shipping_handling.handling_cost}}</span>
+            </div>
+        </li>
     {{/if}}
     {{#each cart.taxes}}
         <li class="cart-total">


### PR DESCRIPTION
#### What?

This PR adds a separate Handling Fee Cost  for Cart Page.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [BCTHEME-109](https://jira.bigcommerce.com/browse/BCTHEME-109)

#### Screenshots (if appropriate)

![handling fee](https://user-images.githubusercontent.com/67792608/89638296-3dc11b80-d8b4-11ea-8851-8c5fb9b39724.png)

