### PR TITLE
fix(storefront): BCTHEME-356 Required checkbox message blocks the checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Fixed required checkbox message displaying. [1963](https://github.com/bigcommerce/cornerstone/pull/1963)
+
 ## Draft
 - Updated Cornerstone theme and respected variants to meet the verticals/industries documented in BCTHEME-387
 - Fixed selecting certain option types which pushes window view to the bottom of the page. [#1959](https://github.com/bigcommerce/cornerstone/pull/1959)

--- a/templates/components/amp/products/options/input-checkbox.html
+++ b/templates/components/amp/products/options/input-checkbox.html
@@ -6,13 +6,15 @@
             <small>{{lang 'common.required'}}</small>
         {{/if}}
     </label>
-    <input
-        class="form-checkbox"
-        type="checkbox"
-        name="attribute[{{id}}]"
-        id="attribute-{{id}}"
-        value="{{value}}"
-        {{#if checked}}checked{{/if}}
-        {{#if required}}required{{/if}}>
-    <label class="form-label {{class}}" for="attribute-{{id}}">{{label}}</label>
+    <div class="form-option-wrapper">
+        <input
+            class="form-checkbox"
+            type="checkbox"
+            name="attribute[{{id}}]"
+            id="attribute-{{id}}"
+            value="{{value}}"
+            {{#if checked}}checked{{/if}}
+            {{#if required}}required{{/if}}>
+        <label class="form-label {{class}}" for="attribute-{{id}}">{{label}}</label>
+    </div>
 </div>

--- a/templates/components/products/options/input-checkbox.html
+++ b/templates/components/products/options/input-checkbox.html
@@ -5,17 +5,19 @@
         {{> components/common/requireness-msg}}
     </label>
     <input type="hidden" name="attribute[{{id}}]" value="{{noValue}}" />
-    <input
-        class="form-checkbox"
-        type="checkbox"
-        name="attribute[{{id}}]"
-        id="attribute-check-{{id}}"
-        value="{{value}}"
-        {{#if checked}}
-            checked
-            data-default
-        {{/if}}
-        {{#if required}}required{{/if}}>
+    <div class="form-option-wrapper">
+        <input
+            class="form-checkbox"
+            type="checkbox"
+            name="attribute[{{id}}]"
+            id="attribute-check-{{id}}"
+            value="{{value}}"
+            {{#if checked}}
+                checked
+                data-default
+            {{/if}}
+            {{#if required}}required{{/if}}>
 
-    <label class="form-label {{class}}" for="attribute-check-{{id}}">{{label}}</label>
+        <label class="form-label {{class}}" for="attribute-check-{{id}}">{{label}}</label>
+    </div>
 </div>


### PR DESCRIPTION
#### What?

Required checkbox error popup blocks the checkbox field. This occurs if you attempt to add a product to cart without selecting a required checkbox. 

#### Tickets / Documentation

[Jira Ticket](https://jira.bigcommerce.com/browse/BCTHEME-356)

#### Screenshots (if appropriate)

<img width="1170" alt="Screenshot 2021-01-21 at 16 02 36" src="https://user-images.githubusercontent.com/66319629/105361175-18c22a00-5c02-11eb-9918-bdcff94dc9b2.png">

