### PR TITLE
fix(storefront): STRF-8607 Unified browsers list that we support

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,1 @@
+>2%, last 2 versions, Firefox ESR

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,17 +1,18 @@
-module.exports = {
-    plugins: [
-        '@babel/plugin-syntax-dynamic-import', // add support for dynamic imports (used in app.js)
-        'lodash', // Tree-shake lodash
-    ],
-    presets: [
-        ['@babel/preset-env', {
-            //debug: true,
-            loose: true, // Enable "loose" transformations for any plugins in this preset that allow them
-            modules: 'auto',
-            useBuiltIns: 'usage', // Tree-shake babel-polyfill
-            targets: {
-                node: 'current',
-            },
-        }],
-    ],
-};
+module.exports = api => {
+    const targets = api.env('test') ? { targets: {  node: 'current' } } : null;
+    return {
+        plugins: [
+            '@babel/plugin-syntax-dynamic-import', // add support for dynamic imports (used in app.js)
+            'lodash', // Tree-shake lodash
+        ],
+        presets: [
+            ['@babel/preset-env', {
+                //debug: true,
+                loose: true, // Enable "loose" transformations for any plugins in this preset that allow them
+                modules: 'auto',
+                useBuiltIns: 'usage', // Tree-shake babel-polyfill
+                ...targets,
+            }],
+        ],
+    };
+}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -30,7 +30,6 @@ module.exports = {
                                 loose: true, // Enable "loose" transformations for any plugins in this preset that allow them
                                 modules: false, // Don't transform modules; needed for tree-shaking
                                 useBuiltIns: 'entry',
-                                targets: '> 1%, last 2 versions, Firefox ESR',
                                 corejs: '^3.6.5',
                             }],
                         ],


### PR DESCRIPTION
#### What?

Cornerstone had webpack config that overrides babel for the browsers list support. That list was updated to target the browsers, that are in the documentation 


#### Tickets / Documentation

https://support.bigcommerce.com/s/article/Themes-Supported-Browsers

#### Screenshots (if appropriate)

<img width="665" alt="Screenshot 2020-09-10 at 19 30 52" src="https://user-images.githubusercontent.com/68893868/92763385-2639ee80-f39c-11ea-9936-1bbaff4f476a.png">
