### PR TITLE
fix(storefront): BCTHEME-16 Cornerstone - loading of thumbnail image delayed on cart page 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Cornerstone - loading of thumbnail image delayed on cart page . [#1925](https://github.com/bigcommerce/cornerstone/pull/1925)
 - Parse HTML entities in jsContext. [#1917](https://github.com/bigcommerce/cornerstone/pull/1917)
 - Product images squashed in Category view in AMP. [#1921](https://github.com/bigcommerce/cornerstone/pull/1921)
 - Fixed misaligned tooltip for required product option. [#1915](https://github.com/bigcommerce/cornerstone/pull/1915)

--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -23,7 +23,7 @@
                             image=image
                             class="cart-item-image"
                             fallback_size=../theme_settings.productthumb_size
-                            lazyload='disabled'
+                            lazyload=../theme_settings.lazyload_mode
                             default_image=../theme_settings.default_image_product
                         }}
                     {{/if}}


### PR DESCRIPTION
#### What?

This PR has fix for long loading of product images on Cart Page. The reason of this issue is using wrong path to images from cdn - they are full size instead of being optimized for small size of cart item. Improvement is that for common resolution displays used 100x100 images and for high resolution displays used 200x200 images

#### Tickets / Documentation

[BCTHEME-16](https://jira.bigcommerce.com/browse/BCTHEME-16)

#### Screenshots (if appropriate)
images were taking from the wrong srcset url because of no size attribute it it
<img width="1661" alt="retina-images-old" src="https://user-images.githubusercontent.com/66325265/101887512-a3e0e680-3ba5-11eb-8408-d7da3092f385.png">

after changing lazyload field sent to responsive-img component, lazysizes library sets sizes attributes to the images and correct url from src set is taken 
<img width="1664" alt="Screenshot 2020-12-17 at 16 18 49" src="https://user-images.githubusercontent.com/66325265/102499691-270dab00-4084-11eb-82d8-965b101139c1.png">

