### PR TITLE
feature(storefront): Empty cart message not read by screen reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Empty cart message not read by screen reader. [#1935](https://github.com/bigcommerce/cornerstone/pull/1935)
 
 ## 5.0.0 (12-14-2020)
 - Parse HTML entities in jsContext. [#1917](https://github.com/bigcommerce/cornerstone/pull/1917)

--- a/templates/components/common/cart-preview.html
+++ b/templates/components/common/cart-preview.html
@@ -77,7 +77,7 @@
                 </div>
             {{/if}}
         {{else}}
-            <div class="previewCart-emptyBody">
+            <div role="alert" aria-live="polite" aria-atomic="false" class="previewCart-emptyBody">
                 {{lang 'cart.checkout.empty_cart'}}
             </div>
         {{/if}}


### PR DESCRIPTION

#### What?

This PR adds empty cart notification for screen reader in cart preview

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

[BCTHEME-342
](https://jira.bigcommerce.com/browse/BCTHEME-342)

#### Screenshots (if appropriate)

<img width="1269" alt="Screenshot 2020-12-24 at 19 29 54" src="https://user-images.githubusercontent.com/66325265/103101276-796c4000-461f-11eb-8b31-9e49b1899b9e.png">
