### PR TITLE
feat(storefront): BCTHEME-116 move tax field after grand total when tax inclusive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Move Tax Field under Grand Total on Cart when Tax inclusive. [#1903](https://github.com/bigcommerce/cornerstone/pull/1903)
 
 ## 4.12.1 (11-10-2020)
 - Write a Review modal cause TypeError. [#1899](https://github.com/bigcommerce/cornerstone/pull/1899)

--- a/lang/en.json
+++ b/lang/en.json
@@ -71,6 +71,7 @@
         "coupon_code": "Coupon Code",
         "discount": "Discount",
         "gift_certificate": "Gift Certificate",
+        "included_in_total": " Included in Total",
         "remove_file": "Remove this file",
         "freeshipping": "Free Shipping",
         "reconfigure_product": "Configure '{name}'",

--- a/templates/components/cart/totals.html
+++ b/templates/components/cart/totals.html
@@ -30,14 +30,16 @@
         </li>
     {{/if}}
     {{#each cart.taxes}}
-        <li class="cart-total">
-            <div class="cart-total-label">
-                <strong>{{name}}:</strong>
-            </div>
-            <div class="cart-total-value">
-                <span>{{cost.formatted}}</span>
-            </div>
-        </li>
+        {{#unless included}}
+            <li class="cart-total">
+                <div class="cart-total-label">
+                    <strong>{{name}}:</strong>
+                </div>
+                <div class="cart-total-value">
+                    <span>{{cost.formatted}}</span>
+                </div>
+            </li>
+        {{/unless}}
     {{/each}}
     {{#if cart.discount }}
         <li class="cart-total">
@@ -104,4 +106,16 @@
             {{/or}}
         </div>
     </li>
+    {{#each cart.taxes}}
+        {{#if included}}
+            <li class="cart-total">
+                <div class="cart-total-label">
+                    <strong>{{concat name (lang 'cart.included_in_total')}}:</strong>
+                </div>
+                <div class="cart-total-value">
+                    <span>{{cost.formatted}}</span>
+                </div>
+            </li>
+        {{/if}}
+    {{/each}}
 </ul>


### PR DESCRIPTION

#### What?

This PR moves tax field on Cart when Tax is set to be inclusive. It  adds feature parity with Blueprint and improves Customer experience.

#### Tickets / Documentation

- [BCTHEME-116](https://jira.bigcommerce.com/browse/BCTHEME-116)

#### Screenshots (if appropriate)
<img width="1109" alt="Cart  Tax Excluded" src="https://user-images.githubusercontent.com/67792608/99083951-f4791a00-25ce-11eb-91e7-dcfaaa5faa58.png">
<img width="1108" alt="Cart  Tax Included" src="https://user-images.githubusercontent.com/67792608/99083958-f511b080-25ce-11eb-9d91-e0adef3b8011.png">
