### PR TITLE
fix(storefront): BCTHEME-144 Button inputs with the same name attribu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Button inputs with the same name attribute should be part of a group. [#1792](https://github.com/bigcommerce/cornerstone/pull/1792)
 
 ## 4.9.0 (08-05-2020)
 

--- a/templates/components/products/options/product-list.html
+++ b/templates/components/products/options/product-list.html
@@ -1,5 +1,5 @@
-<div class="form-field" data-product-attribute="product-list">
-    <label class="form-label form-label--alternate form-label--inlineSmall">
+<div class="form-field" data-product-attribute="product-list" role="radiogroup" aria-labelledby="product-list-label">
+    <label class="form-label form-label--alternate form-label--inlineSmall" id="product-list-label">
         {{display_name}}:
         <span data-option-value></span>
 

--- a/templates/components/products/options/set-radio.html
+++ b/templates/components/products/options/set-radio.html
@@ -1,5 +1,5 @@
-<div class="form-field" data-product-attribute="set-radio">
-    <label class="form-label form-label--alternate form-label--inlineSmall">
+<div class="form-field" data-product-attribute="set-radio" role="radiogroup" aria-labelledby="radio-group-label">
+    <label class="form-label form-label--alternate form-label--inlineSmall" id="radio-group-label">
         {{ this.display_name }}:
 
         {{> components/common/requireness-msg}}

--- a/templates/components/products/options/set-rectangle.html
+++ b/templates/components/products/options/set-rectangle.html
@@ -1,5 +1,5 @@
-<div class="form-field" data-product-attribute="set-rectangle">
-    <label class="form-label form-label--alternate form-label--inlineSmall">
+<div class="form-field" data-product-attribute="set-rectangle" role="radiogroup" aria-labelledby="rectangle-group-label">
+    <label class="form-label form-label--alternate form-label--inlineSmall" id="rectangle-group-label">
         {{this.display_name}}:
         <span data-option-value></span>
 


### PR DESCRIPTION
…te should be part of a group

#### What?

Radio buttons (and others) in product options are not grouped together.  When this happens, buttons may be misidentified or be grouped with other irrelevant buttons.

Fixed for Radio, Rectangle and Product list product variants. (Was fixed for swatches in https://jira.bigcommerce.com/browse/BCTHEME-122)

See here for more details - https://www.w3.org/TR/2016/WD-wai-aria-practices-1.1-20160317/examples/radio/radio.html
#### Tickets / Documentation

[Jira Ticket](http://example.com)
