### PR TITLE
fix(storefront): BCTHEME-369 fix announcement on adding to cart by screen reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed announcement for product on adding to cart. [#1950](https://github.com/bigcommerce/cornerstone/pull/1950)
 - Carousel buttons do not receive focus. [#1937](https://github.com/bigcommerce/cornerstone/pull/1937)
 - Empty cart message not read by screen reader. [#1935](https://github.com/bigcommerce/cornerstone/pull/1935)
 - No tooltips provided for carousel buttons. [#1934](https://github.com/bigcommerce/cornerstone/pull/1934)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -334,6 +334,11 @@ export default class ProductDetails extends ProductDetailsBase {
                 this.redirectTo(response.data.cart_item.cart_url || this.context.urls.cart);
             }
         });
+
+        $addToCartBtn.next().attr({
+            role: 'status',
+            'aria-live': 'polite',
+        });
     }
 
     /**

--- a/templates/components/products/add-to-cart.html
+++ b/templates/components/products/add-to-cart.html
@@ -40,8 +40,14 @@
     <p class="alertBox-column alertBox-message"></p>
 </div>
 {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
-    <div class="form-action" role="status" aria-live="polite">
-        <input id="form-action-addToCart" data-wait-message="{{lang 'products.adding_to_cart'}}" class="button button--primary" type="submit"
-            value="{{#if product.pre_order}}{{lang 'products.pre_order'}}{{else}}{{lang 'products.add_to_cart'}}{{/if}}">
+    <div class="form-action">
+        <input 
+            id="form-action-addToCart"
+            data-wait-message="{{lang 'products.adding_to_cart'}}"
+            class="button button--primary"
+            type="submit"
+            value="{{#if product.pre_order}}{{lang 'products.pre_order'}}{{else}}{{lang 'products.add_to_cart'}}{{/if}}"
+        >
+        <span class="product-status-message aria-description--hidden">{{lang 'products.adding_to_cart'}} {{lang 'category.add_cart_announcement'}}</span>
     </div>
 {{/or}}


### PR DESCRIPTION


#### What?

This PR improves announcement by Screen Reader when User clicks on button 'Add to Cart'. Hidden description has been added for Add to Cart button on Modal window (quickView) and PDP. Role status is being added on button's click.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [BCTHEME-369](https://jira.bigcommerce.com/browse/BCTHEME-369)

#### Screenshots (if appropriate)


https://user-images.githubusercontent.com/67792608/104591877-02eabd00-5676-11eb-80fd-baa5118ab8e6.mov


https://user-images.githubusercontent.com/67792608/104591881-054d1700-5676-11eb-8caf-12e27095983c.mov



