### PR TITLE
fix(storefront): BCTHEME-211 Cross icon on close button missalignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Cross icon on close button missalignment. [#1822](https://github.com/bigcommerce/cornerstone/pull/1822)
+
 ## Draft
 - Review link in quick modal focused twice. [#1797](https://github.com/bigcommerce/cornerstone/pull/1797)
 - Fixed product image doesn't change on click when viewing a product with multiple images in IE11 [#1748](https://github.com/bigcommerce/cornerstone/pull/1748)

--- a/assets/scss/components/foundation/modal/_modal.scss
+++ b/assets/scss/components/foundation/modal/_modal.scss
@@ -82,10 +82,6 @@
     }
 
     @include addFocusTooltip;
-
-    &__aria-text {
-        font-size: 0;
-    }
 }
 
 .modal-body {

--- a/templates/components/common/modal/modal-close-btn.html
+++ b/templates/components/common/modal/modal-close-btn.html
@@ -3,6 +3,6 @@
         title="{{lang 'common.close'}}"
         {{additional_attr}}
 >
-    <span class="modal-close__aria-text">{{lang 'common.close'}}</span>
+    <span class="aria-description--hidden">{{lang 'common.close'}}</span>
     <span aria-hidden="true">&#215;</span>
 </button>


### PR DESCRIPTION
#### What?

Cross icon is not on the center of button

#### Tickets / Documentation

[Jira Ticket](https://jira.bigcommerce.com/browse/BCTHEME-211)

#### Screenshots (if appropriate)

<img width="378" alt="Screenshot 2020-09-07 at 15 08 35" src="https://user-images.githubusercontent.com/66319629/92386319-4196c680-f11c-11ea-9142-4fae08c78c5a.png">
