### PR TITLE
Refactor GitHub action for Bundle Test

### DIFF
--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [12.x]
+        node: [10.x]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -1,13 +1,14 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# This workflow will do a clean install of your theme's dependencies and attempt to bundle the theme with Stencil CLI. 
+# If the theme fails to bundle, you can review the error logs to find out why.
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+name: Theme Bundling Test
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
+  push:
+    branches: [ master, main ]
 
 jobs:
   build:
@@ -16,11 +17,19 @@ jobs:
 
     strategy:
       matrix:
-        node: [10.x]
+        node: [12.x]
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+
+    - name: Ruby Gem cache
+      uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
 
     - name: Setup Ruby 2.7
       uses: ruby/setup-ruby@v1.40.0
@@ -33,14 +42,22 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
 
+    - name: npm cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
     - name: Install Stencil CLI Dependency
       run: npm install -g @bigcommerce/stencil-cli
 
-    - name: Install Dependencies  
+    - name: Install Theme Dependencies
       run: npm ci
 
     - name: Grunt Check  
       run: npx grunt check
 
-    - name: Validate theme bundle
+    - name: Validate theme successfully bundles
       run: npx stencil bundle


### PR DESCRIPTION
Making a few improvements to the GitHub action which does a test bundle.

* Better docs/comments
* Better name
* Support "master" or "main" branch as new forks will use `main`
  * https://www.zdnet.com/article/github-to-replace-master-with-main-starting-next-month/
  * https://github.com/github/renaming
* ~Use node 12~ waiting for new version of CLI to release first
* Add both a ruby gem cache as well as an npm cache to speed things up (CLI install is most of the time spent currently)