### PR TITLE
Display credit card icons when adding payment method in development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Display credit card icons when adding payment method in development [#1941](https://github.com/bigcommerce/cornerstone/pull/1941)
 - Fixed images placeholder on hero carousel shifted on mobile when slide has content. [#2112](https://github.com/bigcommerce/cornerstone/pull/2112)
 - Google AMP feature request - Add in release date info for preorder products. [#2107](https://github.com/bigcommerce/cornerstone/pull/2107)
 - Translation for states select field on account signup page. [#2105](https://github.com/bigcommerce/cornerstone/pull/2105)

--- a/templates/pages/account/add-payment-method.html
+++ b/templates/pages/account/add-payment-method.html
@@ -47,7 +47,7 @@
                 <p class="paymentMethodForm-subheading">
                     {{forms.payment_method.provider_name}}
                     <span class="paymentMethodForm-cards">
-                        {{#each ../theme_settings.supported_card_type_icons}}
+                        {{#each theme_settings.supported_card_type_icons}}
                             <img class="paymentMethodForm-cards-icon" src="{{cdn (concat (concat 'img/payment-methods/' this) '.svg')}}" alt="{{lang (concat 'account.payment_methods.card_types.' this)}}" title="{{lang (concat 'account.payment_methods.card_types.' this)}}">
                         {{/each}}
                     </span>


### PR DESCRIPTION
#### What?

Automatic highlighting of credit card type does not work on localhost due to unnecessarily going outside of the `{{each}}` loop to reach the `supported_card_type_icons` theme setting.

#### Screenshots

**BEFORE**
<img width="627" alt="01 before" src="https://user-images.githubusercontent.com/5056945/103669966-daecb280-4f2d-11eb-9d64-eceeb0603089.png">

**AFTER**
<img width="577" alt="02 after" src="https://user-images.githubusercontent.com/5056945/103669968-db854900-4f2d-11eb-84a6-22e4da1531c8.png">
