### PR TITLE
fix(storefront): BCTHEME-345 define a main region on pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Draft
-
+- Add main tag on pages like Homepage, Category, Product etc to define the dominant content. [#1929](https://github.com/bigcommerce/cornerstone/pull/1929)
 ## 5.0.0 (12-14-2020)
 - Parse HTML entities in jsContext. [#1917](https://github.com/bigcommerce/cornerstone/pull/1917)
 - Product images squashed in Category view in AMP. [#1921](https://github.com/bigcommerce/cornerstone/pull/1921)

--- a/templates/components/common/body.html
+++ b/templates/components/common/body.html
@@ -1,8 +1,8 @@
-<div class="body" id='main-content' data-currency-code="{{currency_selector.active_currency_code}}">
+<main class="body" id='main-content' role='main' data-currency-code="{{currency_selector.active_currency_code}}">
     {{#block "hero"}} {{/block}}
     <div class="container">
         {{#block "page"}} {{/block}}
     </div>
     {{> components/common/modal/modal}}
     {{> components/common/alert/alert-modal}}
-</div>
+</main>


### PR DESCRIPTION
#### What?

This PR fixes an issue with not defining main region on pages by using HTML5 semantic tag `main`; for supporting this on IE11 `role='main' `has been [explicitly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main) added  to ensure it is accessible in screen readers like JAWS. 

#### Tickets / Documentation

- [BCTHEME-345](https://jira.bigcommerce.com/browse/BCTHEME-345)

#### Screenshots (if appropriate)
<img width="1680" alt="main region on category page" src="https://user-images.githubusercontent.com/67792608/102791935-69025e00-43b0-11eb-8929-e5d1665f15c9.png">
<img width="1680" alt="main region on Homepage" src="https://user-images.githubusercontent.com/67792608/102791943-6acc2180-43b0-11eb-9e4c-4cca00058cf3.png">
<img width="1680" alt="main region on PDP" src="https://user-images.githubusercontent.com/67792608/102791945-6b64b800-43b0-11eb-9ee0-c2bb71f9e535.png">

