### PR TITLE
fix(storefront): BCTHEME-85 “Sort by” dropdown selection not reflected on search results page for News and Information tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - HTML Entity displayed as is via system/error message on a Storefront. [#1888](https://github.com/bigcommerce/cornerstone/pull/1888)
 
 ## Draft
+- “Sort by” dropdown selection not reflected on search results page for News and Information tab. [#1910](https://github.com/bigcommerce/cornerstone/pull/1910)
 - Shoppers are not anchor-linked to reviews on PDPs if product description tabs are enabled. [#1883](https://github.com/bigcommerce/cornerstone/pull/1883)
 - Fixed text contrast for brand name on Cart page. [#1882](https://github.com/bigcommerce/cornerstone/pull/1882)
 - Add sufficient contrast for Upsell Banners in Cornerstone Theme according to AA Standard. [#1891](https://github.com/bigcommerce/cornerstone/pull/1891)

--- a/assets/js/theme/search.js
+++ b/assets/js/theme/search.js
@@ -132,8 +132,37 @@ export default class Search extends CatalogPage {
         $($tabsCollection.get(nextTabIdx)).focus().trigger('click');
     }
 
+    getUrlParameter(queryParam) {
+        const regex = new RegExp(`[\\?&]${queryParam}=([^&#]*)`);
+        const results = regex.exec(window.location.search);
+        return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+    }
+
+    setupSortByQuerySearchParam() {
+        const searchQuery = this.getUrlParameter('search_query');
+
+        if (searchQuery.length === 0) return;
+
+        const $baseInput = $('<input/>').attr('type', 'hidden');
+
+        $('[data-sort-by]').each((idx, form) => {
+            const $form = $(form);
+            $form.append(
+                $baseInput.clone().attr({
+                    name: 'search_query',
+                    value: searchQuery,
+                }),
+                $baseInput.clone().attr({
+                    name: 'section',
+                    value: $form.data('sort-by'),
+                }),
+            );
+        });
+    }
+
     onReady() {
         compareProducts(this.context.urls);
+        this.setupSortByQuerySearchParam();
 
         const $searchForm = $('[data-advanced-search-form]');
         const $categoryTreeContainer = $searchForm.find('[data-search-category-tree]');

--- a/templates/components/category/sort-box.html
+++ b/templates/components/category/sort-box.html
@@ -16,4 +16,3 @@
         </select>
     </div>
 </fieldset>
-

--- a/templates/components/products/filter.html
+++ b/templates/components/products/filter.html
@@ -1,3 +1,3 @@
-<form class="actionBar" method="get" data-sort-by>
+<form class="actionBar" method="get" data-sort-by="product">
     {{> components/category/sort-box sort=sort}}
 </form>

--- a/templates/components/search/content-sort-box.html
+++ b/templates/components/search/content-sort-box.html
@@ -1,4 +1,4 @@
-<form class="actionBar" method="get" data-sort-by>
+<form class="actionBar" method="get" data-sort-by="content">
     <fieldset class="form-fieldset actionBar-section">
         <div class="form-field">
             <label class="form-label" for="sort">{{lang 'common.sorter.sort_by'}}</label>


### PR DESCRIPTION

#### What?

This PR has fix for search page sorting. It has fix for both product sorting and content sorting.
Two hidden inputs were added to control search query and active tab of the search page (product or content)
Form submits from stencil utils.
<img width="660" alt="sort-by-submit" src="https://user-images.githubusercontent.com/66325265/99785315-ad86a980-2b25-11eb-801f-c59fa63e4092.png">

#### Tickets / Documentation

[BCTHEME-85](https://jira.bigcommerce.com/browse/BCTHEME-85)

#### Screenshots (if appropriate)
bug on products or content request after submitting sort form looks the same, because sending request from content tab will reload page on content tab
<img width="1558" alt="bug-after-sortby-product-and-content" src="https://user-images.githubusercontent.com/66325265/99788362-af526c00-2b29-11eb-8879-baf3d047bdb5.png">
fix product
<img width="1558" alt="fix-sortby-product" src="https://user-images.githubusercontent.com/66325265/99788391-b8433d80-2b29-11eb-9532-104a92c64efe.png">
fix content
<img width="1558" alt="fix-sortby-content" src="https://user-images.githubusercontent.com/66325265/99788413-be391e80-2b29-11eb-9cf0-df85bf363860.png">

