### PR TITLE
feature(storefront): BCTHEME-158 Improper heading hierarchy on Cart page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Draft
 
+- Improper heading hierarchy on Cart page. [#1775](https://github.com/bigcommerce/cornerstone/pull/1775)
+
 ## 4.9.0 (08-05-2020)
 
 ## 4.9.0 (07-28-2020)

--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -27,7 +27,7 @@
                     {{#if brand.name}}
                         <p class="cart-item-brand">{{brand.name}}</p>
                     {{/if}}
-                    <h4 class="cart-item-name"><a href="{{url}}">{{name}}</a></h4>
+                    <h2 class="cart-item-name"><a href="{{url}}">{{name}}</a></h2>
                     {{#if release_date}}
                         <p>({{release_date}})</p>
                     {{/if}}


### PR DESCRIPTION
#### What?

Updated cart item title tag from h3 to h2 on Cart Page

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-158)

#### Screenshots (if appropriate)

![Screenshot 2020-08-07 at 15 53 41](https://user-images.githubusercontent.com/66325265/89647428-3b67bd00-d8c6-11ea-91fd-1005c522546f.png)
