### PR TITLE
feature(storefront): BCTHEME-196 Create unified focus styling in Cornerstone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Draft
+- Review link in quick modal focused twice. [#1797](https://github.com/bigcommerce/cornerstone/pull/1797)
+- Fixed product image doesn't change on click when viewing a product with multiple images in IE11 [#1748](https://github.com/bigcommerce/cornerstone/pull/1748)
+- Fixed alt text on image change in product view [#1747](https://github.com/bigcommerce/cornerstone/pull/1747)
 - Added tooltip for modal close buttons. [#1773](https://github.com/bigcommerce/cornerstone/pull/1773)
 - Carousel links should have discernible text. [#1789](https://github.com/bigcommerce/cornerstone/pull/1789)
 - Add labels to swatches. [#1761](https://github.com/bigcommerce/cornerstone/pull/1761)

--- a/assets/js/theme/product/image-gallery.js
+++ b/assets/js/theme/product/image-gallery.js
@@ -61,6 +61,8 @@ export default class ImageGallery {
     }
 
     swapMainImage() {
+        const isBrowserIE = navigator.userAgent.includes('Trident');
+
         this.easyzoom.data('easyZoom').swap(
             this.currentImage.mainImageUrl,
             this.currentImage.zoomImageUrl,
@@ -74,6 +76,18 @@ export default class ImageGallery {
             alt: this.currentImage.mainImageAlt,
             title: this.currentImage.mainImageAlt,
         });
+
+        if (isBrowserIE) {
+            const fallbackStylesIE = {
+                'background-image': `url(${this.currentImage.mainImageUrl}&ampimbypass=on)`,
+                'background-position': 'center',
+                'background-repeat': 'no-repeat',
+                'background-origin': 'content-box',
+                'background-size': 'contain',
+            };
+
+            this.$mainImageNested.css(fallbackStylesIE);
+        }
     }
 
     checkImage() {

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -122,6 +122,7 @@
 
 .productView-details {
     margin-bottom: spacing("single") + spacing("third");
+    overflow: hidden; // for Androind Chrome horizontal scroll fix
 }
 
 
@@ -197,20 +198,17 @@
 
 .productView-reviewLink {
     display: inline-block;
-    margin-left: spacing("half");
+    margin-left: spacing("quarter");
     vertical-align: middle;
+    color: stencilColor("color-textSecondary");
+
+    // scss-lint:disable NestingDepth
+    &:hover {
+        color: stencilColor("color-textSecondary--hover");
+    }
 
     &--new {
         padding: 0;
-    }
-
-    > a {
-        color: stencilColor("color-textSecondary");
-
-        // scss-lint:disable NestingDepth
-        &:hover {
-            color: stencilColor("color-textSecondary--hover");
-        }
     }
 }
 
@@ -281,7 +279,6 @@
     @include clearfix;
     margin-bottom: spacing("single");
     text-align: center;
-    overflow: hidden; // for Androind Chrome horizontal scroll fix
 
     @include breakpoint("small") {
         text-align: left;

--- a/assets/scss/components/stencil/search/_search.scss
+++ b/assets/scss/components/stencil/search/_search.scss
@@ -96,8 +96,4 @@
 
 .search-nav {
     position: relative;
-
-    .search-tabs-widget-description {
-        @include ariaDescribeElement
-    }
 }

--- a/assets/scss/tools/_aria.scss
+++ b/assets/scss/tools/_aria.scss
@@ -1,0 +1,11 @@
+.aria-description {
+    &--hidden {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 1px;
+        width: 1px;
+        overflow: hidden;
+        margin-left: -10000px;
+    }
+}

--- a/assets/scss/tools/_mixins.scss
+++ b/assets/scss/tools/_mixins.scss
@@ -1,9 +1,0 @@
-@mixin ariaDescribeElement {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 1px;
-    width: 1px;
-    overflow: hidden;    
-    margin-left: -10000px;
-}

--- a/assets/scss/tools/_theme-focus.scss
+++ b/assets/scss/tools/_theme-focus.scss
@@ -1,0 +1,29 @@
+// =============================================================================
+// THEME FOCUS (global)
+// =============================================================================
+
+$outline-width:  2px;
+$outline-style:  solid;
+$outline-color:  #2E8FFF;
+$outline-offset: 1px;
+
+input,
+button,
+textarea,
+select,
+details,
+[href],
+[tabindex]:not([tabindex="-1"]),
+[contenteditable="true"] {        
+    &:focus {
+        outline: $outline-width $outline-style $outline-color !important;
+        outline-offset: $outline-offset !important;        
+    }
+}
+
+label {
+    input:focus + & {
+        outline: $outline-width $outline-style $outline-color !important;
+        outline-offset: $outline-offset !important;        
+    }
+}

--- a/assets/scss/tools/_tools.scss
+++ b/assets/scss/tools/_tools.scss
@@ -1,4 +1,5 @@
 @import "list";
 @import "string";
 @import "image";
-@import "mixins";
+@import "theme-focus";
+@import "aria";

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Cornerstone",
-  "version": "4.9.0",
+  "version": "4.10.0-rc.1",
   "meta": {
     "price": 0,
     "documentation_url": "https://support.bigcommerce.com/articles/Public/Cornerstone-Theme-Manual",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bigcommerce-cornerstone",
   "description": "The BigCommerce reference theme for the Stencil platform",
-  "version": "4.9.0",
+  "version": "4.10.0-rc.1",
   "private": true,
   "author": "BigCommerce",
   "license": "MIT",

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -98,29 +98,25 @@
                     {{/if}}
                     <span title="{{lang 'products.reviews.rating_aria_label' current_rating=product.rating max_rating=5}}"
                           tabindex="0"
-                          role="text"
                     >
                         {{> components/products/ratings rating=product.rating}}
                     </span>
-                    <span class="productView-reviewLink">
-                        {{#if product.num_reviews '>' 0}}
-                            <a href="{{product.url}}#product-reviews">
-                                {{lang 'products.reviews.link_to_review' total=product.num_reviews}}
-                            </a>
-                        {{else}}
+                    {{#if product.num_reviews '>' 0}}
+                        <a href="{{product.url}}#product-reviews" class=" ">
                             {{lang 'products.reviews.link_to_review' total=product.num_reviews}}
-                        {{/if}}
-                    </span>
+                        </a>
+                    {{else}}
+                        <span>{{lang 'products.reviews.link_to_review' total=product.num_reviews}}</span>
+                    {{/if}}
                 {{/if}}
                 {{#if settings.show_product_reviews}}
-                    <button class="productView-reviewLink productView-reviewLink--new">
-                        <a href="{{product.url}}{{#if is_ajax}}#write_review{{/if}}"
-                           {{#unless is_ajax}}data-reveal-id="modal-review-form"{{/unless}}
-                           role="button"
-                        >
-                           {{lang 'products.reviews.new'}}
-                        </a>
-                    </button>
+                    <a href="{{product.url}}{{#if is_ajax}}#write_review{{/if}}"
+                       class="productView-reviewLink productView-reviewLink--new"
+                       {{#unless is_ajax}}data-reveal-id="modal-review-form"{{/unless}}
+                       role="button"
+                    >
+                       {{lang 'products.reviews.new'}}
+                    </a>
                     {{> components/products/modals/writeReview}}
                 {{/if}}
             </div>

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -22,7 +22,7 @@ product_results:
         </div>
     {{/if}}
     <nav class="navBar navBar--sub search-nav">
-        <span id="search-tabs-widget-description" class="search-tabs-widget-description">
+        <span id="search-tabs-widget-description" class="aria-description--hidden">
             {{lang 'search.tabs_accesibility_hint'}}
         </span>
         <ul role="tablist" class="navBar-section account-navigation" data-search-page-tabs>


### PR DESCRIPTION
#### What?

Fixed next group of issues:
https://jira.bigcommerce.com/browse/BCTHEME-177
https://jira.bigcommerce.com/browse/BCTHEME-180
https://jira.bigcommerce.com/browse/BCTHEME-181
https://jira.bigcommerce.com/browse/BCTHEME-183

I took Chrome focus styles as a base and set closest color for outline. This color is acceptable for dark and light themes (look screenshots)
We can use such focus styles as base and update it for custom cases if we will need

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-196)

#### Screenshots (if appropriate)
dark theme contrast
![dark_theme_contrast](https://user-images.githubusercontent.com/66325265/91826417-389e8480-ec46-11ea-98a4-3cb1061f44c0.png)

light theme contrast
![light_theme_contrast](https://user-images.githubusercontent.com/66325265/91826500-579d1680-ec46-11ea-8c93-9667bc7f1adc.png)

carousel button focus
![button_focus](https://user-images.githubusercontent.com/66325265/91826548-6b487d00-ec46-11ea-8334-610b4275c411.png)

carousel arrow_focus
![arrow_focus](https://user-images.githubusercontent.com/66325265/91826620-80bda700-ec46-11ea-81b7-50346253a321.png)

options focus
![options_focus](https://user-images.githubusercontent.com/66325265/91826684-992dc180-ec46-11ea-8b22-76ede0490a99.png)

cart buttons focus
![cart_focus](https://user-images.githubusercontent.com/66325265/91826735-a945a100-ec46-11ea-99fa-319cdf44ccbd.png)
