### PR TITLE
fix(storefront): BCTHEME-30 fix misaligned tooltip for required product option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed misaligned tooltip for required product option. [#1915](https://github.com/bigcommerce/cornerstone/pull/1915)
 - Fixed tooltip overlaying by facebook button. [#1914](https://github.com/bigcommerce/cornerstone/pull/1914)
 - Cornerstone - Text hover color does not change when Dropdown menu display mode is set to 'Alternative'. [#1918](https://github.com/bigcommerce/cornerstone/pull/1918)
 - “Sort by” dropdown selection not reflected on search results page for News and Information tab. [#1910](https://github.com/bigcommerce/cornerstone/pull/1910)

--- a/assets/scss/components/citadel/forms/_forms.scss
+++ b/assets/scss/components/citadel/forms/_forms.scss
@@ -67,6 +67,8 @@
 
 .form-checkbox,
 .form-radio {
+    bottom: 0.5rem;
+    left: 0.5rem;
 
     + .form-label {
 
@@ -86,6 +88,10 @@
     }
 }
 
+.form-option-wrapper {
+    position: relative;
+    display: inline-block;
+}
 
 // Citadel form-actions
 // -----------------------------------------------------------------------------

--- a/templates/components/amp/products/options/set-rectangle.html
+++ b/templates/components/amp/products/options/set-rectangle.html
@@ -7,6 +7,7 @@
         {{/if}}
     </label>
     {{#each this.values}}
+    <div class="form-option-wrapper">
         <input
             class="form-radio"
             type="radio"
@@ -18,5 +19,6 @@
         <label class="form-option" for="attribute_{{id}}" data-product-attribute-value="{{id}}">
             <span class="form-option-variant">{{this.label}}</span>
         </label>
+    </div>
     {{/each}}
 </div>

--- a/templates/components/amp/products/options/swatch.html
+++ b/templates/components/amp/products/options/swatch.html
@@ -9,6 +9,7 @@
     </label>
 
     {{#each this.values}}
+    <div class="form-option-wrapper">
         <input class="form-radio" type="radio" name="attribute[{{../id}}]" value="{{id}}" id="attribute_{{id}}" {{#if selected}}checked{{/if}} {{#if ../required}}required{{/if}}>
         <label class="form-option" for="attribute_{{id}}" data-product-attribute-value="{{id}}">
             {{#if image}}
@@ -29,5 +30,6 @@
                 {{/if}}
             {{/if}}
         </label>
+    </div>
     {{/each}}
 </div>

--- a/templates/components/products/options/set-rectangle.html
+++ b/templates/components/products/options/set-rectangle.html
@@ -21,6 +21,7 @@
     {{/unless}}
 
     {{#each this.values}}
+    <div class="form-option-wrapper">    
         <input
             class="form-radio"
             type="radio"
@@ -31,9 +32,11 @@
                 checked
                 data-default
             {{/if}}
-            {{#if ../required}}required{{/if}}>
+            {{#if ../required}}required{{/if}}
+        >
         <label class="form-option" for="attribute_rectangle__{{../id}}_{{id}}" data-product-attribute-value="{{id}}">
             <span class="form-option-variant">{{this.label}}</span>
         </label>
+    </div>
     {{/each}}
 </div>

--- a/templates/components/products/options/swatch.html
+++ b/templates/components/products/options/swatch.html
@@ -22,6 +22,7 @@
     {{/unless}}
 
     {{#each this.values}}
+    <div class="form-option-wrapper">
         <input class="form-radio"
                type="radio"
                name="attribute[{{../id}}]"
@@ -55,5 +56,6 @@
                 </span>
             {{/if}}
         </label>
+    </div>
     {{/each}}
 </div>


### PR DESCRIPTION
#### What?

This PR addresses issue with misaligned tooltip. When product has required options and customer clicks  on "Add it on Cart" button without selection a tooltip with message is misaligned. To fix this issue html wrapper has been added as well some css.

#### Tickets / Documentation

- [BCTHEME-30](https://jira.bigcommerce.com/browse/BCTHEME-30)

#### Screenshots (if appropriate)

<img width="1320" alt="BCTHEME-30 Chrome Desktop" src="https://user-images.githubusercontent.com/67792608/100629893-80f73c80-3332-11eb-963d-093279882779.png">
<img width="1320" alt="BCTHEME-30 Chrome, Desktop#2" src="https://user-images.githubusercontent.com/67792608/100629899-82286980-3332-11eb-886a-ab02c742c6a4.png">
<img width="1657" alt="BCTHEME-30 IE11" src="https://user-images.githubusercontent.com/67792608/100629935-8fddef00-3332-11eb-842d-0e23766f249f.png">
<img width="474" alt="BCTHEME-30 IE11#2" src="https://user-images.githubusercontent.com/67792608/100629940-90768580-3332-11eb-87fb-61ec7b34d28d.png">
<img width="1680" alt="BCTHEME-30  Firefox Desktop" src="https://user-images.githubusercontent.com/67792608/100629944-91a7b280-3332-11eb-9762-1712760a8a9e.png">
<img width="602" alt="BCTHEME-30  iPad, safari" src="https://user-images.githubusercontent.com/67792608/100629947-92404900-3332-11eb-94af-8aa0b25c7320.png">
<img width="407" alt="BCTHEME-30 Safari, iphone" src="https://user-images.githubusercontent.com/67792608/100629950-92d8df80-3332-11eb-91e9-8ae39b5a7a15.png">
