### PR TITLE
fix(storefront): BCTHEME-341 fix placeholder contrast ratio according to AA standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed input placeholder color contrast according to AA standard. [#1933](https://github.com/bigcommerce/cornerstone/pull/1933)
 
 ## 5.0.0 (12-14-2020)
 - Parse HTML entities in jsContext. [#1917](https://github.com/bigcommerce/cornerstone/pull/1917)

--- a/assets/scss/components/citadel/forms/_forms.scss
+++ b/assets/scss/components/citadel/forms/_forms.scss
@@ -137,6 +137,11 @@
 //    appear before the button.
 //
 // -----------------------------------------------------------------------------
+@mixin placeholder {
+    &::-webkit-input-placeholder {@content}
+    &::-moz-placeholder          {@content}
+    &:-ms-input-placeholder      {@content}
+}
 
 .form-label--alternate {
     font-family: fontFamily("headingSans");
@@ -208,6 +213,10 @@
     .form-input {
         @include breakpoint("large") {
             width: auto;
+        }
+
+        @include placeholder {
+            color: $formInput-placeholder-color;
         }
     }
 

--- a/assets/scss/settings/citadel/forms/_settings.scss
+++ b/assets/scss/settings/citadel/forms/_settings.scss
@@ -231,3 +231,5 @@ $form-checkRadio-labelBefore-top:           remCalc(3px);
 $form-checkRadio-labelAfter-top:            remCalc(4px);
 
 $form-minMaxRow-column-gutter:              $column-gutter / 4;
+
+$formInput-placeholder-color:                  stencilColor("input-font-color");


### PR DESCRIPTION

#### What?

This PR fixes input placeholder color contrast in compliance with AA standard. It's using ` input-font-color`  from `config.json` for changing color through 3 Theme's variants:
`#666666` for Light, 
`#cccccc` for Bold,
`#4f3f2f` for Warm

#### Tickets / Documentation

- [BCTHEME-341](https://jira.bigcommerce.com/browse/BCTHEME-341)

#### Screenshots (if appropriate)
<img width="1680" alt="Placeholder Color" src="https://user-images.githubusercontent.com/67792608/103008693-35553e80-453e-11eb-91a3-e8d46b79d03d.png">
<img width="1495" alt="Contrast Ratio Placeholder" src="https://user-images.githubusercontent.com/67792608/103008739-43a35a80-453e-11eb-94e0-0d7915b6f62e.png">

