### PR TITLE
fix(storefront): BCTHEME-193 fix not being able to change product qty with keyboard multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed unable to change product quantity several times on cart page using keyboard. [#1927](https://github.com/bigcommerce/cornerstone/pull/1927)
 
 ## 5.0.0 (12-14-2020)
 - Parse HTML entities in jsContext. [#1917](https://github.com/bigcommerce/cornerstone/pull/1917)

--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -15,12 +15,17 @@ export default class Cart extends PageManager {
         this.$cartTotals = $('[data-cart-totals]');
         this.$overlay = $('[data-cart] .loadingOverlay')
             .hide(); // TODO: temporary until roper pulls in his cart components
+        this.$activeCartItemId = null;
+        this.$activeCartItemBtnAction = null;
 
         this.bindEvents();
     }
 
     cartUpdate($target) {
         const itemId = $target.data('cartItemid');
+        this.$activeCartItemId = itemId;
+        this.$activeCartItemBtnAction = $target.data('action');
+
         const $el = $(`#qty-${itemId}`);
         const oldQty = parseInt($el.val(), 10);
         const maxQty = parseInt($el.data('quantityMax'), 10);
@@ -220,6 +225,10 @@ export default class Cart extends PageManager {
             const quantity = $('[data-cart-quantity]', this.$cartContent).data('cartQuantity') || 0;
 
             $('body').trigger('cart-quantity-update', quantity);
+
+            $(`[data-cart-itemid='${this.$activeCartItemId}']`, this.$cartContent)
+                .filter(`[data-action='${this.$activeCartItemBtnAction}']`)
+                .trigger('focus');
         });
     }
 


### PR DESCRIPTION
#### What?

This PR addresses issue with not being able to change product quantity on Cart page using keyboard multiple times.

#### Tickets / Documentation


- [BCTHEME-193](https://jira.bigcommerce.com/browse/BCTHEME-193)


#### Screenshots (if appropriate)
the video is attached to the ticket as well.


https://user-images.githubusercontent.com/67792608/103279357-425aad80-49d6-11eb-881c-1b9e7d382faa.mov

