### PR TITLE
fix(storefront): BCTHEME-185 Sort By dropdowns need visual focus border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Sort By dropdowns need visual focus border. [#1833](https://github.com/bigcommerce/cornerstone/pull/1833)
+
 ## Draft
 - Create unified focus styling in Cornerstone. [#1812](https://github.com/bigcommerce/cornerstone/pull/1812)
 - Review link in quick modal focused twice. [#1797](https://github.com/bigcommerce/cornerstone/pull/1797)

--- a/assets/scss/components/citadel/actionBar/_actionBar.scss
+++ b/assets/scss/components/citadel/actionBar/_actionBar.scss
@@ -9,7 +9,6 @@
         background-color: $input-bg-color;
         border: $actionBar-form-field-border;
         border-radius: $actionBar-form-field-radius;
-        overflow: hidden;
 
         // scss-lint:disable NestingDepth
         &:hover {


### PR DESCRIPTION
#### What?

This PR has fix for selects styles for their outline on focus to be visible

#### Tickets / Documentation

[Ticket](https://jira.bigcommerce.com/browse/BCTHEME-185)

#### Screenshots (if appropriate)

sort-box.html
![category_page_select_focus](https://user-images.githubusercontent.com/66325265/92731334-9a18ce80-f37d-11ea-9dfa-34d9532c27e8.png)

content-sort-box.html
![search_page_select_focus](https://user-images.githubusercontent.com/66325265/92731373-a4d36380-f37d-11ea-8925-3f280424c98c.png)
