### PR TITLE
fix(storefront): BCTHEME-35 Cornerstone - Cart link not visible on mobile Chrome depending on swatch image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Draft
 
+- Cornerstone - Cart link not visible on mobile Chrome depending on swatch image size. [#1793](https://github.com/bigcommerce/cornerstone/pull/1793)
+
 ## 4.9.0 (08-05-2020)
 
 ## 4.9.0 (07-28-2020)

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -281,6 +281,7 @@
     @include clearfix;
     margin-bottom: spacing("single");
     text-align: center;
+    overflow: hidden; // for Androind Chrome horizontal scroll fix
 
     @include breakpoint("small") {
         text-align: left;


### PR DESCRIPTION
#### What?

This PR has fix for hidden cart icon on Android Chrome. Seems like it is a bug in browser calculations of some width

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-35)

#### Screenshots (if appropriate)
![Screenshot 2020-08-25 at 14 14 00](https://user-images.githubusercontent.com/66325265/91168876-07223800-e6df-11ea-809d-87ad099776c3.png)
