### PR TITLE
feat(payments): PAYPAL-627 Render in the site footer verbiage about C…

### DIFF
--- a/assets/scss/layouts/footer/_footer.scss
+++ b/assets/scss/layouts/footer/_footer.scss
@@ -121,6 +121,12 @@
         margin: 0;
     }
 
+    > .paypal-credit {
+        color: stencilColor("color-textSecondary");
+        font-size: fontSize("tiny");
+        margin: 1em 0 2em;
+    }
+
     a {
         color: stencilColor("color-textSecondary");
         text-decoration: none;

--- a/templates/components/common/footer.html
+++ b/templates/components/common/footer.html
@@ -91,6 +91,11 @@
                 {{> components/common/geotrust-ssl-seal}}
             </div>
         {{/if}}
+        {{#if settings.paypal_commerce_credit_message}}
+        <div class="footer-copyright">
+            <p class="paypal-credit">{{nl2br settings.paypal_commerce_credit_message}}</p>
+        </div>
+        {{/if}}
         {{#if theme_settings.show_powered_by}}
             <div class="footer-copyright">
                 <p class="powered-by">Powered by <a href="https://www.bigcommerce.com?utm_source=merchant&amp;utm_medium=poweredbyBC" rel="nofollow">BigCommerce</a></p>


### PR DESCRIPTION
…redit Broker License

#### What?
When PPC merchant unlocks Credit, the new text input - "Merchant name (as per FCA)" is automatically pre-filled by the Store Name and merchant can change it. 
This PR adds banner to the footer of the website  with provided Merchant name like
```<Merchant_name> ACTS LIKE A BROKER AND OFFERS CREDIT FROM PAYPAL CREDIT. PAYPAL CREDIT IS A TRADING NAME OF PAYPAL (Europe) S.À.R.L. ET CIE, S.C.A., 22-24 BOULEVARD ROYAL L-2449, LUXEMBOURG```

#### Tickets / Documentation

- [Story ticket](https://jira.bigcommerce.com/browse/PAYPAL-494)
- [BCApp related PR](https://github.com/bigcommerce/bigcommerce/pull/36297)

#### Screenshots (if appropriate)
![Screenshot 2020-08-10 at 18 50 07](https://user-images.githubusercontent.com/54856617/89802636-6d815500-db3a-11ea-913e-b968f066f7cd.png)

