### PR TITLE
feat(storefront): BCTHEME-128 Error messages from Write a Review form…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Error messages from Write a Review should be announced. [#1777](https://github.com/bigcommerce/cornerstone/pull/1777)
 
 ## 4.9.0 (08-05-2020)
 

--- a/assets/js/theme/product.js
+++ b/assets/js/theme/product.js
@@ -39,6 +39,7 @@ export default class Product extends PageManager {
 
         $('body').on('click', '[data-reveal-id="modal-review-form"]', () => {
             validator = review.registerValidation(this.context);
+            this.ariaDescribeReviewInputs($reviewForm);
         });
 
         $reviewForm.on('submit', () => {
@@ -52,6 +53,16 @@ export default class Product extends PageManager {
 
         this.productReviewHandler();
         this.bulkPricingHandler();
+    }
+
+    ariaDescribeReviewInputs($form) {
+        $form.find('[data-input]').each((_, input) => {
+            const $input = $(input);
+            const msgSpanId = `${$input.attr('name')}-msg`;
+
+            $input.siblings('span').attr('id', msgSpanId);
+            $input.attr('aria-describedby', msgSpanId);
+        });
     }
 
     productReviewHandler() {

--- a/templates/components/common/forms/checkbox.html
+++ b/templates/components/common/forms/checkbox.html
@@ -6,7 +6,16 @@
     </label>
     {{#if checkboxes}}
         {{#each checkboxes}}
-            <input type="checkbox" value="{{value}}" name="{{name}}" id="{{name}}" data-label="{{label}}" class="form-checkbox" {{#if checked}}checked{{/if}} {{#if private_id}}data-field-type="{{private_id}}"{{/if}}>
+            <input type="checkbox"
+                   value="{{value}}"
+                   name="{{name}}"
+                   id="{{name}}"
+                   data-input
+                   data-label="{{label}}"
+                   class="form-checkbox"
+                   {{#if checked}}checked{{/if}}
+                   {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
+            >
             <label class="form-label {{class}}" for="{{name}}">{{label}}</label>
         {{/each}}
     {{/if}}

--- a/templates/components/common/forms/date.html
+++ b/templates/components/common/forms/date.html
@@ -3,21 +3,42 @@
     {{#if required}}<small>{{lang 'common.required' }}</small>{{/if}}</label>
     <div class="form-row form-row--third">
         <div class="form-field">
-            <select class="form-select" name="{{month.name}}" id="{{id}}_month" data-label="month"  aria-required="{{required}}" {{#if private_id}}data-field-type="{{private_id}}"{{/if}}>
+            <select class="form-select"
+                    name="{{month.name}}"
+                    id="{{id}}_month"
+                    data-label="month"
+                    data-input
+                    aria-required="{{required}}"
+                    {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
+            >
                 {{#each month.items}}
                     <option {{#if ../month.value '==' value}} selected {{/if}}value="{{value}}">{{label}}</option>
                 {{/each}}
             </select>
         </div>
         <div class="form-field">
-            <select class="form-select" name="{{day.name}}" id="{{id}}_day" data-label="day" aria-required="{{required}}" {{#if private_id}}data-field-type="{{private_id}}"{{/if}}>
+            <select class="form-select"
+                    name="{{day.name}}"
+                    id="{{id}}_day"
+                    data-label="day"
+                    data-input
+                    aria-required="{{required}}"
+                    {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
+            >
                 {{#each day.items}}
                     <option {{#if ../day.value '==' value}} selected {{/if}}value="{{value}}">{{label}}</option>
                 {{/each}}
             </select>
         </div>
         <div class="form-field">
-            <select class="form-select" name="{{year.name}}" id="{{id}}_year" data-label="year" aria-required="{{required}}" {{#if private_id}}data-field-type="{{private_id}}"{{/if}}>
+            <select class="form-select"
+                    name="{{year.name}}"
+                    id="{{id}}_year"
+                    data-label="year"
+                    data-input
+                    aria-required="{{required}}"
+                    {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
+            >
                 {{#each year.items}}
                     <option {{#if ../year.value '==' value}} selected {{/if}}value="{{value}}">{{label}}</option>
                 {{/each}}

--- a/templates/components/common/forms/multiline.html
+++ b/templates/components/common/forms/multiline.html
@@ -4,5 +4,15 @@
             <small>{{lang 'common.required' }}</small>
         {{/if}}
     </label>
-    <textarea name="{{name}}" id="{{id}}_input" data-label="{{label}}" rows="{{rows}}" aria-required="{{required}}" class="form-input" {{#if private_id}}data-field-type="{{private_id}}"{{/if}}>{{value}}</textarea>
+    <textarea name="{{name}}"
+              id="{{id}}_input"
+              data-label="{{label}}"
+              rows="{{rows}}"
+              aria-required="{{required}}"
+              data-input
+              class="form-input"
+              {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
+    >
+        {{value}}
+    </textarea>
 </div>

--- a/templates/components/common/forms/number.html
+++ b/templates/components/common/forms/number.html
@@ -2,5 +2,18 @@
     <label class="form-label" for="{{id}}_input">{{label}}
         {{#if required}}<small>{{lang 'common.required' }}</small>{{/if}}
     </label>
-    <input type="number" class="form-input" data-label="{{label}}" data-rule="lowerThan" min="{{limitfrom}}" max="{{limitto}}" title="{{lang 'forms.range' limitFrom=limitfrom limitTo=limitto}}" value="{{value}}" id="{{id}}_input" name="{{name}}" aria-required="{{required}}" {{#if private_id}}data-field-type="{{private_id}}"{{/if}}>
+    <input type="number"
+           class="form-input"
+           data-label="{{label}}"
+           data-input
+           data-rule="lowerThan"
+           min="{{limitfrom}}"
+           max="{{limitto}}"
+           title="{{lang 'forms.range' limitFrom=limitfrom limitTo=limitto}}"
+           value="{{value}}"
+           id="{{id}}_input"
+           name="{{name}}"
+           aria-required="{{required}}"
+           {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
+    >
 </div>

--- a/templates/components/common/forms/password.html
+++ b/templates/components/common/forms/password.html
@@ -4,5 +4,14 @@
             <small>{{lang 'common.required' }}</small>
         {{/if}}
     </label>
-    <input type="password"  class="form-input" id="{{id}}_input" data-label="{{label}}" name="{{name}}" value="{{value}}" autocomplete="off" aria-required="{{required}}" {{#if private_id}}data-field-type="{{private_id}}"{{/if}}>
+    <input type="password"
+           class="form-input"
+           id="{{id}}_input"
+           data-label="{{label}}"
+           name="{{name}}"
+           value="{{value}}"
+           autocomplete="off"
+           aria-required="{{required}}"
+           {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
+    >
 </div>

--- a/templates/components/common/forms/radio.html
+++ b/templates/components/common/forms/radio.html
@@ -6,20 +6,18 @@
     </label>
     {{#if radios}}
         {{#each radios}}
-            <input 
+            <input
                 type="radio"
                 class="form-radio"
                 name="{{../name}}"
                 id="{{../name}}_{{@index}}"
                 value="{{value}}"
                 data-label="{{label}}"
+                data-input
                 aria-required="{{required}}"
-                {{#if checked}}
-                    checked
-                {{/if}}
-                {{#if private_id}}
-                    data-field-type="{{private_id}}"
-                {{/if}}>
+                {{#if checked}}checked{{/if}}
+                {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
+            >
             <label class="form-label" for="{{../name}}_{{@index}}">{{label}}</label>
         {{/each}}
     {{/if}}

--- a/templates/components/common/forms/select.html
+++ b/templates/components/common/forms/select.html
@@ -3,8 +3,14 @@
     <label class="form-label" for="{{id}}_select">{{label}}
         {{#if required}}<small>{{lang 'common.required' }}</small>{{/if}}
     </label>
-    <select class="{{class}} form-select" id="{{id}}_select" data-label="{{label}}" aria-required="{{required}}" name="{{name}}"
-        {{#if private_id}} data-field-type="{{private_id}}" {{/if}}>
+    <select class="{{class}} form-select"
+            id="{{id}}_select"
+            data-label="{{label}}"
+            data-input
+            aria-required="{{required}}"
+            name="{{name}}"
+            {{#if private_id}} data-field-type="{{private_id}}" {{/if}}
+    >
         {{#if options}}
         <option value="">{{chooseprefix}}</option>
         {{#each options}}

--- a/templates/components/common/forms/selectortext.html
+++ b/templates/components/common/forms/selectortext.html
@@ -3,7 +3,15 @@
         <label class="form-label" for="{{id}}_input">{{label}}
             {{#if required}}<small>{{lang 'common.required' }}</small>{{/if}}
         </label>
-        <input type="text" id="{{id}}_input" name="{{name}}" value="{{value}}" class="form-input" aria-required="{{required}}" data-label="{{label}}" />
+        <input type="text"
+               id="{{id}}_input"
+               name="{{name}}"
+               value="{{value}}"
+               class="form-input"
+               aria-required="{{required}}"
+               data-label="{{label}}"
+               data-input
+        />
     </noscript>
 
     <label class="form-label" for="{{id}}_select">{{label}}
@@ -11,7 +19,14 @@
             <small>{{lang 'common.required'}}</small>
         {{/if}}
     </label>
-    <select name="{{name}}" class="form-select" aria-required="{{required}}" id="{{id}}_select" data-label="{{label}}" {{#if private_id}}data-field-type="{{private_id}}"{{/if}}>
+    <select name="{{name}}"
+            class="form-select"
+            aria-required="{{required}}"
+            id="{{id}}_select"
+            data-label="{{label}}"
+            data-input
+            {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
+    >
         {{#if options}}
             <option value="">{{chooseprefix}}</option>
             {{#each options}}

--- a/templates/components/common/forms/text.html
+++ b/templates/components/common/forms/text.html
@@ -2,5 +2,16 @@
     <label class="form-label" for="{{id}}_input">{{label}}
         {{#if required}}<small>{{lang 'common.required' }}</small>{{/if}}
     </label>
-    <input type="text" id="{{id}}_input" data-label="{{label}}" name="{{name}}" {{#if value}} value="{{value}}"{{/if}} {{#if placeholder}} placeholder="{{placeholder}}"{{/if}} class="form-input" aria-required="{{required}}" {{#if private_id}}data-field-type="{{private_id}}"{{/if}} {{#if maxlength}}maxlength="{{maxlength}}"{{/if}}>
+    <input type="text"
+           name="{{name}}"
+           id="{{id}}_input"
+           class="form-input"
+           data-label="{{label}}"
+           data-input
+           aria-required="{{required}}"
+           {{#if value}} value="{{value}}"{{/if}}
+           {{#if maxlength}}maxlength="{{maxlength}}"{{/if}}
+           {{#if placeholder}} placeholder="{{placeholder}}"{{/if}}
+           {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
+    >
 </div>

--- a/templates/components/products/modals/writeReview.html
+++ b/templates/components/products/modals/writeReview.html
@@ -30,7 +30,7 @@
                     </label>
                     <!-- Stars -->
                     <!-- TODO: Review Stars need to be componentised, both for display and input -->
-                    <select id="rating-rate" class="form-select" name="revrating">
+                    <select id="rating-rate" class="form-select" name="revrating" data-input>
                         <option value="">{{lang 'products.reviews.select_rating'}}</option>
                         {{#for 1 5}}
                             {{#if ../product.reviews.selected_rating '===' $index}}


### PR DESCRIPTION
… should be announced

#### What?

Error messages generated on the "Write a review" modal are skipped when moving through fields on the modal.
In order for assistive technology to properly aid users, these messages must be announced.

#### Tickets / Documentation

[Jira Ticket](https://jira.bigcommerce.com/browse/BCTHEME-128)

#### Screenshots (if appropriate)

<img width="1188" alt="Screenshot 2020-08-10 at 11 09 50" src="https://user-images.githubusercontent.com/66319629/89762981-3a1ed600-dafa-11ea-849d-e753e8b55d2d.png">

