### PR TITLE
fix(storefront): BCTHEME-277 Certain Special Characters not rendering…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed Special Characters rendering under Wishlists. [#1873](https://github.com/bigcommerce/cornerstone/pull/1873)
 - Unified browsers list that we support. [#1836](https://github.com/bigcommerce/cornerstone/pull/1836)
 - Bump stencil utils and update hooks to account for refactor to drop Jquery in stencil utils [#1821](https://github.com/bigcommerce/cornerstone/pull/1821)
 

--- a/templates/components/account/wishlist-list.html
+++ b/templates/components/account/wishlist-list.html
@@ -10,7 +10,7 @@
     <tbody class="table-tbody">
     {{#each customer.wishlists}}
         <tr>
-            <td><a href="{{view_url}}">{{name}}</a></td>
+            <td><a href="{{view_url}}">{{{name}}}</a></td>
             <td>{{num_items}}</td>
             <td>
                 {{#if is_public }}


### PR DESCRIPTION
… under Wishlists

#### What?

it is being reported that not all special characters display correctly when creating a wishlist.

#### Tickets / Documentation

[Jira Ticket](https://jira.bigcommerce.com/browse/BCTHEME-277)

#### Screenshots (if appropriate)

<img width="1332" alt="Screenshot 2020-10-13 at 16 51 00" src="https://user-images.githubusercontent.com/66319629/95869665-4c282980-0d74-11eb-9382-75974c8bafa3.png">
