### PR TITLE
fix(storefront): BCTHEME-301 Header content placed out of the header block on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - HTML Entity displayed as is via system/error message on a Storefront. [#1888](https://github.com/bigcommerce/cornerstone/pull/1888)
 
 ## Draft
+- Header content placed out of the header block on mobile. [#1908](https://github.com/bigcommerce/cornerstone/pull/1908)
 - Shoppers are not anchor-linked to reviews on PDPs if product description tabs are enabled. [#1883](https://github.com/bigcommerce/cornerstone/pull/1883)
 - Fixed text contrast for brand name on Cart page. [#1882](https://github.com/bigcommerce/cornerstone/pull/1882)
 - Add sufficient contrast for Upsell Banners in Cornerstone Theme according to AA Standard. [#1891](https://github.com/bigcommerce/cornerstone/pull/1891)

--- a/assets/scss/components/stencil/adminBar/_adminBar.scss
+++ b/assets/scss/components/stencil/adminBar/_adminBar.scss
@@ -32,7 +32,7 @@
 // =============================================================================
 
 body.hasAdminBar {
-    padding-top: 101px; // 55px (Mobile Header) + 46px (Admin Bar)
+    padding-top: $header-height; // (Mobile Header)
 
     @include breakpoint("medium") {
         padding-top: 0;
@@ -42,16 +42,12 @@ body.hasAdminBar {
         }
 
         .header {
-            padding-top: 0;
+            padding-top: $adminBar-height;
         }
     }
 
-    .header {
-        padding-top: $adminBar-height;
-    }
-
     .navPages-container.is-open {
-        padding-top: 101px;
+        padding-top: $header-height;
     }
 }
 


### PR DESCRIPTION
#### What?

This PR has fix for header on mobile when admin bar is enabled

#### Tickets / Documentation

[BCTHEME-301](https://jira.bigcommerce.com/browse/BCTHEME-301)

#### Screenshots (if appropriate)
before
<img width="555" alt="Screenshot 2020-11-18 at 11 47 01" src="https://user-images.githubusercontent.com/66325265/99513920-d414db00-2993-11eb-9e6c-6310619daea4.png">

after
<img width="555" alt="Screenshot 2020-11-18 at 11 43 50" src="https://user-images.githubusercontent.com/66325265/99513518-67014580-2993-11eb-8da6-87288859ea02.png">


