### PR TITLE
feature(storefront):  BCTHEME-156 Selected state on search page not announced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Draft
 
+Selected state on search page not announced. [#1788](https://github.com/bigcommerce/cornerstone/pull/1788)
+
 ## 4.9.0 (08-05-2020)
 
 ## 4.9.0 (07-28-2020)

--- a/assets/js/theme/search.js
+++ b/assets/js/theme/search.js
@@ -8,6 +8,9 @@ import collapsibleFactory from './common/collapsible';
 import 'jstree';
 import nod from './common/nod';
 
+const leftArrowKey = 37;
+const rightArrowKey = 39;
+
 export default class Search extends CatalogPage {
     formatCategoryTreeForJSTree(node) {
         const nodeData = {
@@ -34,15 +37,17 @@ export default class Search extends CatalogPage {
     }
 
     showProducts(navigate = true) {
-        this.$productListingContainer.removeClass('u-hiddenVisually');
-        this.$facetedSearchContainer.removeClass('u-hiddenVisually');
-        this.$contentResultsContainer.addClass('u-hiddenVisually');
+        this.$productListingContainer.removeClass('u-hidden');
+        this.$facetedSearchContainer.removeClass('u-hidden');
+        this.$contentResultsContainer.addClass('u-hidden');
 
         $('[data-content-results-toggle]').removeClass('navBar-action-color--active');
         $('[data-content-results-toggle]').addClass('navBar-action');
 
         $('[data-product-results-toggle]').removeClass('navBar-action');
         $('[data-product-results-toggle]').addClass('navBar-action-color--active');
+
+        this.activateTab($('[data-product-results-toggle]'));
 
         if (!navigate) {
             return;
@@ -57,15 +62,17 @@ export default class Search extends CatalogPage {
     }
 
     showContent(navigate = true) {
-        this.$contentResultsContainer.removeClass('u-hiddenVisually');
-        this.$productListingContainer.addClass('u-hiddenVisually');
-        this.$facetedSearchContainer.addClass('u-hiddenVisually');
+        this.$contentResultsContainer.removeClass('u-hidden');
+        this.$productListingContainer.addClass('u-hidden');
+        this.$facetedSearchContainer.addClass('u-hidden');
 
         $('[data-product-results-toggle]').removeClass('navBar-action-color--active');
         $('[data-product-results-toggle]').addClass('navBar-action');
 
         $('[data-content-results-toggle]').removeClass('navBar-action');
         $('[data-content-results-toggle]').addClass('navBar-action-color--active');
+
+        this.activateTab($('[data-content-results-toggle]'));
 
         if (!navigate) {
             return;
@@ -77,6 +84,52 @@ export default class Search extends CatalogPage {
         });
 
         urlUtils.goToUrl(url);
+    }
+
+    activateTab($tabToActivate) {
+        const $tabsCollection = $('[data-search-page-tabs]').find('[role="tab"]');
+
+        $tabsCollection.each((idx, tab) => {
+            const $tab = $(tab);
+
+            if ($tab.is($tabToActivate)) {
+                $tab.removeAttr('tabindex');
+                $tab.attr('aria-selected', true);
+                return;
+            }
+
+            $tab.attr('tabindex', '-1');
+            $tab.attr('aria-selected', false);
+        });
+    }
+
+    onTabChangeWithArrows(event) {
+        const eventKey = event.which;
+        const isLeftOrRightArrowKeydown = eventKey === leftArrowKey
+            || eventKey === rightArrowKey;
+        if (!isLeftOrRightArrowKeydown) return;
+
+        const $tabsCollection = $('[data-search-page-tabs]').find('[role="tab"]');
+
+        const isActiveElementNotTab = $tabsCollection.index($(document.activeElement)) === -1;
+        if (isActiveElementNotTab) return;
+
+        const $activeTab = $(`#${document.activeElement.id}`);
+        const activeTabIdx = $tabsCollection.index($activeTab);
+        const lastTabIdx = $tabsCollection.length - 1;
+
+        let nextTabIdx;
+        switch (eventKey) {
+        case leftArrowKey:
+            nextTabIdx = activeTabIdx === 0 ? lastTabIdx : activeTabIdx - 1;
+            break;
+        case rightArrowKey:
+            nextTabIdx = activeTabIdx === lastTabIdx ? 0 : activeTabIdx + 1;
+            break;
+        default: break;
+        }
+
+        $($tabsCollection.get(nextTabIdx)).focus().trigger('click');
     }
 
     onReady() {
@@ -110,6 +163,8 @@ export default class Search extends CatalogPage {
             event.preventDefault();
             this.showContent();
         });
+
+        $('[data-search-page-tabs]').on('keyup', this.onTabChangeWithArrows);
 
         if (this.$productListingContainer.find('li.product').length === 0 || url.query.section === 'content') {
             this.showContent(false);

--- a/assets/scss/components/stencil/search/_search.scss
+++ b/assets/scss/components/stencil/search/_search.scss
@@ -93,3 +93,11 @@
     margin: spacing("single") 0 0;
     text-align: center;
 }
+
+.search-nav {
+    position: relative;
+
+    .search-tabs-widget-description {
+        @include ariaDescribeElement
+    }
+}

--- a/assets/scss/tools/_mixins.scss
+++ b/assets/scss/tools/_mixins.scss
@@ -1,0 +1,9 @@
+@mixin ariaDescribeElement {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;    
+    margin-left: -10000px;
+}

--- a/assets/scss/tools/_tools.scss
+++ b/assets/scss/tools/_tools.scss
@@ -1,3 +1,4 @@
 @import "list";
 @import "string";
 @import "image";
+@import "mixins";

--- a/lang/en.json
+++ b/lang/en.json
@@ -847,7 +847,8 @@
         },
         "error": {
             "empty_field": "Search field cannot be empty."
-        }
+        },
+        "tabs_accesibility_hint": "Use left and right arrows to navigate between tabs."
     },
     "page_not_found": {
         "page_heading": "404 Error - Page not found",

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -21,15 +21,18 @@ product_results:
             {{>components/search/heading}}
         </div>
     {{/if}}
-    <nav class="navBar navBar--sub">
-        <ul class="navBar-section account-navigation">
-            <li class="navBar-item">
-                <a id="search-results-product-count" class="navBar-action" href="{{forms.search.product_url}}" data-product-results-toggle>
+    <nav class="navBar navBar--sub search-nav">
+        <span id="search-tabs-widget-description" class="search-tabs-widget-description">
+            {{lang 'search.tabs_accesibility_hint'}}
+        </span>
+        <ul role="tablist" class="navBar-section account-navigation" data-search-page-tabs>
+            <li role="presentation" class="navBar-item">
+                <a aria-describedby="search-tabs-widget-description" role="tab" aria-controls="product-listing-container" id="search-results-product-count" class="navBar-action" href="{{forms.search.product_url}}" data-product-results-toggle>
                     {{>components/search/product-count}}
                 </a>
             </li>
-            <li class="navBar-item">
-                <a id="search-results-content-count" class="navBar-action" href="{{forms.search.content_url}}" data-content-results-toggle>
+            <li role="presentation" class="navBar-item">
+                <a aria-describedby="search-tabs-widget-description" role="tab" aria-controls="search-results-content" id="search-results-content-count" class="navBar-action" href="{{forms.search.content_url}}" data-content-results-toggle>
                     {{>components/search/content-count}}
                 </a>
             </li>
@@ -122,11 +125,11 @@ product_results:
             </div>
         {{/if}}
 
-        <div id="search-results-content" {{#if forms.search.section '!=' 'content'}}class="u-hiddenVisually"{{/if}}>
+        <div role="tabpanel" id="search-results-content" aria-labelledby="search-results-content-count" {{#if forms.search.section '!=' 'content'}}class="u-hidden"{{/if}}>
             {{> components/search/content-listing}}
         </div>
 
-        <div id="product-listing-container" {{#if forms.search.section '!=' 'product'}}class="u-hiddenVisually"{{/if}}>
+        <div role="tabpanel" id="product-listing-container" aria-labelledby="search-results-product-count" {{#if forms.search.section '!=' 'product'}}class="u-hidden"{{/if}}>
             {{> components/search/product-listing}}
         </div>
 


### PR DESCRIPTION
#### What?

Search page tabs status (selected) was not announced by screen reader. Now it is working. Also I added a hint how to change selected tab using left and right arrows/


#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-156)

#### Screenshots (if appropriate)

first tab selected
<img width="1557" alt="first_tab_selected" src="https://user-images.githubusercontent.com/66325265/90507435-8e5f3100-e15e-11ea-9776-3cfa2eb2844f.png">

second tab selected (hint text)
<img width="1557" alt="second_tab_selected_hint" src="https://user-images.githubusercontent.com/66325265/90507560-c0709300-e15e-11ea-93df-e5fa41d22754.png">

video example
[search_tabs.zip](https://github.com/bigcommerce/cornerstone/files/5090034/search_tabs.zip)


