### PR TITLE
Bump sweetalert2 and replace window.confirm()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Bump sweetalert2 and replace window.confirm() [#1938](https://github.com/bigcommerce/cornerstone/pull/1938)
 
 ## 5.0.0 (12-14-2020)
 - Parse HTML entities in jsContext. [#1917](https://github.com/bigcommerce/cornerstone/pull/1917)

--- a/assets/js/theme/account.js
+++ b/assets/js/theme/account.js
@@ -84,22 +84,62 @@ export default class Account extends PageManager {
      * Binds a submit hook to ensure the customer receives a confirmation dialog before deleting an address
      */
     bindDeleteAddress() {
+        // Keep track of swal popup answer
+        let isConfirmed = false;
+
         $('[data-delete-address]').on('submit', event => {
+            // If answered "ok" previously continue submitting the form.
+            if (isConfirmed) {
+                return true;
+            }
+
             const message = $(event.currentTarget).data('deleteAddress');
 
-            if (!window.confirm(message)) {
-                event.preventDefault();
-            }
+            // Confirm is not ok yet so prevent the form from submitting and show the message.
+            event.preventDefault();
+
+            swal.fire({
+                icon: 'warning',
+                text: message,
+                showCloseButton: true,
+                showCancelButton: true,
+                reverseButtons: true,
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    isConfirmed = true;
+                    $(event.currentTarget).trigger('submit');
+                }
+            });
         });
     }
 
     bindDeletePaymentMethod() {
+        // Keep track of swal popup answer
+        let isConfirmed = false;
+
         $('[data-delete-payment-method]').on('submit', event => {
+            // If answered "ok" previously continue submitting the form.
+            if (isConfirmed) {
+                return true;
+            }
+
             const message = $(event.currentTarget).data('deletePaymentMethod');
 
-            if (!window.confirm(message)) {
-                event.preventDefault();
-            }
+            // Confirm is not ok yet so prevent the form from submitting and show the message.
+            event.preventDefault();
+
+            swal.fire({
+                icon: 'warning',
+                text: message,
+                showCloseButton: true,
+                showCancelButton: true,
+                reverseButtons: true,
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    isConfirmed = true;
+                    $(event.currentTarget).trigger('submit');
+                }
+            });
         });
     }
 

--- a/assets/js/theme/wishlist.js
+++ b/assets/js/theme/wishlist.js
@@ -2,6 +2,7 @@ import 'foundation-sites/js/foundation/foundation';
 import 'foundation-sites/js/foundation/foundation.reveal';
 import nod from './common/nod';
 import PageManager from './page-manager';
+import swal from './global/sweet-alert';
 
 export default class WishList extends PageManager {
     constructor(context) {
@@ -18,14 +19,32 @@ export default class WishList extends PageManager {
      * Creates a confirm box before deleting all wish lists
      */
     wishlistDeleteConfirm() {
-        $('body').on('click', '[data-wishlist-delete]', event => {
-            const confirmed = window.confirm(this.context.wishlistDelete);
+        // Keep track of swal popup answer
+        let isConfirmed = false;
 
-            if (confirmed) {
+        $('[data-wishlist-delete]').on('submit', event => {
+            // If answered "ok" previously continue submitting the form.
+            if (isConfirmed) {
                 return true;
             }
 
+            const message = this.context.wishlistDelete;
+
+            // Confirm is not ok yet so prevent the form from submitting and show the message.
             event.preventDefault();
+
+            swal.fire({
+                icon: 'warning',
+                text: message,
+                showCloseButton: true,
+                showCancelButton: true,
+                reverseButtons: true,
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    isConfirmed = true;
+                    $(event.currentTarget).trigger('submit');
+                }
+            });
         });
     }
 

--- a/assets/scss/components/vendor/sweetalert2/_sweetalert2.scss
+++ b/assets/scss/components/vendor/sweetalert2/_sweetalert2.scss
@@ -79,6 +79,7 @@
         background-color: $alert-button-cancel-bgColor;
         border-color: $alert-button-cancel-borderColor;
         color: $alert-button-cancel-color;
+        margin-right: spacing("half");
     }
 
     .swal2-cancel:focus,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigcommerce-cornerstone",
-  "version": "4.12.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -18168,9 +18168,9 @@
       "integrity": "sha1-j7oY10GeX4GOcSxPgtg+41dhDmE="
     },
     "sweetalert2": {
-      "version": "9.17.2",
-      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-9.17.2.tgz",
-      "integrity": "sha512-HkpPZVMYsnhFUBLdy/LvkU9snggKP3VAuSVnPhVXjxdg02lWbFx0W8H3m7A+WMWw2diXZS1wIa4m67XkNxdvew=="
+      "version": "10.12.6",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-10.12.6.tgz",
+      "integrity": "sha512-kkPRpNqP0wF9tAVu1Ygp4pQx4pXY/pgseyW3dOXXRu0S6s7HKfHEmpBUIZrBylRfeJFPOsSEk6sALSwKzNZ9RQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "regenerator-runtime": "^0.13.7",
     "slick-carousel": "^1.8.1",
     "svg-injector": "^1.1.3",
-    "sweetalert2": "^9.17.2",
+    "sweetalert2": "^10.12.6",
     "whatwg-fetch": "^3.4.1"
   },
   "devDependencies": {

--- a/templates/components/account/wishlist-list.html
+++ b/templates/components/account/wishlist-list.html
@@ -20,14 +20,14 @@
                 {{/if}}
             </td>
             <td class="table-actions">
-                <form method="post" action="{{delete_url}}" class="form">
+                <form method="post" action="{{delete_url}}" class="form" data-wishlist-delete>
                     <fieldset class="form-fieldset">
                         {{#if is_public}}
                             <a href="{{share_url}}" class="button button--primary button--small"
                            role="button">{{lang 'common.share'}}</a>
                         {{/if}}
                         <a href="{{edit_url}}" class="button button--small" data-wishlist>{{lang 'common.edit'}}</a>
-                        <input type="submit" value="{{lang 'common.delete'}}" class="button button--small" data-wishlist-delete>
+                        <input type="submit" value="{{lang 'common.delete'}}" class="button button--small">
                     </fieldset>
                 </form>
             </td>
@@ -35,7 +35,7 @@
     {{/each}}
     </tbody>
 </table>
-<form method="post" action="{{this.urls.account.wishlists.delete}}" class="form">
+<form method="post" action="{{this.urls.account.wishlists.delete}}" class="form" data-wishlist-delete>
     {{#unless customer.wishlists}}
         <p class="form-actions">{{> components/common/alert/alert-info (lang 'account.wishlists.you_have_none')}}</p>
 
@@ -47,7 +47,7 @@
             {{#each customer.wishlists}}
                 <input type="hidden" value="{{this.id}}" name="deletewishlist[]">
             {{/each}}
-            <input type="submit" value="{{lang 'account.wishlists.delete_all'}}" class="button" data-wishlist-delete>
+            <input type="submit" value="{{lang 'account.wishlists.delete_all'}}" class="button">
         {{/if}}
     </div>
 </form>


### PR DESCRIPTION
#### What?

Bump sweetalert2 and replace the usage of window.confirm when deleting wishlists, addresses, and payment methods.

#### Screenshots

**Delete Wishlist**
<img width="2160" alt="Screen Shot 2020-12-30 at 8 08 59 PM" src="https://user-images.githubusercontent.com/5056945/103394125-7ec40180-4adb-11eb-81cb-2dbb029d458f.png">

**Delete Address**
<img width="2160" alt="Screen Shot 2020-12-30 at 8 10 44 PM" src="https://user-images.githubusercontent.com/5056945/103394130-82578880-4adb-11eb-83d2-87a314f41ac9.png">

**Delete Payment Method**
<img width="2160" alt="Screen Shot 2020-12-30 at 8 12 48 PM" src="https://user-images.githubusercontent.com/5056945/103394132-8388b580-4adb-11eb-8338-5c8858d0b462.png">
