### PR TITLE
Replaced rawValue to numericValue in Lighthouse NPM Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "scripts": {
     "build": "npx webpack --config webpack.prod.js",
     "buildDev": "npx webpack --config webpack.dev.js",
-    "lighthouse": "npx lighthouse --config-path=lighthouse-config.js --quiet --output json --chrome-flags=\"--headless\" $URL | jq '.audits | map_values(.rawValue)'",
+    "lighthouse": "npx lighthouse --config-path=lighthouse-config.js --quiet --output json --chrome-flags=\"--headless\" $URL | jq '.audits | map_values(.displayValue)'",
     "test": "npx jest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "scripts": {
     "build": "npx webpack --config webpack.prod.js",
     "buildDev": "npx webpack --config webpack.dev.js",
-    "lighthouse": "npx lighthouse --config-path=lighthouse-config.js --quiet --output json --chrome-flags=\"--headless\" $URL | jq '.audits | map_values(.displayValue)'",
+    "lighthouse": "npx lighthouse --config-path=lighthouse-config.js --quiet --output json --chrome-flags=\"--headless\" $URL | jq '.audits | map_values(.numericValue)'",
     "test": "npx jest"
   }
 }


### PR DESCRIPTION
#### What?

I replaced `rawValue` to `numericValue` within the lighthous NPM script due to it being [changed upstream](https://github.com/GoogleChrome/lighthouse/pull/8385).

#### Tickets / Documentation

- [core: replace rawValue with numericValue in audit result](https://github.com/GoogleChrome/lighthouse/pull/8385)
- [Running Lighthouse NPM Script returns null](https://github.com/bigcommerce/cornerstone/issues/1969)
