### PR TITLE
STRF-8747: add new stencil config files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 .stencil
+config.stencil.json
+secrets.stencil.json
 .DS_Store
 assets/css-artifacts
 assets/js/bundle.js


### PR DESCRIPTION
#### What?

In https://github.com/bigcommerce/stencil-cli/pull/662 we split the `.stencil` file into 2 separate config files, so I added these files to .gitignore here.

#### Tickets / Documentation

STRF-8747