### PR TITLE
feature(storefront): BCTHEME-196 Create unified focus styling in Cornerstone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Create unified focus styling in Cornerstone. [#1812](https://github.com/bigcommerce/cornerstone/pull/1812)
 - Review link in quick modal focused twice. [#1797](https://github.com/bigcommerce/cornerstone/pull/1797)
 - Fixed product image doesn't change on click when viewing a product with multiple images in IE11 [#1748](https://github.com/bigcommerce/cornerstone/pull/1748)
 - Fixed alt text on image change in product view [#1747](https://github.com/bigcommerce/cornerstone/pull/1747)

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -121,7 +121,8 @@
 // -----------------------------------------------------------------------------
 
 .productView-details {
-    margin-bottom: spacing("single") + spacing("third");
+    padding-bottom: spacing("single") + spacing("third");
+    overflow: hidden; // for Androind Chrome horizontal scroll fix
 }
 
 
@@ -278,7 +279,6 @@
     @include clearfix;
     margin-bottom: spacing("single");
     text-align: center;
-    overflow: hidden; // for Androind Chrome horizontal scroll fix
 
     @include breakpoint("small") {
         text-align: left;

--- a/assets/scss/tools/_theme_focus.scss
+++ b/assets/scss/tools/_theme_focus.scss
@@ -1,0 +1,29 @@
+// =============================================================================
+// THEME FOCUS (global)
+// =============================================================================
+
+$outline-width:  2px;
+$outline-style:  solid;
+$outline-color:  #2E8FFF;
+$outline-offset: 1px;
+
+input,
+button,
+textarea,
+select,
+details,
+[href],
+[tabindex]:not([tabindex="-1"]),
+[contenteditable="true"] {        
+    &:focus {
+        outline: $outline-width $outline-style $outline-color !important;
+        outline-offset: $outline-offset !important;        
+    }
+}
+
+label {
+    input:focus + & {
+        outline: $outline-width $outline-style $outline-color !important;
+        outline-offset: $outline-offset !important;        
+    }
+}

--- a/assets/scss/tools/_tools.scss
+++ b/assets/scss/tools/_tools.scss
@@ -2,3 +2,4 @@
 @import "string";
 @import "image";
 @import "aria";
+@import "theme_focus";


### PR DESCRIPTION
#### What?

Fixed next group of issues:
https://jira.bigcommerce.com/browse/BCTHEME-177
https://jira.bigcommerce.com/browse/BCTHEME-180
https://jira.bigcommerce.com/browse/BCTHEME-181
https://jira.bigcommerce.com/browse/BCTHEME-183

https://jira.bigcommerce.com/browse/BCTHEME-182

I took Chrome focus styles as a base and changed it outline color for it to be acceptable for light and dark themes.
We can use this focus styles as a base and rewrite it for custom cases if we will need

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-196)

#### Screenshots (if appropriate)

light theme contrast
![light_theme_contrast](https://user-images.githubusercontent.com/66325265/91833734-c03cc100-ec4f-11ea-9295-08af1fd3c5c9.png)

dark theme contrast
![dark_theme_contrast](https://user-images.githubusercontent.com/66325265/91833772-cc288300-ec4f-11ea-957f-448ede75709a.png)

carousel arrows focus
![carousel_arrows_focus](https://user-images.githubusercontent.com/66325265/91833999-2295c180-ec50-11ea-83be-02e161bf947f.png)

carousel dots focus
![carousel_dots_focus](https://user-images.githubusercontent.com/66325265/91834129-4c4ee880-ec50-11ea-92bc-4dc45d649be2.png)

cart buttons focus
![cart_buttons_focus](https://user-images.githubusercontent.com/66325265/91834283-802a0e00-ec50-11ea-9f39-ecbc214e79b5.png)

options focus
![options_focus](https://user-images.githubusercontent.com/66325265/91834445-b8c9e780-ec50-11ea-93c3-761b63146b1d.png)
