### PR TITLE
feat(payments): PAYPAL-823 Add new banner on the cart page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Move Tax Field under Grand Total on Cart when Tax inclusive. [#1903](https://github.com/bigcommerce/cornerstone/pull/1903)
 - Added styling config for the PayPal SPB on checkout page [#1866](https://github.com/bigcommerce/cornerstone/pull/1866)
 - Moved zoomSize and productSize to the upper level, cause product.js is not availabe on the Quick View [#1884](https://github.com/bigcommerce/cornerstone/pull/1884)
+- Added new region on the cart page [#1901](https://github.com/bigcommerce/cornerstone/pull/1901)
 
 ## 4.12.1 (11-10-2020)
 - Write a Review modal cause TypeError. [#1899](https://github.com/bigcommerce/cornerstone/pull/1899)

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -24,7 +24,7 @@ cart: true
                 {{> components/cart/totals}}
             </div>
 
-            {{{region name="cartpage_banner_below_totals"}}}
+            {{{region name="cart_below_totals"}}}
 
             {{#if cart.show_primary_checkout_button}}
                 <div class="cart-actions cart-content-padding-right">

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -24,6 +24,8 @@ cart: true
                 {{> components/cart/totals}}
             </div>
 
+            {{{region name="banner_below_price"}}}
+
             {{#if cart.show_primary_checkout_button}}
                 <div class="cart-actions cart-content-padding-right">
                     <a class="button button--primary" href="{{urls.checkout.single_address}}" title="{{lang 'cart.checkout.title'}}">{{lang 'cart.checkout.button'}}</a>

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -24,7 +24,7 @@ cart: true
                 {{> components/cart/totals}}
             </div>
 
-            {{{region name="banner_below_price"}}}
+            {{{region name="cartpage_banner_below_totals"}}}
 
             {{#if cart.show_primary_checkout_button}}
                 <div class="cart-actions cart-content-padding-right">


### PR DESCRIPTION
#### What?
New PayPal credit banner on the cart page above the checkout button

#### Tickets / Documentation

Add links to any relevant tickets and documentation.
 [Ticket](https://jira.bigcommerce.com/browse/PAYPAL-823)

#### Screenshots (if appropriate)

<img width="1146" alt="Screenshot 2020-11-11 at 18 46 43" src="https://user-images.githubusercontent.com/32959076/98839491-40e91c00-244e-11eb-848c-32f579f4d887.png">