### PR TITLE
fix(storefront): BCTHEME-37 Cornerstone - Image Zoom Does Not Work on Internet Explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Cornerstone - Image Zoom Does Not Work on Internet Explorer. [#1923](https://github.com/bigcommerce/cornerstone/pull/1923)
 - Parse HTML entities in jsContext. [#1917](https://github.com/bigcommerce/cornerstone/pull/1917)
 - Product images squashed in Category view in AMP. [#1921](https://github.com/bigcommerce/cornerstone/pull/1921)
 - Fixed misaligned tooltip for required product option. [#1915](https://github.com/bigcommerce/cornerstone/pull/1915)

--- a/assets/js/theme/product/image-gallery.js
+++ b/assets/js/theme/product/image-gallery.js
@@ -90,10 +90,14 @@ export default class ImageGallery {
     }
 
     checkImage() {
-        const containerHeight = $('.productView-image').height();
-        const containerWidth = $('.productView-image').width();
-        const height = this.easyzoom.data('easyZoom').$zoom.context.height;
-        const width = this.easyzoom.data('easyZoom').$zoom.context.width;
+        const $imageContainer = $('.productView-image');
+        const containerHeight = $imageContainer.height();
+        const containerWidth = $imageContainer.width();
+
+        const $image = this.easyzoom.data('easyZoom').$zoom;
+        const height = $image.height();
+        const width = $image.width();
+
         if (height < containerHeight || width < containerWidth) {
             this.easyzoom.data('easyZoom').hide();
         }

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -422,6 +422,8 @@
 .productView-image .easyzoom-flyout {
     overflow: hidden;
     position: absolute;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
 


### PR DESCRIPTION

#### What?

This PR has fix for product image zoom on PDP in IE11. The problem was because zoom image height and width were calculated as 0 in IE, so if statement with hiding zoom was truthful. Changing the method of calculating width and height fixed the problem

#### Tickets / Documentation

[BCTHEME-37](https://jira.bigcommerce.com/browse/BCTHEME-37)

#### Screenshots (if appropriate)

in chrome calculations of image sizes was correct
<img width="1385" alt="chrome" src="https://user-images.githubusercontent.com/66325265/101503520-dce94300-397a-11eb-9c65-6d58e6d82ecf.png">
but in ie11 old method of calculation returned 0
![ie](https://user-images.githubusercontent.com/66325265/101503619-f2f70380-397a-11eb-9dc1-54affa9392f4.jpg)

