### PR TITLE
fix(storefront): BCTHEME-279 fix logo displaying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed Logo displaying on mobile. [#1865](https://github.com/bigcommerce/cornerstone/pull/1865)
 - Add Info and Add Coupon forms on Cart Page tabbable when hidden. [#1820](https://github.com/bigcommerce/cornerstone/pull/1820)
 - Fixed outline styles for breadcrumbs on focus state. [#1824](https://github.com/bigcommerce/cornerstone/pull/1824)
 - Fixed review rating icons focus border. [#1818](https://github.com/bigcommerce/cornerstone/pull/1818)

--- a/assets/scss/layouts/header/_header.scss
+++ b/assets/scss/layouts/header/_header.scss
@@ -12,6 +12,8 @@
 // 5. When logo size is set to "original", we don't have advance knowledge of the
 //    image size, so we can't use absolute positioning + padding to reserve space
 //    for lazy loading.
+// 6. When logo size is set to "original" and switch to mobile version, it keeps 
+//    content in center regardless its size.
 //
 // -----------------------------------------------------------------------------
 
@@ -86,6 +88,7 @@
         color: $storeName-color;
         height: inherit;
         display: flex;
+        justify-content: center; // 6
         align-items: center;
         margin: 0 auto;
         position: relative;


### PR DESCRIPTION
#### What?

This PR fixes issue with not optimised logo size and how it's been displayed on different Store versions.  When Logo is set to Origin and Mobile Store in use Logo is moved to flex-start position. The problem is related only for origin size since image has different css class in this case `.header-logo-image-unknown-size`. Due to using of flexbox we can fix this with its properties.

Origin ticket has been also opened in terms of overlapping Navigation Menu while using specific (custom) size Logo. It's been fixed earlier thanks to @yurytut1993 on [PR#1800](https://github.com/bigcommerce/cornerstone/pull/1800).Pics are attached.
#### Tickets / Documentation

- [BCTHEME-279](https://jira.bigcommerce.com/browse/BCTHEME-279)


#### Screenshots (if appropriate)

Attach images or add image links here.

<img width="1679" alt="Logo Origin Mobile After" src="https://user-images.githubusercontent.com/67792608/95315044-ad468d80-089a-11eb-823a-fffbf1ea20c9.png">
<img width="1679" alt="Logo Origin Mobile Before" src="https://user-images.githubusercontent.com/67792608/95315051-af105100-089a-11eb-8c8e-18c5ff24542e.png">
<img width="1679" alt="Logo Custom Size  Before" src="https://user-images.githubusercontent.com/67792608/95315529-4a092b00-089b-11eb-8e1d-c90522f410ed.png">
<img width="1679" alt="Logo Custom Size After" src="https://user-images.githubusercontent.com/67792608/95315541-4c6b8500-089b-11eb-95a6-3a428d94ed08.png">

