### PR TITLE
feat(storefront): BCTHEME-145 Add presentation role for table on cart page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Draft
-
+- Added presentation role for table on cart page. [#1785](https://github.com/bigcommerce/cornerstone/pull/1785) 
 ## 4.9.0 (08-05-2020)
 
 ## 4.9.0 (07-28-2020)

--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -1,4 +1,4 @@
-<table class="cart" data-cart-quantity="{{cart.quantity}}">
+<table class="cart" data-cart-quantity="{{cart.quantity}}" role="presentation">
     <thead class="cart-header">
         <tr>
             <th class="cart-header-item" colspan="2">{{lang 'cart.checkout.item'}}</th>


### PR DESCRIPTION
#### What?
@BC-tymurbiedukhin @yurytut1993 
this PR adds a presentation role for table to prevent inaccurate screen reader output

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [BCTHEME-145](https://jira.bigcommerce.com/browse/BCTHEME-145)

#### Screenshots (if appropriate)
![Table role added](https://user-images.githubusercontent.com/67792608/90111895-f6290c80-dd57-11ea-8d85-383495b30fde.png)




[BCTHEME-145]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ