### PR TITLE
Replaced time-to-first-byte audit to server-response-time in lighthouse-config.js

### DIFF
--- a/lighthouse-config.js
+++ b/lighthouse-config.js
@@ -39,7 +39,7 @@ module.exports = {
         },
     ],
     audits: [
-        'time-to-first-byte',
+        'server-response-time',
         'metrics/first-meaningful-paint',
         'metrics/interactive',
     ],


### PR DESCRIPTION
#### What?

`time-to-first-byte` [was replaced](https://github.com/GoogleChrome/lighthouse/issues/10720) with `server-response-time` in lighthouse, which would cause this NPM script to fail. 

#### Tickets / Documentation

- [Lighthouse Proposal to replace time-to-first-byte](https://github.com/GoogleChrome/lighthouse/issues/10720)
- [Running Lighthouse NPM Script fails with `time-to-first-byte](https://github.com/bigcommerce/cornerstone/issues/1967)
