### PR TITLE
fix(storefront): BCTHEME-104 Selecting product options doesn't update image on PDP in Internet Explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Selecting product options doesn't update image on PDP in Internet Explorer. [#1913](https://github.com/bigcommerce/cornerstone/pull/1913)
 - HTML Entity displayed as is via system/error message on a Storefront. [#1888](https://github.com/bigcommerce/cornerstone/pull/1888)
 - Shoppers are not anchor-linked to reviews on PDPs if product description tabs are enabled. [#1883](https://github.com/bigcommerce/cornerstone/pull/1883)
 - Fixed text contrast for brand name on Cart page. [#1882](https://github.com/bigcommerce/cornerstone/pull/1882)

--- a/assets/js/theme/product/image-gallery.js
+++ b/assets/js/theme/product/image-gallery.js
@@ -78,7 +78,7 @@ export default class ImageGallery {
 
         if (isBrowserIE) {
             const fallbackStylesIE = {
-                'background-image': `url(${this.currentImage.mainImageUrl}&ampimbypass=on)`,
+                'background-image': `url(${this.currentImage.mainImageUrl})`,
                 'background-position': 'center',
                 'background-repeat': 'no-repeat',
                 'background-origin': 'content-box',


### PR DESCRIPTION
#### What?

Selecting product options doesn't update image on PDP in Internet Explorer

#### Tickets / Documentation

[Jira ticket](https://jira.bigcommerce.com/browse/BCTHEME-104)

#### Screenshots (if appropriate)

<img width="1680" alt="Screenshot 2020-11-24 at 12 46 42" src="https://user-images.githubusercontent.com/66319629/100084817-eb503e80-2e53-11eb-884c-78ef038bc10b.png">

