### PR TITLE
fix(storefront): BCTHEME-139 Unnecessary heading tag in carousel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Changed heading tag for carousel slides. [#1780](https://github.com/bigcommerce/cornerstone/pull/1780)
 
 ## 4.9.0 (08-05-2020)
 

--- a/templates/components/carousel-content.html
+++ b/templates/components/carousel-content.html
@@ -1,5 +1,5 @@
 <div class="heroCarousel-content{{#unless show_background}} heroCarousel-content--empty{{/unless}}">
-    <h1 class="heroCarousel-title">{{{heading}}}</h1>
+    <span class="heroCarousel-title">{{{heading}}}</span>
     <p class="heroCarousel-description">{{{text}}}</p>
     {{#if button_text}}
         <span class="heroCarousel-action button button--primary button--large">{{button_text}}</span>


### PR DESCRIPTION
#### What?

Each slide in the homepage carousel contains an h1 tag for the slide headings.  These headings are inconsistent with guidelines for page hierarchy. Instead of h1 tags, carousel headings should be h3 or h4

#### Tickets / Documentation

[Jira Ticket](https://jira.bigcommerce.com/browse/BCTHEME-139)

#### Screenshots (if appropriate)

<img width="1192" alt="Screenshot 2020-08-12 at 11 09 28" src="https://user-images.githubusercontent.com/66319629/89991308-50f53200-dc8c-11ea-9e37-22a24f2108d2.png">
