### PR TITLE
Update _navUser.scss

### DIFF
--- a/assets/scss/components/stencil/navUser/_navUser.scss
+++ b/assets/scss/components/stencil/navUser/_navUser.scss
@@ -184,7 +184,6 @@
 
         // scss-lint:disable NestingDepth
         &.is-open {
-            top: auto !important; // 7
             left: auto !important; // 7
             right: remCalc(5px); // 7
             @include breakpoint("medium") {


### PR DESCRIPTION
top: auto !important; is overwriting position set inline by javascript.

#### What?

Adding a top: auto value to minicart dropdown overrides inline styling set by javascript function.