### PR TITLE
Hide social sharing icons from quick view

### DIFF
--- a/assets/js/theme/global/quick-view.js
+++ b/assets/js/theme/global/quick-view.js
@@ -24,9 +24,6 @@ export default function (context) {
 
             modal.setupFocusableElements(modalTypes.QUICK_VIEW);
 
-            // eslint-disable-next-line no-undef
-            addthis.toolbox('.addthis_toolbox');
-
             return new ProductDetails(modal.$content.find('.quickView'), context);
         });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigcommerce-cornerstone",
-  "version": "4.12.0-rc.4",
+  "version": "4.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3342,7 +3342,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -10142,7 +10143,7 @@
       }
     },
     "jstree": {
-      "version": "github:vakata/jstree#acb4e5c30a9c1643b854f508e464794ac30a89f2",
+      "version": "github:vakata/jstree#308b85722d86294f1504eca2cec475e6f73b3e13",
       "from": "github:vakata/jstree",
       "requires": {
         "jquery": ">=1.9.1"
@@ -11175,7 +11176,8 @@
       "dependencies": {
         "ansi-align": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "dev": true,
           "requires": {
             "string-width": "^2.0.0"
@@ -11183,12 +11185,14 @@
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -11196,12 +11200,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "boxen": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
           "dev": true,
           "requires": {
             "ansi-align": "^2.0.0",
@@ -11215,7 +11221,8 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -11224,22 +11231,26 @@
         },
         "builtins": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "capture-stack-trace": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
           "dev": true
         },
         "chalk": {
           "version": "2.4.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -11249,17 +11260,20 @@
         },
         "ci-info": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
           "dev": true
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
           "dev": true
         },
         "cliui": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
             "string-width": "^2.1.1",
@@ -11269,12 +11283,14 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "color-convert": {
           "version": "1.9.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
           "dev": true,
           "requires": {
             "color-name": "1.1.3"
@@ -11282,17 +11298,20 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "configstore": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
           "dev": true,
           "requires": {
             "dot-prop": "^4.1.0",
@@ -11305,7 +11324,8 @@
         },
         "create-error-class": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
           "dev": true,
           "requires": {
             "capture-stack-trace": "^1.0.0"
@@ -11313,7 +11333,8 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -11323,22 +11344,26 @@
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true
         },
         "dot-prop": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
           "dev": true,
           "requires": {
             "is-obj": "^1.0.0"
@@ -11346,17 +11371,20 @@
         },
         "dotenv": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
           "dev": true
         },
         "duplexer3": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
           "dev": true
         },
         "end-of-stream": {
           "version": "1.4.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
           "dev": true,
           "requires": {
             "once": "^1.4.0"
@@ -11364,12 +11392,14 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -11383,7 +11413,8 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
@@ -11391,22 +11422,26 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "glob": {
           "version": "7.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -11419,7 +11454,8 @@
         },
         "global-dirs": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "dev": true,
           "requires": {
             "ini": "^1.3.4"
@@ -11427,7 +11463,8 @@
         },
         "got": {
           "version": "6.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
             "create-error-class": "^3.0.0",
@@ -11445,32 +11482,38 @@
         },
         "graceful-fs": {
           "version": "4.2.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.8.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
           "dev": true
         },
         "import-lazy": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -11479,22 +11522,26 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true
         },
         "invert-kv": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
           "dev": true
         },
         "is-ci": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
           "dev": true,
           "requires": {
             "ci-info": "^1.5.0"
@@ -11502,12 +11549,14 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "dev": true,
           "requires": {
             "global-dirs": "^0.1.0",
@@ -11516,17 +11565,20 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
           "dev": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
           "dev": true
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "dev": true,
           "requires": {
             "path-is-inside": "^1.0.1"
@@ -11534,27 +11586,32 @@
         },
         "is-redirect": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
           "dev": true
         },
         "is-retry-allowed": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "latest-version": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "dev": true,
           "requires": {
             "package-json": "^4.0.0"
@@ -11562,7 +11619,8 @@
         },
         "lcid": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
             "invert-kv": "^2.0.0"
@@ -11570,7 +11628,8 @@
         },
         "libnpx": {
           "version": "10.2.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ujaYToga1SAX5r7FU5ShMFi88CWpY75meNZtr6RtEyv4l2ZK3+Wgvxq2IqlwWBiDZOqhumdeiocPS1aKrCMe3A==",
           "dev": true,
           "requires": {
             "dotenv": "^5.0.1",
@@ -11585,7 +11644,8 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -11594,12 +11654,14 @@
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -11608,7 +11670,8 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "dev": true,
           "requires": {
             "pify": "^3.0.0"
@@ -11616,7 +11679,8 @@
         },
         "map-age-cleaner": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
           "dev": true,
           "requires": {
             "p-defer": "^1.0.0"
@@ -11624,7 +11688,8 @@
         },
         "mem": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
           "dev": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
@@ -11634,12 +11699,14 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -11647,17 +11714,20 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "nice-try": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
           "dev": true
         },
         "npm": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-pt5ClxEmY/dLpb60SmGQQBKi3nB6Ljx1FXmpoCUdAULlGqGVn2uCyXxPCWFbcuHGthT7qGiaGa1wOfs/UjGYMw==",
           "dev": true,
           "requires": {
             "JSONStream": "~1.3.1",
@@ -11760,7 +11830,8 @@
           "dependencies": {
             "JSONStream": {
               "version": "1.3.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
               "dev": true,
               "requires": {
                 "jsonparse": "^1.2.0",
@@ -11769,54 +11840,64 @@
               "dependencies": {
                 "jsonparse": {
                   "version": "1.3.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
                   "dev": true
                 },
                 "through": {
                   "version": "2.3.8",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
                   "dev": true
                 }
               }
             },
             "abbrev": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
               "dev": true
             },
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "ansicolors": {
               "version": "0.3.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
               "dev": true
             },
             "ansistyles": {
               "version": "0.1.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
               "dev": true
             },
             "aproba": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
               "dev": true
             },
             "archy": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
               "dev": true
             },
             "bluebird": {
               "version": "3.5.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
               "dev": true
             },
             "cacache": {
               "version": "9.2.9",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
               "dev": true,
               "requires": {
                 "bluebird": "^3.5.0",
@@ -11836,7 +11917,8 @@
               "dependencies": {
                 "lru-cache": {
                   "version": "4.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
                   "dev": true,
                   "requires": {
                     "pseudomap": "^1.0.2",
@@ -11845,36 +11927,42 @@
                   "dependencies": {
                     "pseudomap": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
                       "dev": true
                     },
                     "yallist": {
                       "version": "2.1.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
                       "dev": true
                     }
                   }
                 },
                 "y18n": {
                   "version": "3.2.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
                   "dev": true
                 }
               }
             },
             "call-limit": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o=",
               "dev": true
             },
             "chownr": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
               "dev": true
             },
             "cmd-shim": {
               "version": "2.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -11883,7 +11971,8 @@
             },
             "columnify": {
               "version": "1.5.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
               "dev": true,
               "requires": {
                 "strip-ansi": "^3.0.0",
@@ -11892,7 +11981,8 @@
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
@@ -11900,14 +11990,16 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                       "dev": true
                     }
                   }
                 },
                 "wcwidth": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
                   "dev": true,
                   "requires": {
                     "defaults": "^1.0.3"
@@ -11915,7 +12007,8 @@
                   "dependencies": {
                     "defaults": {
                       "version": "1.0.3",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                       "dev": true,
                       "requires": {
                         "clone": "^1.0.2"
@@ -11923,7 +12016,8 @@
                       "dependencies": {
                         "clone": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
                           "dev": true
                         }
                       }
@@ -11934,7 +12028,8 @@
             },
             "config-chain": {
               "version": "1.1.11",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
               "dev": true,
               "requires": {
                 "ini": "^1.3.4",
@@ -11943,24 +12038,28 @@
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
                   "dev": true
                 }
               }
             },
             "debuglog": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
               "dev": true
             },
             "detect-indent": {
               "version": "5.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
               "dev": true
             },
             "dezalgo": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
               "dev": true,
               "requires": {
                 "asap": "^2.0.0",
@@ -11969,19 +12068,22 @@
               "dependencies": {
                 "asap": {
                   "version": "2.0.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
                   "dev": true
                 }
               }
             },
             "editor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
               "dev": true
             },
             "fs-vacuum": {
               "version": "1.2.10",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -11991,7 +12093,8 @@
             },
             "fs-write-stream-atomic": {
               "version": "1.0.10",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -12002,7 +12105,8 @@
             },
             "fstream": {
               "version": "1.0.11",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -12013,7 +12117,8 @@
             },
             "fstream-npm": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-iBHpm/LmD1qw0TlHMAqVd9rwdU6M+EHRUnPkXpRi5G/Hf0FIFH+oZFryodAU2MFNfGRh/CzhUFlMKV3pdeOTDw==",
               "dev": true,
               "requires": {
                 "fstream-ignore": "^1.0.0",
@@ -12022,7 +12127,8 @@
               "dependencies": {
                 "fstream-ignore": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
                   "dev": true,
                   "requires": {
                     "fstream": "^1.0.0",
@@ -12032,7 +12138,8 @@
                   "dependencies": {
                     "minimatch": {
                       "version": "3.0.4",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                       "dev": true,
                       "requires": {
                         "brace-expansion": "^1.1.7"
@@ -12040,7 +12147,8 @@
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.8",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                           "dev": true,
                           "requires": {
                             "balanced-match": "^1.0.0",
@@ -12049,12 +12157,14 @@
                           "dependencies": {
                             "balanced-match": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                               "dev": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                               "dev": true
                             }
                           }
@@ -12067,7 +12177,8 @@
             },
             "glob": {
               "version": "7.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "dev": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
@@ -12080,12 +12191,14 @@
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                   "dev": true
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
@@ -12093,7 +12206,8 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "dev": true,
                       "requires": {
                         "balanced-match": "^1.0.0",
@@ -12102,12 +12216,14 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "dev": true
                         }
                       }
@@ -12116,39 +12232,46 @@
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                   "dev": true
                 }
               }
             },
             "graceful-fs": {
               "version": "4.1.11",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
               "dev": true
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true
             },
             "hosted-git-info": {
               "version": "2.5.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             },
             "imurmurhash": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
               "dev": true
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "requires": {
                 "once": "^1.3.0",
@@ -12157,17 +12280,20 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true
             },
             "ini": {
               "version": "1.3.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
               "dev": true
             },
             "init-package-json": {
               "version": "1.10.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o=",
               "dev": true,
               "requires": {
                 "glob": "^7.1.1",
@@ -12182,7 +12308,8 @@
               "dependencies": {
                 "promzard": {
                   "version": "0.3.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
                   "dev": true,
                   "requires": {
                     "read": "1"
@@ -12192,22 +12319,26 @@
             },
             "lazy-property": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
               "dev": true
             },
             "lockfile": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k=",
               "dev": true
             },
             "lodash._baseindexof": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
               "dev": true
             },
             "lodash._baseuniq": {
               "version": "4.6.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
               "dev": true,
               "requires": {
                 "lodash._createset": "~4.0.0",
@@ -12216,29 +12347,34 @@
               "dependencies": {
                 "lodash._createset": {
                   "version": "4.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
                   "dev": true
                 },
                 "lodash._root": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
                   "dev": true
                 }
               }
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
               "dev": true
             },
             "lodash._cacheindexof": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
               "dev": true
             },
             "lodash._createcache": {
               "version": "3.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
               "dev": true,
               "requires": {
                 "lodash._getnative": "^3.0.0"
@@ -12246,37 +12382,44 @@
             },
             "lodash._getnative": {
               "version": "3.9.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
               "dev": true
             },
             "lodash.clonedeep": {
               "version": "4.5.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
               "dev": true
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
               "dev": true
             },
             "lodash.union": {
               "version": "4.6.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
               "dev": true
             },
             "lodash.uniq": {
               "version": "4.5.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
               "dev": true
             },
             "lodash.without": {
               "version": "4.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
               "dev": true
             },
             "lru-cache": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
               "dev": true,
               "requires": {
                 "pseudomap": "^1.0.2",
@@ -12285,19 +12428,22 @@
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
                   "dev": true
                 },
                 "yallist": {
                   "version": "2.1.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
                   "dev": true
                 }
               }
             },
             "mississippi": {
               "version": "1.3.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
               "dev": true,
               "requires": {
                 "concat-stream": "^1.5.0",
@@ -12314,7 +12460,8 @@
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
                   "dev": true,
                   "requires": {
                     "inherits": "^2.0.3",
@@ -12324,14 +12471,16 @@
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                       "dev": true
                     }
                   }
                 },
                 "duplexify": {
                   "version": "3.5.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
                   "dev": true,
                   "requires": {
                     "end-of-stream": "1.0.0",
@@ -12342,7 +12491,8 @@
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
                       "dev": true,
                       "requires": {
                         "once": "~1.3.0"
@@ -12350,7 +12500,8 @@
                       "dependencies": {
                         "once": {
                           "version": "1.3.3",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                           "dev": true,
                           "requires": {
                             "wrappy": "1"
@@ -12360,14 +12511,16 @@
                     },
                     "stream-shift": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                       "dev": true
                     }
                   }
                 },
                 "end-of-stream": {
                   "version": "1.4.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                   "dev": true,
                   "requires": {
                     "once": "^1.4.0"
@@ -12375,7 +12528,8 @@
                 },
                 "flush-write-stream": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
                   "dev": true,
                   "requires": {
                     "inherits": "^2.0.1",
@@ -12384,7 +12538,8 @@
                 },
                 "from2": {
                   "version": "2.3.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
                   "dev": true,
                   "requires": {
                     "inherits": "^2.0.1",
@@ -12393,7 +12548,8 @@
                 },
                 "parallel-transform": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
                   "dev": true,
                   "requires": {
                     "cyclist": "~0.2.2",
@@ -12403,14 +12559,16 @@
                   "dependencies": {
                     "cyclist": {
                       "version": "0.2.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
                       "dev": true
                     }
                   }
                 },
                 "pump": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
                   "dev": true,
                   "requires": {
                     "end-of-stream": "^1.1.0",
@@ -12419,7 +12577,8 @@
                 },
                 "pumpify": {
                   "version": "1.3.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
                   "dev": true,
                   "requires": {
                     "duplexify": "^3.1.2",
@@ -12429,7 +12588,8 @@
                 },
                 "stream-each": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
                   "dev": true,
                   "requires": {
                     "end-of-stream": "^1.1.0",
@@ -12438,14 +12598,16 @@
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                       "dev": true
                     }
                   }
                 },
                 "through2": {
                   "version": "2.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
                   "dev": true,
                   "requires": {
                     "readable-stream": "^2.1.5",
@@ -12454,7 +12616,8 @@
                   "dependencies": {
                     "xtend": {
                       "version": "4.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                       "dev": true
                     }
                   }
@@ -12463,7 +12626,8 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "requires": {
                 "minimist": "0.0.8"
@@ -12471,14 +12635,16 @@
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                   "dev": true
                 }
               }
             },
             "move-concurrently": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
               "dev": true,
               "requires": {
                 "aproba": "^1.1.1",
@@ -12491,7 +12657,8 @@
               "dependencies": {
                 "copy-concurrently": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Rft4ZiSaHKiJqlcI5svSc+dbslA=",
                   "dev": true,
                   "requires": {
                     "aproba": "^1.1.1",
@@ -12504,7 +12671,8 @@
                 },
                 "run-queue": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
                   "dev": true,
                   "requires": {
                     "aproba": "^1.1.1"
@@ -12514,7 +12682,8 @@
             },
             "node-gyp": {
               "version": "3.6.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
               "dev": true,
               "requires": {
                 "fstream": "^1.0.0",
@@ -12534,7 +12703,8 @@
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
@@ -12542,7 +12712,8 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "dev": true,
                       "requires": {
                         "balanced-match": "^1.0.0",
@@ -12551,12 +12722,14 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "dev": true
                         }
                       }
@@ -12565,7 +12738,8 @@
                 },
                 "nopt": {
                   "version": "3.0.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
                   "dev": true,
                   "requires": {
                     "abbrev": "1"
@@ -12575,7 +12749,8 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "requires": {
                 "abbrev": "1",
@@ -12584,7 +12759,8 @@
             },
             "normalize-package-data": {
               "version": "2.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
               "dev": true,
               "requires": {
                 "hosted-git-info": "^2.1.4",
@@ -12595,7 +12771,8 @@
               "dependencies": {
                 "is-builtin-module": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                   "dev": true,
                   "requires": {
                     "builtin-modules": "^1.0.0"
@@ -12603,7 +12780,8 @@
                   "dependencies": {
                     "builtin-modules": {
                       "version": "1.1.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
                       "dev": true
                     }
                   }
@@ -12612,12 +12790,14 @@
             },
             "npm-cache-filename": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
               "dev": true
             },
             "npm-install-checks": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
               "dev": true,
               "requires": {
                 "semver": "^2.3.0 || 3.x || 4 || 5"
@@ -12625,7 +12805,8 @@
             },
             "npm-package-arg": {
               "version": "5.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
               "dev": true,
               "requires": {
                 "hosted-git-info": "^2.4.2",
@@ -12636,7 +12817,8 @@
             },
             "npm-registry-client": {
               "version": "8.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-PVNfqq0lyRdFnE//nDmn3CC9uqTsr8Bya9KPLIevlXMfkP0m4RpCVyFFk0W1Gfx436kKwyhLA6J+lV+rgR81gQ==",
               "dev": true,
               "requires": {
                 "concat-stream": "^1.5.2",
@@ -12654,7 +12836,8 @@
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
                   "dev": true,
                   "requires": {
                     "inherits": "^2.0.3",
@@ -12664,7 +12847,8 @@
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                       "dev": true
                     }
                   }
@@ -12673,12 +12857,14 @@
             },
             "npm-user-validate": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
               "dev": true
             },
             "npmlog": {
               "version": "4.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "dev": true,
               "requires": {
                 "are-we-there-yet": "~1.1.2",
@@ -12689,7 +12875,8 @@
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
                   "dev": true,
                   "requires": {
                     "delegates": "^1.0.0",
@@ -12698,19 +12885,22 @@
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                       "dev": true
                     }
                   }
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                   "dev": true
                 },
                 "gauge": {
                   "version": "2.7.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                   "dev": true,
                   "requires": {
                     "aproba": "^1.0.3",
@@ -12725,17 +12915,20 @@
                   "dependencies": {
                     "object-assign": {
                       "version": "4.1.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                       "dev": true
                     },
                     "signal-exit": {
                       "version": "3.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                       "dev": true
                     },
                     "string-width": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
                       "requires": {
                         "code-point-at": "^1.0.0",
@@ -12745,12 +12938,14 @@
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                           "dev": true
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
                           "requires": {
                             "number-is-nan": "^1.0.0"
@@ -12758,7 +12953,8 @@
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                               "dev": true
                             }
                           }
@@ -12767,7 +12963,8 @@
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "dev": true,
                       "requires": {
                         "ansi-regex": "^2.0.0"
@@ -12775,14 +12972,16 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                           "dev": true
                         }
                       }
                     },
                     "wide-align": {
                       "version": "1.1.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
                       "dev": true,
                       "requires": {
                         "string-width": "^1.0.2"
@@ -12792,14 +12991,16 @@
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                   "dev": true
                 }
               }
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "requires": {
                 "wrappy": "1"
@@ -12807,12 +13008,14 @@
             },
             "opener": {
               "version": "1.4.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
               "dev": true
             },
             "osenv": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
               "dev": true,
               "requires": {
                 "os-homedir": "^1.0.0",
@@ -12821,19 +13024,22 @@
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                   "dev": true
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                   "dev": true
                 }
               }
             },
             "pacote": {
               "version": "2.7.38",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-XxHUyHQB7QCVBxoXeVu0yKxT+2PvJucsc0+1E+6f95lMUxEAYERgSAc71ckYXrYr35Ew3xFU/LrhdIK21GQFFA==",
               "dev": true,
               "requires": {
                 "bluebird": "^3.5.0",
@@ -12861,7 +13067,8 @@
               "dependencies": {
                 "make-fetch-happen": {
                   "version": "2.4.13",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-73CsTlMRSLdGr7VvOE8iYl/ejOSIxyfRYg7jZhepGGEqIlgdq6FLe2DEAI5bo813Jdg5fS/Ku62SRQ/UpT6NJA==",
                   "dev": true,
                   "requires": {
                     "agentkeepalive": "^3.3.0",
@@ -12879,7 +13086,8 @@
                   "dependencies": {
                     "agentkeepalive": {
                       "version": "3.3.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
                       "dev": true,
                       "requires": {
                         "humanize-ms": "^1.2.1"
@@ -12887,7 +13095,8 @@
                       "dependencies": {
                         "humanize-ms": {
                           "version": "1.2.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
                           "dev": true,
                           "requires": {
                             "ms": "^2.0.0"
@@ -12895,7 +13104,8 @@
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                               "dev": true
                             }
                           }
@@ -12904,12 +13114,14 @@
                     },
                     "http-cache-semantics": {
                       "version": "3.7.3",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-LzXFMuzSnx5UE7mvgztySjxvf3I=",
                       "dev": true
                     },
                     "http-proxy-agent": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
                       "dev": true,
                       "requires": {
                         "agent-base": "4",
@@ -12918,7 +13130,8 @@
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
                           "dev": true,
                           "requires": {
                             "es6-promisify": "^5.0.0"
@@ -12926,7 +13139,8 @@
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                               "dev": true,
                               "requires": {
                                 "es6-promise": "^4.0.3"
@@ -12934,7 +13148,8 @@
                               "dependencies": {
                                 "es6-promise": {
                                   "version": "4.1.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                                   "dev": true
                                 }
                               }
@@ -12943,7 +13158,8 @@
                         },
                         "debug": {
                           "version": "2.6.8",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                           "dev": true,
                           "requires": {
                             "ms": "2.0.0"
@@ -12951,7 +13167,8 @@
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                               "dev": true
                             }
                           }
@@ -12960,7 +13177,8 @@
                     },
                     "https-proxy-agent": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-/6pLb69YasNAwYoUBDHna31/KUQ=",
                       "dev": true,
                       "requires": {
                         "agent-base": "^4.1.0",
@@ -12969,7 +13187,8 @@
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
                           "dev": true,
                           "requires": {
                             "es6-promisify": "^5.0.0"
@@ -12977,7 +13196,8 @@
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                               "dev": true,
                               "requires": {
                                 "es6-promise": "^4.0.3"
@@ -12985,7 +13205,8 @@
                               "dependencies": {
                                 "es6-promise": {
                                   "version": "4.1.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                                   "dev": true
                                 }
                               }
@@ -12994,7 +13215,8 @@
                         },
                         "debug": {
                           "version": "2.6.8",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                           "dev": true,
                           "requires": {
                             "ms": "2.0.0"
@@ -13002,7 +13224,8 @@
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                               "dev": true
                             }
                           }
@@ -13011,7 +13234,8 @@
                     },
                     "node-fetch-npm": {
                       "version": "2.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha512-W3onhopST5tqpX0/MGSL47pDQLLKobNR83AvkiOWQKaw54h+uYUfzeLAxCiyhWlUOiuI+GIb4O9ojLaAFlhCCA==",
                       "dev": true,
                       "requires": {
                         "encoding": "^0.1.11",
@@ -13021,7 +13245,8 @@
                       "dependencies": {
                         "encoding": {
                           "version": "0.1.12",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                           "dev": true,
                           "requires": {
                             "iconv-lite": "~0.4.13"
@@ -13029,14 +13254,16 @@
                           "dependencies": {
                             "iconv-lite": {
                               "version": "0.4.18",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
                               "dev": true
                             }
                           }
                         },
                         "json-parse-helpfulerror": {
                           "version": "1.0.3",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
                           "dev": true,
                           "requires": {
                             "jju": "^1.1.0"
@@ -13044,7 +13271,8 @@
                           "dependencies": {
                             "jju": {
                               "version": "1.3.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
                               "dev": true
                             }
                           }
@@ -13053,7 +13281,8 @@
                     },
                     "socks-proxy-agent": {
                       "version": "3.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha512-YJcT+SNNBgFoK/NpO20PChz0VnBOhkjG3X10BwlrYujd0NZlSsH1jbxSQ1S0njt3sOvzwQ2PvGqqUIvP4rNk/w==",
                       "dev": true,
                       "requires": {
                         "agent-base": "^4.0.1",
@@ -13062,7 +13291,8 @@
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
                           "dev": true,
                           "requires": {
                             "es6-promisify": "^5.0.0"
@@ -13070,7 +13300,8 @@
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                               "dev": true,
                               "requires": {
                                 "es6-promise": "^4.0.3"
@@ -13078,7 +13309,8 @@
                               "dependencies": {
                                 "es6-promise": {
                                   "version": "4.1.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                                   "dev": true
                                 }
                               }
@@ -13087,7 +13319,8 @@
                         },
                         "socks": {
                           "version": "1.1.10",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
                           "dev": true,
                           "requires": {
                             "ip": "^1.1.4",
@@ -13096,12 +13329,14 @@
                           "dependencies": {
                             "ip": {
                               "version": "1.1.5",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
                               "dev": true
                             },
                             "smart-buffer": {
                               "version": "1.1.15",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
                               "dev": true
                             }
                           }
@@ -13112,7 +13347,8 @@
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
@@ -13120,7 +13356,8 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "dev": true,
                       "requires": {
                         "balanced-match": "^1.0.0",
@@ -13129,12 +13366,14 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "dev": true
                         }
                       }
@@ -13143,7 +13382,8 @@
                 },
                 "npm-pick-manifest": {
                   "version": "1.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-MKxNdeyOZysPRTTbHtW0M5Fw38Jo/3ARsoGw5qjCfS+XGjvNB/Gb4qtAZUFmKPM2mVum+eX559eHvKywU856BQ==",
                   "dev": true,
                   "requires": {
                     "npm-package-arg": "^5.1.2",
@@ -13152,7 +13392,8 @@
                 },
                 "promise-retry": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
                   "dev": true,
                   "requires": {
                     "err-code": "^1.0.0",
@@ -13161,14 +13402,16 @@
                   "dependencies": {
                     "err-code": {
                       "version": "1.1.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
                       "dev": true
                     }
                   }
                 },
                 "protoduck": {
                   "version": "4.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
                   "dev": true,
                   "requires": {
                     "genfun": "^4.0.1"
@@ -13176,14 +13419,16 @@
                   "dependencies": {
                     "genfun": {
                       "version": "4.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E=",
                       "dev": true
                     }
                   }
                 },
                 "tar-fs": {
                   "version": "1.15.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
                   "dev": true,
                   "requires": {
                     "chownr": "^1.0.1",
@@ -13194,7 +13439,8 @@
                   "dependencies": {
                     "pump": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
                       "dev": true,
                       "requires": {
                         "end-of-stream": "^1.1.0",
@@ -13203,7 +13449,8 @@
                       "dependencies": {
                         "end-of-stream": {
                           "version": "1.4.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                           "dev": true,
                           "requires": {
                             "once": "^1.4.0"
@@ -13215,7 +13462,8 @@
                 },
                 "tar-stream": {
                   "version": "1.5.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
                   "dev": true,
                   "requires": {
                     "bl": "^1.0.0",
@@ -13226,7 +13474,8 @@
                   "dependencies": {
                     "bl": {
                       "version": "1.2.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
                       "dev": true,
                       "requires": {
                         "readable-stream": "^2.0.5"
@@ -13234,7 +13483,8 @@
                     },
                     "end-of-stream": {
                       "version": "1.4.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                       "dev": true,
                       "requires": {
                         "once": "^1.4.0"
@@ -13242,7 +13492,8 @@
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                       "dev": true
                     }
                   }
@@ -13251,17 +13502,20 @@
             },
             "path-is-inside": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
               "dev": true
             },
             "promise-inflight": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
               "dev": true
             },
             "read": {
               "version": "1.0.7",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
               "dev": true,
               "requires": {
                 "mute-stream": "~0.0.4"
@@ -13269,14 +13523,16 @@
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.7",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
                   "dev": true
                 }
               }
             },
             "read-cmd-shim": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2"
@@ -13284,7 +13540,8 @@
             },
             "read-installed": {
               "version": "4.0.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
               "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
@@ -13298,14 +13555,16 @@
               "dependencies": {
                 "util-extend": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
                   "dev": true
                 }
               }
             },
             "read-package-json": {
               "version": "2.0.9",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-vuV8p921IgyelL4UOKv3FsRuRZSaRn30HanLAOKargsr8TbBEq+I3MgloSRXYuKhNdYP1wlEGilMWAIayA2RFg==",
               "dev": true,
               "requires": {
                 "glob": "^7.1.1",
@@ -13316,7 +13575,8 @@
               "dependencies": {
                 "json-parse-helpfulerror": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
                   "dev": true,
                   "requires": {
                     "jju": "^1.1.0"
@@ -13324,7 +13584,8 @@
                   "dependencies": {
                     "jju": {
                       "version": "1.3.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
                       "dev": true
                     }
                   }
@@ -13333,7 +13594,8 @@
             },
             "read-package-tree": {
               "version": "5.1.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
               "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
@@ -13345,7 +13607,8 @@
             },
             "readable-stream": {
               "version": "2.3.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -13359,22 +13622,26 @@
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                   "dev": true
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                   "dev": true
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                   "dev": true
                 },
                 "string_decoder": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                   "dev": true,
                   "requires": {
                     "safe-buffer": "~5.1.0"
@@ -13382,14 +13649,16 @@
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                   "dev": true
                 }
               }
             },
             "readdir-scoped-modules": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
               "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
@@ -13400,7 +13669,8 @@
             },
             "request": {
               "version": "2.81.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
               "dev": true,
               "requires": {
                 "aws-sign2": "~0.6.0",
@@ -13429,22 +13699,26 @@
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
                   "dev": true
                 },
                 "aws4": {
                   "version": "1.6.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
                   "dev": true
                 },
                 "caseless": {
                   "version": "0.12.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
                   "dev": true
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                   "dev": true,
                   "requires": {
                     "delayed-stream": "~1.0.0"
@@ -13452,24 +13726,28 @@
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                       "dev": true
                     }
                   }
                 },
                 "extend": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
                   "dev": true
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
                   "dev": true
                 },
                 "form-data": {
                   "version": "2.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
                   "dev": true,
                   "requires": {
                     "asynckit": "^0.4.0",
@@ -13479,14 +13757,16 @@
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
                       "dev": true
                     }
                   }
                 },
                 "har-validator": {
                   "version": "4.2.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
                   "dev": true,
                   "requires": {
                     "ajv": "^4.9.1",
@@ -13495,7 +13775,8 @@
                   "dependencies": {
                     "ajv": {
                       "version": "4.11.8",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                       "dev": true,
                       "requires": {
                         "co": "^4.6.0",
@@ -13504,12 +13785,14 @@
                       "dependencies": {
                         "co": {
                           "version": "4.6.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
                           "dev": true
                         },
                         "json-stable-stringify": {
                           "version": "1.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                           "dev": true,
                           "requires": {
                             "jsonify": "~0.0.0"
@@ -13517,7 +13800,8 @@
                           "dependencies": {
                             "jsonify": {
                               "version": "0.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
                               "dev": true
                             }
                           }
@@ -13526,14 +13810,16 @@
                     },
                     "har-schema": {
                       "version": "1.0.5",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
                       "dev": true
                     }
                   }
                 },
                 "hawk": {
                   "version": "3.1.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                   "dev": true,
                   "requires": {
                     "boom": "2.x.x",
@@ -13544,7 +13830,8 @@
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                       "dev": true,
                       "requires": {
                         "hoek": "2.x.x"
@@ -13552,7 +13839,8 @@
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                       "dev": true,
                       "requires": {
                         "boom": "2.x.x"
@@ -13560,12 +13848,14 @@
                     },
                     "hoek": {
                       "version": "2.16.3",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
                       "dev": true
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                       "dev": true,
                       "requires": {
                         "hoek": "2.x.x"
@@ -13575,7 +13865,8 @@
                 },
                 "http-signature": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                   "dev": true,
                   "requires": {
                     "assert-plus": "^0.2.0",
@@ -13585,12 +13876,14 @@
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
                       "dev": true
                     },
                     "jsprim": {
                       "version": "1.4.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
                       "dev": true,
                       "requires": {
                         "assert-plus": "1.0.0",
@@ -13601,22 +13894,26 @@
                       "dependencies": {
                         "assert-plus": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                           "dev": true
                         },
                         "extsprintf": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
                           "dev": true
                         },
                         "json-schema": {
                           "version": "0.2.3",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
                           "dev": true
                         },
                         "verror": {
                           "version": "1.3.6",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
                           "dev": true,
                           "requires": {
                             "extsprintf": "1.0.2"
@@ -13626,7 +13923,8 @@
                     },
                     "sshpk": {
                       "version": "1.13.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
                       "dev": true,
                       "requires": {
                         "asn1": "~0.2.3",
@@ -13641,17 +13939,20 @@
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                           "dev": true
                         },
                         "assert-plus": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                           "dev": true
                         },
                         "bcrypt-pbkdf": {
                           "version": "1.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -13660,7 +13961,8 @@
                         },
                         "dashdash": {
                           "version": "1.14.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                           "dev": true,
                           "requires": {
                             "assert-plus": "^1.0.0"
@@ -13668,7 +13970,8 @@
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -13677,7 +13980,8 @@
                         },
                         "getpass": {
                           "version": "0.1.7",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                           "dev": true,
                           "requires": {
                             "assert-plus": "^1.0.0"
@@ -13685,13 +13989,15 @@
                         },
                         "jsbn": {
                           "version": "0.1.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                           "dev": true,
                           "optional": true
                         },
                         "tweetnacl": {
                           "version": "0.14.5",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                           "dev": true,
                           "optional": true
                         }
@@ -13701,22 +14007,26 @@
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
                   "dev": true
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
                   "dev": true
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
                   "dev": true
                 },
                 "mime-types": {
                   "version": "2.1.15",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
                   "dev": true,
                   "requires": {
                     "mime-db": "~1.27.0"
@@ -13724,34 +14034,40 @@
                   "dependencies": {
                     "mime-db": {
                       "version": "1.27.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
                       "dev": true
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
                   "dev": true
                 },
                 "performance-now": {
                   "version": "0.2.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
                   "dev": true
                 },
                 "qs": {
                   "version": "6.4.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
                   "dev": true
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
                   "dev": true
                 },
                 "tough-cookie": {
                   "version": "2.3.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
                   "dev": true,
                   "requires": {
                     "punycode": "^1.4.1"
@@ -13759,14 +14075,16 @@
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
                       "dev": true
                     }
                   }
                 },
                 "tunnel-agent": {
                   "version": "0.6.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                   "dev": true,
                   "requires": {
                     "safe-buffer": "^5.0.1"
@@ -13776,12 +14094,14 @@
             },
             "retry": {
               "version": "0.10.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
               "dev": true
             },
             "rimraf": {
               "version": "2.6.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
               "dev": true,
               "requires": {
                 "glob": "^7.0.5"
@@ -13789,17 +14109,20 @@
             },
             "safe-buffer": {
               "version": "5.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
               "dev": true
             },
             "semver": {
               "version": "5.3.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
               "dev": true
             },
             "sha": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -13808,17 +14131,20 @@
             },
             "slide": {
               "version": "1.1.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
               "dev": true
             },
             "sorted-object": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
               "dev": true
             },
             "sorted-union-stream": {
               "version": "2.1.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
               "dev": true,
               "requires": {
                 "from2": "^1.3.0",
@@ -13827,7 +14153,8 @@
               "dependencies": {
                 "from2": {
                   "version": "1.3.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
                   "dev": true,
                   "requires": {
                     "inherits": "~2.0.1",
@@ -13836,7 +14163,8 @@
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.14",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                       "dev": true,
                       "requires": {
                         "core-util-is": "~1.0.0",
@@ -13847,17 +14175,20 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                           "dev": true
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                           "dev": true
                         }
                       }
@@ -13866,7 +14197,8 @@
                 },
                 "stream-iterate": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
                   "dev": true,
                   "requires": {
                     "readable-stream": "^2.1.5",
@@ -13875,7 +14207,8 @@
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                       "dev": true
                     }
                   }
@@ -13884,7 +14217,8 @@
             },
             "ssri": {
               "version": "4.1.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.0"
@@ -13892,7 +14226,8 @@
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -13900,14 +14235,16 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "3.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                   "dev": true
                 }
               }
             },
             "tar": {
               "version": "2.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "dev": true,
               "requires": {
                 "block-stream": "*",
@@ -13917,7 +14254,8 @@
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
                   "dev": true,
                   "requires": {
                     "inherits": "~2.0.0"
@@ -13927,22 +14265,26 @@
             },
             "text-table": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
               "dev": true
             },
             "uid-number": {
               "version": "0.0.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
               "dev": true
             },
             "umask": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
               "dev": true
             },
             "unique-filename": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
               "dev": true,
               "requires": {
                 "unique-slug": "^2.0.0"
@@ -13950,7 +14292,8 @@
               "dependencies": {
                 "unique-slug": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
                   "dev": true,
                   "requires": {
                     "imurmurhash": "^0.1.4"
@@ -13960,12 +14303,14 @@
             },
             "unpipe": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
               "dev": true
             },
             "update-notifier": {
               "version": "2.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
               "dev": true,
               "requires": {
                 "boxen": "^1.0.0",
@@ -13980,7 +14325,8 @@
               "dependencies": {
                 "boxen": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
                   "dev": true,
                   "requires": {
                     "ansi-align": "^2.0.0",
@@ -13994,7 +14340,8 @@
                   "dependencies": {
                     "ansi-align": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
                       "dev": true,
                       "requires": {
                         "string-width": "^2.0.0"
@@ -14002,17 +14349,20 @@
                     },
                     "camelcase": {
                       "version": "4.1.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                       "dev": true
                     },
                     "cli-boxes": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
                       "dev": true
                     },
                     "string-width": {
                       "version": "2.1.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
                       "dev": true,
                       "requires": {
                         "is-fullwidth-code-point": "^2.0.0",
@@ -14021,12 +14371,14 @@
                       "dependencies": {
                         "is-fullwidth-code-point": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                           "dev": true
                         },
                         "strip-ansi": {
                           "version": "4.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                           "dev": true,
                           "requires": {
                             "ansi-regex": "^3.0.0"
@@ -14036,7 +14388,8 @@
                     },
                     "term-size": {
                       "version": "0.1.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
                       "dev": true,
                       "requires": {
                         "execa": "^0.4.0"
@@ -14044,7 +14397,8 @@
                       "dependencies": {
                         "execa": {
                           "version": "0.4.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
                           "dev": true,
                           "requires": {
                             "cross-spawn-async": "^2.1.1",
@@ -14057,7 +14411,8 @@
                           "dependencies": {
                             "cross-spawn-async": {
                               "version": "2.2.5",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
                               "dev": true,
                               "requires": {
                                 "lru-cache": "^4.0.0",
@@ -14066,12 +14421,14 @@
                             },
                             "is-stream": {
                               "version": "1.1.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                               "dev": true
                             },
                             "npm-run-path": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
                               "dev": true,
                               "requires": {
                                 "path-key": "^1.0.0"
@@ -14079,17 +14436,20 @@
                             },
                             "object-assign": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                               "dev": true
                             },
                             "path-key": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
                               "dev": true
                             },
                             "strip-eof": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
                               "dev": true
                             }
                           }
@@ -14098,7 +14458,8 @@
                     },
                     "widest-line": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
                       "dev": true,
                       "requires": {
                         "string-width": "^1.0.1"
@@ -14106,7 +14467,8 @@
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                           "dev": true,
                           "requires": {
                             "code-point-at": "^1.0.0",
@@ -14116,12 +14478,14 @@
                           "dependencies": {
                             "code-point-at": {
                               "version": "1.1.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                               "dev": true
                             },
                             "is-fullwidth-code-point": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                               "dev": true,
                               "requires": {
                                 "number-is-nan": "^1.0.0"
@@ -14129,14 +14493,16 @@
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                                   "dev": true
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                               "dev": true,
                               "requires": {
                                 "ansi-regex": "^2.0.0"
@@ -14144,7 +14510,8 @@
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                                   "dev": true
                                 }
                               }
@@ -14157,7 +14524,8 @@
                 },
                 "chalk": {
                   "version": "1.1.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                   "dev": true,
                   "requires": {
                     "ansi-styles": "^2.2.1",
@@ -14169,17 +14537,20 @@
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
                       "dev": true
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                       "dev": true
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                       "dev": true,
                       "requires": {
                         "ansi-regex": "^2.0.0"
@@ -14187,14 +14558,16 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                           "dev": true
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "dev": true,
                       "requires": {
                         "ansi-regex": "^2.0.0"
@@ -14202,21 +14575,24 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                           "dev": true
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                       "dev": true
                     }
                   }
                 },
                 "configstore": {
                   "version": "3.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
                   "dev": true,
                   "requires": {
                     "dot-prop": "^4.1.0",
@@ -14229,7 +14605,8 @@
                   "dependencies": {
                     "dot-prop": {
                       "version": "4.1.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
                       "dev": true,
                       "requires": {
                         "is-obj": "^1.0.0"
@@ -14237,14 +14614,16 @@
                       "dependencies": {
                         "is-obj": {
                           "version": "1.0.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
                           "dev": true
                         }
                       }
                     },
                     "make-dir": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
                       "dev": true,
                       "requires": {
                         "pify": "^2.3.0"
@@ -14252,14 +14631,16 @@
                       "dependencies": {
                         "pify": {
                           "version": "2.3.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                           "dev": true
                         }
                       }
                     },
                     "unique-string": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
                       "dev": true,
                       "requires": {
                         "crypto-random-string": "^1.0.0"
@@ -14267,7 +14648,8 @@
                       "dependencies": {
                         "crypto-random-string": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
                           "dev": true
                         }
                       }
@@ -14276,17 +14658,20 @@
                 },
                 "import-lazy": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
                   "dev": true
                 },
                 "is-npm": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
                   "dev": true
                 },
                 "latest-version": {
                   "version": "3.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
                   "dev": true,
                   "requires": {
                     "package-json": "^4.0.0"
@@ -14294,7 +14679,8 @@
                   "dependencies": {
                     "package-json": {
                       "version": "4.0.1",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
                       "dev": true,
                       "requires": {
                         "got": "^6.7.1",
@@ -14305,7 +14691,8 @@
                       "dependencies": {
                         "got": {
                           "version": "6.7.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
                           "dev": true,
                           "requires": {
                             "create-error-class": "^3.0.0",
@@ -14323,7 +14710,8 @@
                           "dependencies": {
                             "create-error-class": {
                               "version": "3.0.2",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
                               "dev": true,
                               "requires": {
                                 "capture-stack-trace": "^1.0.0"
@@ -14331,54 +14719,64 @@
                               "dependencies": {
                                 "capture-stack-trace": {
                                   "version": "1.0.0",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
                                   "dev": true
                                 }
                               }
                             },
                             "duplexer3": {
                               "version": "0.1.4",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
                               "dev": true
                             },
                             "get-stream": {
                               "version": "3.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                               "dev": true
                             },
                             "is-redirect": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
                               "dev": true
                             },
                             "is-retry-allowed": {
                               "version": "1.1.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
                               "dev": true
                             },
                             "is-stream": {
                               "version": "1.1.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                               "dev": true
                             },
                             "lowercase-keys": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
                               "dev": true
                             },
                             "timed-out": {
                               "version": "4.0.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
                               "dev": true
                             },
                             "unzip-response": {
                               "version": "2.0.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
                               "dev": true
                             },
                             "url-parse-lax": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
                               "dev": true,
                               "requires": {
                                 "prepend-http": "^1.0.1"
@@ -14386,7 +14784,8 @@
                               "dependencies": {
                                 "prepend-http": {
                                   "version": "1.0.4",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
                                   "dev": true
                                 }
                               }
@@ -14395,7 +14794,8 @@
                         },
                         "registry-auth-token": {
                           "version": "3.3.1",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
                           "dev": true,
                           "requires": {
                             "rc": "^1.1.6",
@@ -14404,7 +14804,8 @@
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                               "dev": true,
                               "requires": {
                                 "deep-extend": "~0.4.0",
@@ -14415,17 +14816,20 @@
                               "dependencies": {
                                 "deep-extend": {
                                   "version": "0.4.2",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                                   "dev": true
                                 },
                                 "minimist": {
                                   "version": "1.2.0",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                                   "dev": true
                                 },
                                 "strip-json-comments": {
                                   "version": "2.0.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                                   "dev": true
                                 }
                               }
@@ -14434,7 +14838,8 @@
                         },
                         "registry-url": {
                           "version": "3.1.0",
-                          "bundled": true,
+                          "resolved": false,
+                          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
                           "dev": true,
                           "requires": {
                             "rc": "^1.0.1"
@@ -14442,7 +14847,8 @@
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
-                              "bundled": true,
+                              "resolved": false,
+                              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                               "dev": true,
                               "requires": {
                                 "deep-extend": "~0.4.0",
@@ -14453,17 +14859,20 @@
                               "dependencies": {
                                 "deep-extend": {
                                   "version": "0.4.2",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                                   "dev": true
                                 },
                                 "minimist": {
                                   "version": "1.2.0",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                                   "dev": true
                                 },
                                 "strip-json-comments": {
                                   "version": "2.0.1",
-                                  "bundled": true,
+                                  "resolved": false,
+                                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                                   "dev": true
                                 }
                               }
@@ -14476,7 +14885,8 @@
                 },
                 "semver-diff": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
                   "dev": true,
                   "requires": {
                     "semver": "^5.0.3"
@@ -14484,19 +14894,22 @@
                 },
                 "xdg-basedir": {
                   "version": "3.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
                   "dev": true
                 }
               }
             },
             "uuid": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
               "dev": true
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
               "dev": true,
               "requires": {
                 "spdx-correct": "~1.0.0",
@@ -14505,7 +14918,8 @@
               "dependencies": {
                 "spdx-correct": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                   "dev": true,
                   "requires": {
                     "spdx-license-ids": "^1.0.2"
@@ -14513,21 +14927,24 @@
                   "dependencies": {
                     "spdx-license-ids": {
                       "version": "1.2.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
                       "dev": true
                     }
                   }
                 },
                 "spdx-expression-parse": {
                   "version": "1.0.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
                   "dev": true
                 }
               }
             },
             "validate-npm-package-name": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
               "dev": true,
               "requires": {
                 "builtins": "^1.0.3"
@@ -14535,14 +14952,16 @@
               "dependencies": {
                 "builtins": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
                   "dev": true
                 }
               }
             },
             "which": {
               "version": "1.2.14",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
               "dev": true,
               "requires": {
                 "isexe": "^2.0.0"
@@ -14550,14 +14969,16 @@
               "dependencies": {
                 "isexe": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
                   "dev": true
                 }
               }
             },
             "worker-farm": {
               "version": "1.3.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-QzMRK7SbF6oFC4eJXKayys9A5f8=",
               "dev": true,
               "requires": {
                 "errno": ">=0.1.1 <0.2.0-0",
@@ -14566,7 +14987,8 @@
               "dependencies": {
                 "errno": {
                   "version": "0.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
                   "dev": true,
                   "requires": {
                     "prr": "~0.0.0"
@@ -14574,26 +14996,30 @@
                   "dependencies": {
                     "prr": {
                       "version": "0.0.0",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
                       "dev": true
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                   "dev": true
                 }
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true
             },
             "write-file-atomic": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.11",
@@ -14605,7 +15031,8 @@
         },
         "npm-package-arg": {
           "version": "6.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.7.1",
@@ -14616,7 +15043,8 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -14624,12 +15052,14 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -14637,12 +15067,14 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
             "execa": "^1.0.0",
@@ -14652,7 +15084,8 @@
           "dependencies": {
             "cross-spawn": {
               "version": "6.0.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
               "dev": true,
               "requires": {
                 "nice-try": "^1.0.4",
@@ -14664,7 +15097,8 @@
             },
             "execa": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
               "dev": true,
               "requires": {
                 "cross-spawn": "^6.0.0",
@@ -14678,7 +15112,8 @@
             },
             "get-stream": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
               "dev": true,
               "requires": {
                 "pump": "^3.0.0"
@@ -14688,12 +15123,14 @@
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -14702,22 +15139,26 @@
         },
         "p-defer": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
           "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-is-promise": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
           "dev": true
         },
         "p-limit": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -14725,7 +15166,8 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -14733,12 +15175,14 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "package-json": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "dev": true,
           "requires": {
             "got": "^6.7.1",
@@ -14749,42 +15193,50 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "pify": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "prepend-http": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -14793,7 +15245,8 @@
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "requires": {
             "deep-extend": "^0.6.0",
@@ -14804,7 +15257,8 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
           "dev": true,
           "requires": {
             "rc": "^1.1.6",
@@ -14813,7 +15267,8 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "dev": true,
           "requires": {
             "rc": "^1.0.1"
@@ -14821,17 +15276,20 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -14839,17 +15297,20 @@
         },
         "safe-buffer": {
           "version": "5.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
           "dev": true
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "semver-diff": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "dev": true,
           "requires": {
             "semver": "^5.0.3"
@@ -14857,12 +15318,14 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -14870,17 +15333,20 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -14889,7 +15355,8 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -14897,17 +15364,20 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -14915,7 +15385,8 @@
         },
         "term-size": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "dev": true,
           "requires": {
             "execa": "^0.7.0"
@@ -14923,12 +15394,14 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
           "dev": true
         },
         "unique-string": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "dev": true,
           "requires": {
             "crypto-random-string": "^1.0.0"
@@ -14936,12 +15409,14 @@
         },
         "unzip-response": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
           "dev": true
         },
         "update-notifier": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
           "dev": true,
           "requires": {
             "boxen": "^1.2.1",
@@ -14958,7 +15433,8 @@
         },
         "url-parse-lax": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true,
           "requires": {
             "prepend-http": "^1.0.1"
@@ -14966,7 +15442,8 @@
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "dev": true,
           "requires": {
             "builtins": "^1.0.3"
@@ -14974,7 +15451,8 @@
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -14982,12 +15460,14 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "widest-line": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
           "dev": true,
           "requires": {
             "string-width": "^2.1.1"
@@ -14995,7 +15475,8 @@
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -15004,12 +15485,14 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -15017,7 +15500,8 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -15027,7 +15511,8 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -15037,12 +15522,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.4.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -15052,22 +15539,26 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
           "dev": true
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "11.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
@@ -15086,14 +15577,16 @@
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
               "dev": true
             }
           }
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
@@ -17210,7 +17703,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -18011,7 +18505,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/templates/components/common/share.html
+++ b/templates/components/common/share.html
@@ -43,6 +43,15 @@
                 </li>
             {{/each}}
         </ul>
+        <script type="text/javascript"
+                defer src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-4e94ed470ee51e32"></script>
+        <script>
+            window.addEventListener('DOMContentLoaded', function() {
+                if (typeof(addthis) === "object") {
+                    addthis.toolbox('.addthis_toolbox');
+                }
+            });
+        </script>
     </div>
 {{/if}}
 {{#if settings.facebook_like_button.enabled}}

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -250,7 +250,9 @@
                 {{> components/common/wishlist-dropdown}}
             {{/if}}
         </div>
-        {{> components/common/share}}
+        {{#unless is_ajax}}
+            {{> components/common/share}}
+        {{/unless}}
     </section>
 
     {{#if product.description}}

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -68,12 +68,6 @@
             window.stencilBootstrap("{{page_type}}", {{jsContext}}).load();
         </script>
 
-        {{!-- Adding script for addthis social icons --}}
-        <script type="text/javascript"
-                defer
-                src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-4e94ed470ee51e32">
-        </script>
-
         {{{footer.scripts}}}
     </body>
 </html>


### PR DESCRIPTION
#### What?

Instead of adding global JS to make sure social icons load, we will instead hide them from quick view. Making this change as the previous approach introduced a performance regression.

#### Screenshots (if appropriate)

Normal PDP:
![image](https://user-images.githubusercontent.com/8922457/98188087-00caec00-1ed8-11eb-88f6-640264c93df1.png)

Quick view:
![image](https://user-images.githubusercontent.com/8922457/98188117-0c1e1780-1ed8-11eb-86f4-8875396086c9.png)

Depends on [`stencil-utils` release](https://github.com/bigcommerce/stencil-utils/pull/144) and https://github.com/bigcommerce/bigcommerce/pull/38045
