### PR TITLE
fix(storefront): BCTHEME-191 Incorrect styles for focused buttons in grid card product item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Improper heading hierarchy on Sitemap. [#1774](https://github.com/bigcommerce/cornerstone/pull/1774)
 - Added modal trap for for product details. [#1758](https://github.com/bigcommerce/cornerstone/pull/1758)
 - Added tooltips for carousel Previous and Next buttons. [#1749](https://github.com/bigcommerce/cornerstone/pull/1749)
+- Incorrect styles for focused buttons in grid card product item. [#1801](https://github.com/bigcommerce/cornerstone/pull/1801)
 
 ## 4.9.0 (07-28-2020)
 - Added correct alt text on image change in product view. [#1747](https://github.com/bigcommerce/cornerstone/pull/1747)

--- a/assets/scss/components/citadel/cards/_cards.scss
+++ b/assets/scss/components/citadel/cards/_cards.scss
@@ -104,6 +104,13 @@
         border: $card-figcaption-button-border;
     }
 
+    .card-figcaption-body & {
+        &:focus {
+            background-color: $card-figcaption-button-backgroundHover;
+            outline: revert;
+        }
+    }
+
     + .card-figcaption-button {
         margin: $card-figcaption-button-margin;
     }


### PR DESCRIPTION
#### What?

When card buttons in focus they becomes transparent and without outline. This styles we have from class .button. We can not remove this class, because it has styles from page bilder. So for now I override needed styles.

p.s. 
revert css value not supported in some browsers, such is ie 11 and opera. In this browsers focused buttons just will not be transparent. In other focused buttons will have default browser styles. In nearest future we will create our own Cornerstone focus styles with will work in all browsers. For now - just switching to default

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-191)

#### Screenshots (if appropriate)

![Screenshot 2020-08-28 at 12 31 51](https://user-images.githubusercontent.com/66325265/91547146-295cc580-e92c-11ea-9d4f-a41384452a1a.png)
