### PR TITLE
fix(storefront): BCTHEME-171 State of search link not announced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+##next draft
+- State of search link not announced. [#1798](https://github.com/bigcommerce/cornerstone/pull/1798)
+
 ## Draft
 - Fixed product image doesn't change on click when viewing a product with multiple images in IE11 [#1748](https://github.com/bigcommerce/cornerstone/pull/1748)
 - Fixed alt text on image change in product view [#1747](https://github.com/bigcommerce/cornerstone/pull/1747)

--- a/assets/js/theme/global/quick-search.js
+++ b/assets/js/theme/global/quick-search.js
@@ -7,11 +7,14 @@ export default function () {
     const $quickSearchResults = $('.quickSearchResults');
     const $quickSearchDiv = $('#quickSearch');
     const $searchQuery = $('[data-search-quick]');
+    const $quickSearchExpand = $('#quick-search-expand');
     const stencilDropDownExtendables = {
         hide: () => {
+            $quickSearchExpand.attr('aria-expanded', false);
             $searchQuery.trigger('blur');
         },
         show: (event) => {
+            $quickSearchExpand.attr('aria-expanded', true);
             $searchQuery.trigger('focus');
             event.stopPropagation();
         },

--- a/templates/components/common/navigation.html
+++ b/templates/components/common/navigation.html
@@ -35,14 +35,15 @@
             <li class="navUser-item navUser-item--divider">|</li>
         {{/if}}
         <li class="navUser-item">
-            <a class="navUser-action navUser-action--quickSearch"
-               href="#" data-search="quickSearch"
+            <button class="navUser-action navUser-action--quickSearch"
+               type="button"
+               id="quick-search-expand"
+               data-search="quickSearch"
                aria-controls="quickSearch"
-               aria-expanded="false"
                aria-label="{{lang 'common.search'}}"
             >
                 {{lang 'common.search'}}
-            </a>
+            </button>
         </li>
         {{#if settings.gift_certificates_enabled}}
             <li class="navUser-item">


### PR DESCRIPTION
#### What?

Expanded/Collapsed state of Search link is not notify by screen reader.

Notifications and alerts of content changes, errors, and status updates are important aspects of a website or web application’s usability.

https://www.w3.org/WAI/GL/wiki/Using_the_WAI-ARIA_aria-expanded_state_to_mark_expandable_and_collapsible_regions

#### Tickets / Documentation

[Jira Ticket](https://jira.bigcommerce.com/browse/BCTHEME-171)

#### Screenshots (if appropriate)

<img width="1037" alt="Screenshot 2020-08-27 at 14 13 40" src="https://user-images.githubusercontent.com/66319629/91435991-eb01d080-e86f-11ea-9332-f26c53430b5f.png">

