### PR TITLE
feat(storefront): BCTHEME-344 Carousel buttons do not receive focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Carousel buttons do not receive focus. [#1937](https://github.com/bigcommerce/cornerstone/pull/1937)
 
 ## 5.0.0 (12-14-2020)
 - Parse HTML entities in jsContext. [#1917](https://github.com/bigcommerce/cornerstone/pull/1917)

--- a/assets/js/theme/common/carousel/utils/setTabindexes.js
+++ b/assets/js/theme/common/carousel/utils/setTabindexes.js
@@ -4,7 +4,7 @@ export default ($slides, $prevArrow, $nextArrow, actualSlide, actualSlideCount) 
     $slides.each((index, element) => {
         const $element = $(element);
         const tabIndex = $element.hasClass('slick-active') ? 0 : -1;
-        if (!$element.hasClass('js-product-slide')) {
+        if ($element.attr('href') !== undefined) {
             $element.attr('tabindex', tabIndex);
         }
 

--- a/templates/components/carousel-content.html
+++ b/templates/components/carousel-content.html
@@ -2,6 +2,6 @@
     <span class="heroCarousel-title">{{{heading}}}</span>
     <p class="heroCarousel-description">{{{text}}}</p>
     {{#if button_text}}
-        <span class="heroCarousel-action button button--primary button--large">{{button_text}}</span>
+        <a href="{{url}}" aria-label="{{#if this.alt_text.length '!=' 0}}{{this.alt_text}}{{else}}{{lang 'common.carousel_slide_number' slide_number=(add @index 1)}}{{/if}}, {{button_text}}" class="heroCarousel-action button button--primary button--large">{{button_text}}</a>
     {{/if}}
 </div>

--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -19,7 +19,11 @@
     <button aria-label="{{lang 'carousel.arrowAriaLabel'}} {{carousel.slides.length}}" class="js-hero-prev-arrow slick-prev slick-arrow">hero-prev-arrow</button>
     {{/and}}
     {{#each carousel.slides}}
+    {{#if button_text}}
+    <div class="js-hero-slide">
+    {{else}}
     <a href="{{url}}" class="js-hero-slide" aria-label="{{#if this.alt_text.length '!=' 0}}{{this.alt_text}}{{else}}{{lang 'common.carousel_slide_number' slide_number=(add @index 1)}}{{/if}}">
+    {{/if}}
         <div class="heroCarousel-slide {{#if ../theme_settings.homepage_stretch_carousel_images}}stretch{{/if}} {{#if @first}}heroCarousel-slide--first{{/if}}">
             <div class="heroCarousel-image-wrapper">
             {{#if @first}}
@@ -50,7 +54,11 @@
                 {{/if}}
             {{/if}}
         </div>
+    {{#if button_text}}
+    </div>
+    {{else}}
     </a>
+    {{/if}}
     {{/each}}
     {{#and arrows (if carousel.slides.length '>' 1)}}
     <button aria-label="{{lang 'carousel.arrowAriaLabel'}} {{carousel.slides.length}}" class="js-hero-next-arrow slick-next slick-arrow">hero-next-arrow</button>


### PR DESCRIPTION

#### What?

This PR has update for slide button in carousel. If button added to slide - it use link from page builder and the slide is div tag. In case we have no button whole slide is the link

#### Tickets / Documentation

[BCTHEME-344](https://jira.bigcommerce.com/browse/BCTHEME-344)

#### Screenshots (if appropriate)

Attach images or add image links here.

![Screenshot 2020-12-29 at 17 46 48](https://user-images.githubusercontent.com/66325265/103298611-62ed2c80-4a03-11eb-9741-6f129296aae7.png)
![Screenshot 2020-12-29 at 17 50 54](https://user-images.githubusercontent.com/66325265/103298751-a9428b80-4a03-11eb-995a-83785228e8ec.png)
