### PR TITLE
fix(storefront): BCTHEME-146 Improper heading hierarchy on Add to Car…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed improper heading hierarchy on Add to Cart modal heading. [#1783](https://github.com/bigcommerce/cornerstone/pull/1783)
 
 ## 4.9.0 (08-05-2020)
 

--- a/templates/components/cart/preview.html
+++ b/templates/components/cart/preview.html
@@ -1,7 +1,7 @@
 <div class="modal-header">
-    <h2 class="modal-header-title">
+    <h1 class="modal-header-title">
         {{lang 'cart.added_to_cart.what_next' num_products=cart.quantity}}
-    </h2>
+    </h1>
 </div>
 
 <div class="modal-body">
@@ -66,9 +66,9 @@
                 </figure>
 
                 <div class="productView-details">
-                    <h4 class="productView-title">
+                    <h2 class="productView-title">
                         {{name}}
-                    </h4>
+                    </h2>
 
                     <div class="productView-brand">
                         {{brand.name}}


### PR DESCRIPTION
…t modal heading

#### What?

The heading inside the modal window for Add to Cart are tagged incorrectly as h4.
As the product name is the next hierarchical item on the page, it should be tagged with h2.
Modal title was changed from h2 to h1.

#### Tickets / Documentation

[Jira Ticket](https://jira.bigcommerce.com/browse/BCTHEME-146)

#### Screenshots (if appropriate)

<img width="1286" alt="Screenshot 2020-08-12 at 14 41 12" src="https://user-images.githubusercontent.com/66319629/90011224-e357fe80-dca9-11ea-97c6-8bc9bbc2da93.png">
