### PR TITLE
fix(storefront): STRF-8599 Drop Jquery: Replaced event's current target to the element passed from utils(on hook)

### DIFF
--- a/assets/js/test-unit/theme/common/faceted-search.spec.js
+++ b/assets/js/test-unit/theme/common/faceted-search.spec.js
@@ -197,11 +197,11 @@ describe('FacetedSearch', () => {
     describe('when price range form is submitted', () => {
         let event;
         let eventName;
+        let currentTarget = '#facet-range-form';
 
         beforeEach(() => {
             eventName = 'facetedSearch-range-submitted';
             event = {
-                currentTarget: '#facet-range-form',
                 preventDefault: jest.fn(),
             };
 
@@ -210,7 +210,7 @@ describe('FacetedSearch', () => {
         });
 
         it('should set `min_price` and `max_price` query param to corresponding form values if form is valid', () => {
-            hooks.emit(eventName, event);
+            hooks.emit(eventName, event, currentTarget);
 
             expect(urlUtils.goToUrl).toHaveBeenCalledWith('/?min_price=0&max_price=100');
         });
@@ -232,20 +232,21 @@ describe('FacetedSearch', () => {
     describe('when price range form is submitted with other facets selected', () => {
         let event;
         let eventName;
+        let currentTarget;
 
         beforeEach(() => {
             eventName = 'facetedSearch-range-submitted';
             event = {
-                currentTarget: '#facet-range-form-with-other-facets',
                 preventDefault: jest.fn(),
             };
+            currentTarget = '#facet-range-form-with-other-facets';
 
             jest.spyOn(urlUtils, 'goToUrl').mockImplementation(() => {});
             jest.spyOn(facetedSearch.priceRangeValidator, 'areAll').mockImplementation(() => true);
         });
 
         it('send `min_price` and `max_price` query params if form is valid', () => {
-            hooks.emit(eventName, event);
+            hooks.emit(eventName, event, currentTarget);
 
             expect(urlUtils.goToUrl).toHaveBeenCalledWith('/?brand[]=item1&brand[]=item2&min_price=0&max_price=50');
         });
@@ -254,25 +255,26 @@ describe('FacetedSearch', () => {
     describe('when sort filter is submitted', () => {
         let event;
         let eventName;
+        let currentTarget;
 
         beforeEach(() => {
             eventName = 'sortBy-submitted';
             event = {
-                currentTarget: '#facet-sort',
                 preventDefault: jest.fn(),
             };
+            currentTarget = '#facet-sort';
 
             jest.spyOn(urlUtils, 'goToUrl').mockImplementation(() => {});
         });
 
         it('should set `sort` query param to the value of selected option', () => {
-            hooks.emit(eventName, event);
+            hooks.emit(eventName, event, currentTarget);
 
             expect(urlUtils.goToUrl).toHaveBeenCalledWith('/?sort=featured');
         });
 
         it('should prevent default event', function() {
-            hooks.emit(eventName, event);
+            hooks.emit(eventName, event, currentTarget);
 
             expect(event.preventDefault).toHaveBeenCalled();
         });
@@ -281,25 +283,26 @@ describe('FacetedSearch', () => {
     describe('when a facet is clicked', () => {
         let event;
         let eventName;
+        let currentTarget;
 
         beforeEach(() => {
             eventName = 'facetedSearch-facet-clicked';
             event = {
-                currentTarget: '[href="?brand=item1"]',
                 preventDefault: jest.fn(),
             };
+            currentTarget = '[href="?brand=item1"]';
 
             jest.spyOn(urlUtils, 'goToUrl').mockImplementation(() => {});
         });
 
         it('should change the URL of window to the URL of facet item', () => {
-            hooks.emit(eventName, event);
+            hooks.emit(eventName, event, currentTarget);
 
             expect(urlUtils.goToUrl).toHaveBeenCalledWith('?brand=item1');
         });
 
         it('should prevent default event', function() {
-            hooks.emit(eventName, event);
+            hooks.emit(eventName, event, currentTarget);
 
             expect(event.preventDefault).toHaveBeenCalled();
         });

--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -139,8 +139,8 @@ export default class Cart extends PageManager {
             this.bindGiftWrappingForm();
         });
 
-        utils.hooks.on('product-option-change', (event, option) => {
-            const $changedOption = $(option);
+        utils.hooks.on('product-option-change', (event, currentTarget) => {
+            const $changedOption = $(currentTarget);
             const $form = $changedOption.parents('form');
             const $submit = $('input.button', $form);
             const $messageBox = $('.alertMessageBox');

--- a/assets/js/theme/catalog.js
+++ b/assets/js/theme/catalog.js
@@ -3,9 +3,9 @@ import urlUtils from './common/utils/url-utils';
 import Url from 'url';
 
 export default class CatalogPage extends PageManager {
-    onSortBySubmit(event) {
+    onSortBySubmit(event, currentTarget) {
         const url = Url.parse(window.location.href, true);
-        const queryParams = $(event.currentTarget).serialize().split('=');
+        const queryParams = $(currentTarget).serialize().split('=');
 
         url.query[queryParams[0]] = queryParams[1];
         delete url.query.page;

--- a/assets/js/theme/common/faceted-search.js
+++ b/assets/js/theme/common/faceted-search.js
@@ -347,8 +347,8 @@ class FacetedSearch {
         this.toggleFacetItems($navList);
     }
 
-    onFacetClick(event) {
-        const $link = $(event.currentTarget);
+    onFacetClick(event, currentTarget) {
+        const $link = $(currentTarget);
         const url = $link.attr('href');
 
         event.preventDefault();
@@ -363,9 +363,9 @@ class FacetedSearch {
         }
     }
 
-    onSortBySubmit(event) {
+    onSortBySubmit(event, currentTarget) {
         const url = Url.parse(window.location.href, true);
-        const queryParams = $(event.currentTarget).serialize().split('=');
+        const queryParams = $(currentTarget).serialize().split('=');
 
         url.query[queryParams[0]] = queryParams[1];
         delete url.query.page;
@@ -379,7 +379,7 @@ class FacetedSearch {
         urlUtils.goToUrl(Url.format({ pathname: url.pathname, search: urlUtils.buildQueryString(urlQueryParams) }));
     }
 
-    onRangeSubmit(event) {
+    onRangeSubmit(event, currentTarget) {
         event.preventDefault();
 
         if (!this.priceRangeValidator.areAll(nod.constants.VALID)) {
@@ -387,7 +387,7 @@ class FacetedSearch {
         }
 
         const url = Url.parse(window.location.href, true);
-        let queryParams = decodeURI($(event.currentTarget).serialize()).split('&');
+        let queryParams = decodeURI($(currentTarget).serialize()).split('&');
         queryParams = urlUtils.parseQueryParams(queryParams);
 
         for (const key in queryParams) {

--- a/assets/js/theme/global/quick-search.js
+++ b/assets/js/theme/global/quick-search.js
@@ -39,8 +39,8 @@ export default function () {
         });
     }, 200);
 
-    utils.hooks.on('search-quick', (event) => {
-        const searchQuery = $(event.currentTarget).val();
+    utils.hooks.on('search-quick', (event, currentTarget) => {
+        const searchQuery = $(currentTarget).val();
 
         // server will only perform search with at least 3 characters
         if (searchQuery.length < 3) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigcommerce-cornerstone",
-  "version": "4.9.0",
+  "version": "4.10.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -927,13 +927,19 @@
       "dev": true
     },
     "@bigcommerce/stencil-utils": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-5.0.3.tgz",
-      "integrity": "sha512-GGbBRl+krY7SIyqWv+Ey/vqIbehX0DAXoSLxH47mVX89yuZNUAzyhTpLG/G6gJHflbdYjbanQ8UJMzMUU04fKA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-6.2.0.tgz",
+      "integrity": "sha512-20D0hVzrRrxOZhTA0GpZOr4GKNSVDQVVd5mb6QBCZ+YHb2kssQrmcbVRfFRSDaW+xjH1uz2mNZz30S3j8sAE3g==",
       "requires": {
-        "eventemitter2": "^0.4.14",
-        "jquery": "^3.4.1",
-        "query-string": "^5.0.0"
+        "eventemitter3": "^4.0.4",
+        "whatwg-fetch": "^3.4.0"
+      },
+      "dependencies": {
+        "whatwg-fetch": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
+          "integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
+        }
       }
     },
     "@cnakazawa/watch": {
@@ -4113,7 +4119,8 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -5284,7 +5291,13 @@
     "eventemitter2": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "events": {
       "version": "3.2.0",
@@ -16026,7 +16039,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -16809,16 +16823,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
-    },
-    "query-string": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -18585,11 +18589,6 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
-    },
-    "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-length": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "BigCommerce",
   "license": "MIT",
   "dependencies": {
-    "@bigcommerce/stencil-utils": "^5.0.3",
+    "@bigcommerce/stencil-utils": "^6.2.0",
     "core-js": "^3.6.5",
     "creditcards": "^3.0.1",
     "easyzoom": "^2.5.3",


### PR DESCRIPTION
…

#### What?

Changed the behaviour of the stencil utils event handlers. Target element is now taken not from event.currentTarget, but passed from the stencil-utils eventemitter.

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/STRF-8599

#### Screenshots (if appropriate)

Attach images or add image links here.

![Example Image](http://placehold.it/300x200)
