### PR TITLE
fix(storefront): BCTHEME-308 HTML Entity displayed as is via system/e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- HTML Entity displayed as is via system/error message on a Storefront. [#1888](https://github.com/bigcommerce/cornerstone/pull/1888)
+
 ## Draft
 - Reduce lodash usage in compare-products.js and image-gallery.js [#1827](https://github.com/bigcommerce/cornerstone/pull/1827)
 - Fixed Product Image Carousel Becomes Responsiveness on Product Page. [#1879](https://github.com/bigcommerce/cornerstone/pull/1879)

--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -304,7 +304,7 @@ export default class Cart extends PageManager {
                     this.refreshContent();
                 } else {
                     swal.fire({
-                        text: response.data.errors.join('\n'),
+                        html: response.data.errors.join('\n'),
                         icon: 'error',
                     });
                 }
@@ -348,7 +348,7 @@ export default class Cart extends PageManager {
                     this.refreshContent();
                 } else {
                     swal.fire({
-                        text: resp.data.errors.join('\n'),
+                        html: resp.data.errors.join('\n'),
                         icon: 'error',
                     });
                 }


### PR DESCRIPTION
…rror message on a Storefront

#### What?

Reserved characters in HTML don’t replace with character entities for Add Coupon and GIft Certificate error alerts

#### Tickets / Documentation

[Jira ticket](https://jira.bigcommerce.com/browse/BCTHEME-308)

#### Screenshots (if appropriate)

<img width="652" alt="Screenshot 2020-10-29 at 16 37 18" src="https://user-images.githubusercontent.com/66319629/97588321-0c647180-1a05-11eb-8c60-4a861d992db2.png">
<img width="665" alt="Screenshot 2020-10-29 at 16 37 25" src="https://user-images.githubusercontent.com/66319629/97588328-0cfd0800-1a05-11eb-9c1d-317481bed17d.png">

