### PR TITLE
fix(storefront): BCTHEME-153 Insufficient link text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed Shop by price insufficient link text. [#1786](https://github.com/bigcommerce/cornerstone/pull/1786)
 
 ## 4.9.0 (08-05-2020)
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -211,6 +211,7 @@
     "category": {
         "label": "Categories",
         "shop_by_price": "Shop By Price",
+        "shop_by_price_range_aria": "Price range from {from} to {to}",
         "reset": "Reset",
         "view_all": {
             "name": "All {category}"

--- a/templates/components/category/shop-by-price.html
+++ b/templates/components/category/shop-by-price.html
@@ -4,7 +4,14 @@
         <ul class="navList">
             {{#each shop_by_price}}
             <li class="navList-item">
-                <a class="navList-action {{#if selected }} is-active {{/if}}" href="{{url}}" alt="{{low.formatted}} - {{high.formatted}}" title="{{low.formatted}} - {{high.formatted}}">{{low.formatted}} - {{high.formatted}}</a>
+                <a class="navList-action
+                   {{#if selected }} is-active {{/if}}"
+                   href="{{url}}"
+                   title="{{low.formatted}} - {{high.formatted}}"
+                   aria-label="{{{lang 'category.shop_by_price_range_aria' from=low.formatted to=high.formatted}}}"
+                >
+                    {{low.formatted}} - {{high.formatted}}
+                </a>
             </li>
             {{/each}}
 

--- a/templates/components/category/sidebar.html
+++ b/templates/components/category/sidebar.html
@@ -5,7 +5,7 @@
             <ul class="navList">
                 {{#each category.subcategories}}
                 <li class="navList-item">
-                    <a class="navList-action" href="{{url}}" alt="{{name}}" title="{{name}}">{{name}}</a>
+                    <a class="navList-action" href="{{url}}" title="{{name}}">{{name}}</a>
                 </li>
                 {{/each}}
             </ul>


### PR DESCRIPTION
#### What?

The link text provided for the links present under "Shop By Price" is insufficient to describe what the links are in reference to.
The link text should have more meaningful text in order to provide users with useful information - (ex: "Range of $0.00 to $51.00")

#### Tickets / Documentation

[Jira Ticket](https://jira.bigcommerce.com/browse/BCTHEME-153)

#### Screenshots (if appropriate)

<img width="729" alt="Screenshot 2020-08-13 at 14 04 54" src="https://user-images.githubusercontent.com/66319629/90127741-575bda80-dd6e-11ea-9830-9fa6735fbd81.png">

