### PR TITLE
feat(storefront): BCTHEME-306 show price range on option selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Added narrow down pricing during option selections [#1924](https://github.com/bigcommerce/cornerstone/pull/1924)
 
 ## 5.0.0 (12-14-2020)
 - Parse HTML entities in jsContext. [#1917](https://github.com/bigcommerce/cornerstone/pull/1917)

--- a/assets/js/test-unit/theme/common/payment-method.spec.js
+++ b/assets/js/test-unit/theme/common/payment-method.spec.js
@@ -127,7 +127,7 @@ describe('PaymentMethod', () => {
 
             it('should have valid input expiration date', () => {
                 const callback = jasmine.createSpy();
-                const validator = { add: ({ validate }) => validate(callback, '12/20') };
+                const validator = { add: ({ validate }) => validate(callback, '12/25') };
                 Validators.setExpirationValidation(validator, 'selector');
 
                 expect(callback).toHaveBeenCalledWith(true);

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -274,13 +274,19 @@ export default class ProductDetailsBase {
         this.clearPricingNotFound(viewModel);
 
         if (price.with_tax) {
+            const updatedPrice = price.price_range ?
+                `${price.price_range.min.with_tax.formatted} - ${price.price_range.max.with_tax.formatted}`
+                : price.with_tax.formatted;
             viewModel.priceLabel.$span.show();
-            viewModel.$priceWithTax.html(price.with_tax.formatted);
+            viewModel.$priceWithTax.html(updatedPrice);
         }
 
         if (price.without_tax) {
+            const updatedPrice = price.price_range ?
+                `${price.price_range.min.without_tax.formatted} - ${price.price_range.max.without_tax.formatted}`
+                : price.without_tax.formatted;
             viewModel.priceLabel.$span.show();
-            viewModel.$priceWithoutTax.html(price.without_tax.formatted);
+            viewModel.$priceWithoutTax.html(updatedPrice);
         }
 
         if (price.rrp_with_tax) {


### PR DESCRIPTION
#### What?

This PR adds opportunity to narrow down price on option selection and show to Customer a price range for selected option if it's avalable. It's linked with [PRICE-14](https://jira.bigcommerce.com/browse/PRICE-14).

#### Tickets / Documentation


- [BCTHEME-306](https://jira.bigcommerce.com/browse/BCTHEME-306)

#### Screenshots (if appropriate)
After:
<img width="875" alt="After Price Range " src="https://user-images.githubusercontent.com/67792608/101798190-8105f200-3b13-11eb-9a94-9d28e126e2e4.png">
Before:
<img width="1199" alt="Before Price Range" src="https://user-images.githubusercontent.com/67792608/101798197-82371f00-3b13-11eb-87a3-019f47d22eb1.png">

