### PR TITLE
Reduce lodash usage in compare-products.js and image-gallery.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Reduce lodash usage in compare-products.js and image-gallery.js [#1827](https://github.com/bigcommerce/cornerstone/pull/1827)
 - Fixed Product Image Carousel Becomes Responsiveness on Product Page. [#1879](https://github.com/bigcommerce/cornerstone/pull/1879)
 - Move phrases and static strings to en.json for improving translation customizing. [#1850](https://github.com/bigcommerce/cornerstone/pull/1850)
 - Update carousel images to improve LCP indicator from Lighthouse performance report. [#1876](https://github.com/bigcommerce/cornerstone/pull/1876)

--- a/assets/js/theme/global/compare-products.js
+++ b/assets/js/theme/global/compare-products.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { showAlertModal } from './modal';
 
 function decrementCounter(counter, item) {
@@ -33,7 +32,7 @@ export default function (urlContext) {
     $('body').on('compareReset', () => {
         const $checked = $('body').find('input[name="products\[\]"]:checked');
 
-        compareCounter = $checked.length ? _.map($checked, element => element.value) : [];
+        compareCounter = $checked.length ? $checked.map((index, element) => element.value).get() : [];
         updateCounterNav(compareCounter, $compareLink, urlContext);
     });
 

--- a/assets/js/theme/product/image-gallery.js
+++ b/assets/js/theme/product/image-gallery.js
@@ -1,5 +1,4 @@
 import 'easyzoom';
-import _ from 'lodash';
 
 export default class ImageGallery {
     constructor($gallery) {
@@ -15,7 +14,7 @@ export default class ImageGallery {
     }
 
     setMainImage(imgObj) {
-        this.currentImage = _.clone(imgObj);
+        this.currentImage = { ...imgObj };
 
         this.setActiveThumb();
         this.swapMainImage();


### PR DESCRIPTION
#### What?

Reduce lodash usage (and bundle size) by utilizing the object spread operator to clone imgObj in image-gallery.js when setMainImage() runs.

**BEFORE**
<img width="2048" alt="01 before" src="https://user-images.githubusercontent.com/5056945/92505141-7d7f6980-f1b8-11ea-849b-0fc58cf13432.png">

**AFTER**
<img width="2048" alt="02 after" src="https://user-images.githubusercontent.com/5056945/92505148-82441d80-f1b8-11ea-9dd8-e54b4f3d4f5b.png">
