### PR TITLE
fix(storefront): BCTHEME-385 move a phrase from html to en.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Moved phrase from compare.html to en.json for increasing localization. [#1972](https://github.com/bigcommerce/cornerstone/pull/1972)
 - Updated Cornerstone theme and respected variants to meet the verticals/industries documented in BCTHEME-387
 - Fixed selecting certain option types which pushes window view to the bottom of the page. [#1959](https://github.com/bigcommerce/cornerstone/pull/1959)
 - Fixed case when default option is out of stock add to cart button does not populate for in stock options. [#1955](https://github.com/bigcommerce/cornerstone/pull/1955)

--- a/lang/en.json
+++ b/lang/en.json
@@ -720,6 +720,7 @@
                 "5": "5 stars (best)"
             },
             "write_a_review": "Write a Review",
+            "no_reviews": "No Reviews",
             "form_write": {
                 "name": "Name",
                 "email": "Email",

--- a/templates/pages/compare.html
+++ b/templates/pages/compare.html
@@ -96,7 +96,7 @@
                         {{#if rating}}
                             {{> components/products/ratings rating=rating}}
                         {{else}}
-                            No Reviews
+                            {{lang 'products.reviews.no_reviews'}}
                     {{/if}}
                     </td>
                     {{/each}}


### PR DESCRIPTION
#### What?

The PR fixes hard-coding phrase in html and moves it to en.json

#### Tickets / Documentation
- [BCTHEME-385](https://jira.bigcommerce.com/browse/BCTHEME-385)

#### Screenshots (if appropriate)
<img width="1176" alt="bctheme-385" src="https://user-images.githubusercontent.com/67792608/105714432-01967b80-5f25-11eb-994f-5ad8be0ef7a8.png">
