### PR TITLE
Update GitHub Action to use Node 12

### DIFF
--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [10.x]
+        node: [12.x]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Node 12 is now supported for Stencil CLI, so we'll use it for this action going forward.