### PR TITLE
Upload bundle analysis as part of github action

### DIFF
--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -67,4 +67,10 @@ jobs:
       with:
         name: Bundled Theme
         path: bundle.zip
+        
+    - name: Upload bundle analysis
+      uses: actions/upload-artifact@v2
+      with:
+        name: Webpack Analysis
+        path: assets/dist/report.html
 


### PR DESCRIPTION
#### What?

Upload the analysis HTML file from Webpack Bundle Analyzer when PRs are reviewed, to make it easier to review the results for each change.
