### PR TITLE
fix(storefront): BCTHEME-379 fix non-text contrast on add to cart button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed non-text contrast on add to cart modal according to WCAG AA standard.  [#1946](https://github.com/bigcommerce/cornerstone/pull/1946)
 - Carousel buttons do not receive focus. [#1937](https://github.com/bigcommerce/cornerstone/pull/1937)
 - Empty cart message not read by screen reader. [#1935](https://github.com/bigcommerce/cornerstone/pull/1935)
 - No tooltips provided for carousel buttons. [#1934](https://github.com/bigcommerce/cornerstone/pull/1934)

--- a/assets/scss/tools/_theme_focus.scss
+++ b/assets/scss/tools/_theme_focus.scss
@@ -4,7 +4,7 @@
 
 $outline-width:  2px;
 $outline-style:  solid;
-$outline-color:  #2E8FFF;
+$outline-color:  #0F7FFF;
 $outline-offset: 1px;
 
 input,


### PR DESCRIPTION
#### What?

This PR fixes issue with Insufficient non-text contrast for active focus on buttons like add to cart, proceed to checkout etc.
Used color in line with AA standard.
#### Tickets / Documentation



- [BCTHEME-379](https://jira.bigcommerce.com/browse/BCTHEME-379)


#### Screenshots (if appropriate)

<img width="1680" alt="Oultine on focus  Bold theme" src="https://user-images.githubusercontent.com/67792608/104442460-c350a200-559d-11eb-8682-2c3235f4e7f7.png">
<img width="1679" alt="Oultine on focus  Light theme" src="https://user-images.githubusercontent.com/67792608/104442468-c481cf00-559d-11eb-97ab-25b42281821d.png">
<img width="1680" alt="Oultine on focus  Warm theme" src="https://user-images.githubusercontent.com/67792608/104442473-c5b2fc00-559d-11eb-8382-0ff8f0a8e28a.png">
<img width="781" alt="Contrast check for Warm Theme" src="https://user-images.githubusercontent.com/67792608/104442481-c8155600-559d-11eb-8a0e-e4a646df495e.png">

