### PR TITLE
BCTHEME-160: add valid ARIA role for Related Products tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Added a valid ARIA role for li elemenents on "Related Products" tab [#1782](https://github.com/bigcommerce/cornerstone/pull/1782)
 
 ## 4.9.0 (08-05-2020)
 

--- a/templates/components/products/tabs.html
+++ b/templates/components/products/tabs.html
@@ -1,11 +1,11 @@
 <ul class="tabs" data-tab role="tablist">
     {{#if product.related_products}}
-        <li class="tab is-active" role="presentational">
+        <li class="tab is-active" role="presentation">
             <a class="tab-title" href="#tab-related" role="tab" tabindex="0" aria-selected="true" controls="tab-related">{{lang 'products.related_products'}}</a>
         </li>
     {{/if}}
     {{#if product.similar_by_views}}
-        <li class="tab{{#unless product.related_products}} is-active{{/unless}}" role="presentational">
+        <li class="tab{{#unless product.related_products}} is-active{{/unless}}" role="presentation">
             <a class="tab-title" href="#tab-similar" role="tab" tabindex="0" aria-selected="{{#if product.related_products}}false{{else}}true{{/if}}" controls="tab-similar">{{lang 'products.similar_by_views'}}</a>
         </li>
     {{/if}}


### PR DESCRIPTION
#### What?

@BC-tymurbiedukhin @yurytut1993 
This PR adds valid ARIA roles for Related Products Tab li elements

#### Tickets / Documentation

- [BCTHEME-160](https://jira.bigcommerce.com/browse/BCTHEME-160)

#### Screenshots (if appropriate)

Attach images or add image links here.

![role presentation](https://user-images.githubusercontent.com/67792608/90010634-d5ee4480-dca8-11ea-8fbb-07edd906beae.png)
