### PR TITLE
fix(storefront): BCTHEME-147 Improper heading hierarchy on Add to Car…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed improper heading hierarchy on Add to Cart modal recommendation. [#1784](https://github.com/bigcommerce/cornerstone/pull/1784)
 
 ## 4.9.0 (08-05-2020)
 

--- a/templates/components/cart/preview.html
+++ b/templates/components/cart/preview.html
@@ -99,9 +99,9 @@
 
     {{#if cart.suggested_products}}
         <section class="suggestiveCart">
-            <h4>
+            <h2>
                 {{lang 'cart.added_to_cart.you_might_also_like'}}&hellip;
-            </h4>
+            </h2>
 
             <ul class="productGrid">
                 {{#each cart.suggested_products}}


### PR DESCRIPTION
…t modal recommendation

#### What?

The heading inside the modal window for Add to Cart are tagged incorrectly as h4.
As the product recommendation ("You may also like...") is the next hierarchical item on the page, it should be tagged with h2.

#### Tickets / Documentation

[Jira Ticket](https://jira.bigcommerce.com/browse/BCTHEME-147)

#### Screenshots (if appropriate)
-
