### PR TITLE
fix(storefront): BCTHEME-167 Focus not visible on logo element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Improper heading hierarchy on Sitemap. [#1774](https://github.com/bigcommerce/cornerstone/pull/1774)
 - Added modal trap for for product details. [#1758](https://github.com/bigcommerce/cornerstone/pull/1758)
 - Added tooltips for carousel Previous and Next buttons. [#1749](https://github.com/bigcommerce/cornerstone/pull/1749)
+- Focus not visible on logo element. [#1800](https://github.com/bigcommerce/cornerstone/pull/1800)
 
 ## 4.9.0 (07-28-2020)
 - Added correct alt text on image change in product view. [#1747](https://github.com/bigcommerce/cornerstone/pull/1747)

--- a/assets/scss/layouts/header/_header.scss
+++ b/assets/scss/layouts/header/_header.scss
@@ -69,6 +69,7 @@
     @include breakpoint("medium") {
         margin: (spacing("double") + spacing("base")) auto (spacing("double") + spacing("single"));
         padding: 0;
+        height: auto;
 
         .header.fixed & {
             background-color: color("greys", "lightest");
@@ -96,9 +97,9 @@
         @include breakpoint("medium") {
             background: none;
             border-bottom: 0;
-            display: inline;
+            display: inline-flex;
             padding: 0;
-            width: 100%;
+            width: auto;
         }
 
         &:hover {
@@ -158,6 +159,7 @@
         max-width: none;
         overflow: auto;
         white-space: normal;
+        padding: 0 10px;
 
         .header.fixed & {
             font-size: fontSize("larger");
@@ -168,21 +170,21 @@
 .header-logo-image-container {
     position: relative;
     width: 100%;
+    
+    @include breakpoint("medium") {
+        min-height: get-height(stencilString('logo_size'));
+    }
 }
 
 .header-logo-image-container:after {
     content: '';
     display: block;
-    padding-bottom: remCalc($header-height) - $header-logo-marginVertical * 2;
-
-    @include breakpoint("medium") {
-        padding-bottom: get-height(stencilString('logo_size'));
-    }
 }
 
 .header-logo-image {
-    @include lazy-loaded-img;
     max-height: remCalc($header-height) - $header-logo-marginVertical * 2;
+    display: block;
+    margin: 0 auto;
 
     @include breakpoint("medium") {
         max-height: none;


### PR DESCRIPTION
#### What?

Logo has no visible focus state styles. I have changed some link styles to become focus styles visible 

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-167)

#### Screenshots (if appropriate)

text logo desktop
![logo_focus_text_desktop](https://user-images.githubusercontent.com/66325265/91470607-95441d00-e89d-11ea-8507-cbe1d883e885.png)


text logo mobile
![log_focus_text_mob](https://user-images.githubusercontent.com/66325265/91470553-86f60100-e89d-11ea-9a48-3af211bbfe11.png)

image logo desktop
![logo_focus_image_desktop](https://user-images.githubusercontent.com/66325265/91470588-907f6900-e89d-11ea-8723-d71195b13fe1.png)

image logo mobile
![logo_focus_image_mob](https://user-images.githubusercontent.com/66325265/91470640-a12fdf00-e89d-11ea-8f1e-fda85b39bc20.png)

