### PR TITLE
fix(storefront): BCTHEME-87 Product images squashed in Category view in AMP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Product images squashed in Category view in AMP. [#1921](https://github.com/bigcommerce/cornerstone/pull/1921)
 - Fixed misaligned tooltip for required product option. [#1915](https://github.com/bigcommerce/cornerstone/pull/1915)
 - Fixed tooltip overlaying by facebook button. [#1914](https://github.com/bigcommerce/cornerstone/pull/1914)
 - Cornerstone - Text hover color does not change when Dropdown menu display mode is set to 'Alternative'. [#1918](https://github.com/bigcommerce/cornerstone/pull/1918)

--- a/templates/components/amp/css/category.html
+++ b/templates/components/amp/css/category.html
@@ -109,6 +109,15 @@
     position: relative;
 }
 
+.card-figure amp-img img {
+    height: auto;
+    min-height: auto;
+    max-height: 100%;
+    width: auto;
+    min-width: auto;
+    max-width: 100%;
+}
+
 .card-image {
     max-width: 100%;
     height: auto;


### PR DESCRIPTION
#### What?

This PR has fix for destorted images of product cards on category page. Now all images will be contained in card space

#### Tickets / Documentation

[BCTHEME-87](https://jira.bigcommerce.com/browse/BCTHEME-87)

#### Screenshots (if appropriate)

<img width="851" alt="Screenshot 2020-12-03 at 17 44 07" src="https://user-images.githubusercontent.com/66325265/101053432-74701f80-3590-11eb-9156-b0a1c61781d6.png">

ios
<img width="577" alt="Screenshot 2020-12-03 at 17 37 52" src="https://user-images.githubusercontent.com/66325265/101053463-7c2fc400-3590-11eb-83d1-c71adb448a72.png">

android
<img width="577" alt="Screenshot 2020-12-03 at 17 38 18" src="https://user-images.githubusercontent.com/66325265/101053482-82be3b80-3590-11eb-90c0-5c99a1c94dae.png">

