### PR TITLE
fix(payments): INT-3211 Change width size for apple pay button

### DIFF
--- a/assets/scss/components/stencil/applePay/_applePay.scss
+++ b/assets/scss/components/stencil/applePay/_applePay.scss
@@ -7,7 +7,8 @@
     display: none;
     max-height: remCalc(64px);
     min-height: remCalc(32px);
-    min-width: remCalc(134px);
+    min-width: 90px;
+    width: 160px;
     padding: spacing("single");
     @if stencilString("applePay-button") == "white" {
         background-color: $applePay-white;
@@ -33,16 +34,13 @@
 .apple-pay-supported {
     .apple-pay-checkout-button {
         display: block;
-
-        @include breakpoint("small") {
-            display: inline-block;
-            float: right;
-        }
+        float: right;
     }
 }
 
 .previewCartCheckout {
     .apple-pay-checkout-button {
+        display: inline-block;
         float: none;
         margin-top: spacing("half");
     }


### PR DESCRIPTION
#### What?
Change the width size for apple pay button in order to avoid button size varies

#### Tickets / Documentation
[Ticket](https://jira.bigcommerce.com/browse/INT-3211)

#### Screenshots (if appropriate)

Desktop
<img width="397" alt="Screen Shot 2020-10-05 at 18 30 37" src="https://user-images.githubusercontent.com/69487179/95142481-68efac00-0739-11eb-912d-0b4fcefdcc8d.png">

Safari responsive mode emulating iPhone 8 Plus
<img width="397" alt="Screen Shot 2020-10-05 at 18 31 02" src="https://user-images.githubusercontent.com/69487179/95142500-7311aa80-0739-11eb-9a5b-a0b33cb88b81.png">
