### PR TITLE
fix(storefront): BCTHEME-313 Parse HTML entities in jsContext

### DIFF
--- a/assets/js/theme/common/utils/safe-string.js
+++ b/assets/js/theme/common/utils/safe-string.js
@@ -1,0 +1,9 @@
+/**
+ * This function parses HTML entities in strings
+ * @param str: String
+ * @returns String
+*/
+export const safeString = (str) => {
+    const d = new DOMParser();
+    return d.parseFromString(str, 'text/html').body.textContent;
+};

--- a/assets/js/theme/product/reviews.js
+++ b/assets/js/theme/product/reviews.js
@@ -1,6 +1,7 @@
 import nod from '../common/nod';
 import { CollapsibleEvents } from '../common/collapsible';
 import forms from '../common/models/forms';
+import { safeString } from '../common/utils/safe-string';
 
 export default class {
     constructor($reviewForm) {
@@ -62,15 +63,15 @@ export default class {
         this.validator.add([{
             selector: '[name="revrating"]',
             validate: 'presence',
-            errorMessage: this.context.reviewRating,
+            errorMessage: safeString(this.context.reviewRating),
         }, {
             selector: '[name="revtitle"]',
             validate: 'presence',
-            errorMessage: this.context.reviewSubject,
+            errorMessage: safeString(this.context.reviewSubject),
         }, {
             selector: '[name="revtext"]',
             validate: 'presence',
-            errorMessage: this.context.reviewComment,
+            errorMessage: safeString(this.context.reviewComment),
         }, {
             selector: '.writeReview-form [name="email"]',
             validate: (cb, val) => {


### PR DESCRIPTION
#### What?
This change introduces a utility function to Cornerstone that parses strings with HTML entities safely.

When https://github.com/bigcommerce/paper-handlebars/pull/110 and https://github.com/bigcommerce/paper/pull/215 are deployed, all strings injected into jsContext will have unsafe characters escaped to prevent XSS. This means any string pulled directly from jsContext and surfaced to the storefront user will display HTML entities if it has escaped characters. 

There are values that can be controlled exclusively by the merchant/developer that should be parsed so that they're rendered correctly.

The product review modal is one example; it uses injected strings that are managed from the lang files. Since the strings include escaped single quotes, HTML entities will be displayed to the storefront user unless you parse the string.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [BCTHEME-313](https://jira.bigcommerce.com/browse/BCTHEME-313)
- [List of escaped characters](https://handlebarsjs.com/api-reference/utilities.html#handlebars-escapeexpression-string)

#### Screenshots (if appropriate)
Before:
![image](https://user-images.githubusercontent.com/16565458/100674791-5c4b9680-332b-11eb-842c-493ded80ddb5.png)

After:
![image](https://user-images.githubusercontent.com/16565458/100674848-74bbb100-332b-11eb-9535-38be0439b236.png)

