### PR TITLE
Bump stencil-utils to 6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigcommerce-cornerstone",
-  "version": "4.9.0",
+  "version": "4.10.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -927,13 +927,19 @@
       "dev": true
     },
     "@bigcommerce/stencil-utils": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-5.0.3.tgz",
-      "integrity": "sha512-GGbBRl+krY7SIyqWv+Ey/vqIbehX0DAXoSLxH47mVX89yuZNUAzyhTpLG/G6gJHflbdYjbanQ8UJMzMUU04fKA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-6.0.0.tgz",
+      "integrity": "sha512-RgcM+LslcAO/fPyR7daEnbSAz2s3q44a5BgUKN7GHPH2wXRtJEX1JISxKKnccs3ZMnxSV/V+1oboCPlJX9HUzg==",
       "requires": {
-        "eventemitter2": "^0.4.14",
-        "jquery": "^3.4.1",
-        "query-string": "^5.0.0"
+        "eventemitter3": "^4.0.4",
+        "whatwg-fetch": "^3.4.0"
+      },
+      "dependencies": {
+        "whatwg-fetch": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz",
+          "integrity": "sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ=="
+        }
       }
     },
     "@cnakazawa/watch": {
@@ -4113,7 +4119,8 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -5284,7 +5291,13 @@
     "eventemitter2": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "events": {
       "version": "3.2.0",
@@ -10626,7 +10639,7 @@
       }
     },
     "jstree": {
-      "version": "github:vakata/jstree#19bad17697386873b8643e89e1c157238a9dc3f4",
+      "version": "github:vakata/jstree#308b85722d86294f1504eca2cec475e6f73b3e13",
       "from": "github:vakata/jstree",
       "requires": {
         "jquery": ">=1.9.1"
@@ -16026,7 +16039,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -16809,16 +16823,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
-    },
-    "query-string": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -18585,11 +18589,6 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
-    },
-    "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-length": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "BigCommerce",
   "license": "MIT",
   "dependencies": {
-    "@bigcommerce/stencil-utils": "^5.0.3",
+    "@bigcommerce/stencil-utils": "^6.0.0",
     "core-js": "^3.6.5",
     "creditcards": "^3.0.1",
     "easyzoom": "^2.5.3",


### PR DESCRIPTION
#### What?

Bump stencil-utils to 6.0.0.

This version of utils gets rid of jquery, and as a result contains significant changes to the event system. It'll need thorough testing, and we might even consider it a major release of Cornerstone as a result (CC @bc-as )
