### PR TITLE
Eliminate web font loader and use display=block instead to optimize font loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Draft
+- Reduce lodash usage in compare-products.js and image-gallery.js [#1894](https://github.com/bigcommerce/cornerstone/pull/1894)
+- Switch font loading to use display=block to improve Lighthouse results [#1895](https://github.com/bigcommerce/cornerstone/pull/1895)
 
 ## 4.12.0 (11-05-2020)
 - Reduce lodash usage in compare-products.js and image-gallery.js [#1827](https://github.com/bigcommerce/cornerstone/pull/1827)

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -25,18 +25,7 @@
         </script>
         <script async src="{{cdn 'assets/dist/theme-bundle.head_async.js'}}"></script>
 
-        <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js"></script>
-
-        <script>
-            WebFont.load({
-                custom: {
-                    families: ['Karla', 'Roboto', 'Source Sans Pro']
-                },
-                classes: false
-            });
-        </script>
-
-        {{ getFontsCollection }}
+        {{ getFontsCollection font-display="block" }}
         {{{stylesheet '/assets/css/theme.css'}}}
 
         {{{head.scripts}}}


### PR DESCRIPTION
Further optimizing font loading to make Lighthouse happy.
3 scenarios have been tested:

**Previous approach of display=swap**

- Lighthouse complains about CLS
- Lighthouse complains about font CSS as blocking resource

**New approach of JS webfontloader**

- Lighthouse complains about blocking JS
- Lighthouse complains "make sure text is visible during webfont load"
- Lighthouse complains about font CSS as blocking resource
- Adds another HTTP request

**Proposed approach of using [display=block](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display)**

- Lighthouse complains about font CSS as blocking resource

This approach has the best overall results.