### PR TITLE
feature(storefront): BCTHEME-157 Improper heading hierarchy on Sitemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Draft
 
+- Improper heading hierarchy on Sitemap. [#1774](https://github.com/bigcommerce/cornerstone/pull/1774)
+
 ## 4.9.0 (08-05-2020)
 
 ## 4.9.0 (07-28-2020)

--- a/templates/pages/sitemap.html
+++ b/templates/pages/sitemap.html
@@ -4,7 +4,7 @@
 <ul>
 {{#each sitemap}}
     <li>
-        <h3>{{label}}</h3>
+        <h2>{{label}}</h2>
         <ul>
             {{#each body}}
             <li>


### PR DESCRIPTION
#### What?

Changes sitemap list titles from h3 to h2

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-157)

#### Screenshots (if appropriate)

![Screenshot 2020-08-07 at 15 01 30](https://user-images.githubusercontent.com/66325265/89643843-508d1d80-d8bf-11ea-9c5d-237c0b85cb02.png)
