### PR TITLE
fix(storefront): BCTHEME-264 fix update discount banner on PDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed Discount Banner update on adding item to Cart from PDP [#1974](https://github.com/bigcommerce/cornerstone/pull/1974)
 - Updated Cornerstone theme and respected variants to meet the verticals/industries documented in BCTHEME-387
 - Fixed selecting certain option types which pushes window view to the bottom of the page. [#1959](https://github.com/bigcommerce/cornerstone/pull/1959)
 - Fixed case when default option is out of stock add to cart button does not populate for in stock options. [#1955](https://github.com/bigcommerce/cornerstone/pull/1955)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -401,12 +401,27 @@ export default class ProductDetails extends ProductDetailsBase {
             const $cartQuantity = $('[data-cart-quantity]', modal.$content);
             const $cartCounter = $('.navUser-action .cart-count');
             const quantity = $cartQuantity.data('cartQuantity') || 0;
+            const $promotionBanner = $('[data-promotion-banner]');
+            const $backToShopppingBtn = $('.previewCartCheckout > [data-reveal-close]');
+            const $modalCloseBtn = $('#previewModal > .modal-close');
+            const bannerUpdateHandler = () => {
+                const $productContainer = $('#main-content > .container');
+
+                $productContainer.append('<div class="loadingOverlay pdp-update"></div>');
+                $('.loadingOverlay.pdp-update', $productContainer).show();
+                window.location.reload();
+            };
 
             $cartCounter.addClass('cart-count--positive');
             $body.trigger('cart-quantity-update', quantity);
 
             if (onComplete) {
                 onComplete(response);
+            }
+
+            if ($promotionBanner.length && $backToShopppingBtn.length) {
+                $backToShopppingBtn.on('click', bannerUpdateHandler);
+                $modalCloseBtn.on('click', bannerUpdateHandler);
             }
         });
     }

--- a/templates/components/common/alert/alert-info.html
+++ b/templates/components/common/alert/alert-info.html
@@ -1,4 +1,4 @@
-<div class="alertBox alertBox--info">
+<div class="alertBox alertBox--info" data-promotion-banner>
     <div class="alertBox-column alertBox-icon">
         <icon glyph="ic-success" class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"></path></svg></icon>
     </div>


### PR DESCRIPTION
#### What?

This PR fixes issue with updating Discount Banner when product is added to Cart on PDP. After adding product to cart we reload page if banner is presented. The same behaviour is also added for modal close button since it returns us to PDP as well.  For categories that don't contain any promotions there won't be extra reloading.

**Note:** there is a discount banner for kitchen category products in the the attached videos. 

#### Tickets / Documentation
- [BCTHEME-264](https://jira.bigcommerce.com/browse/BCTHEME-264)


#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/67792608/106008058-9d5bef00-60bf-11eb-8d06-08b0092ab1c1.mov


https://user-images.githubusercontent.com/67792608/106008107-a77ded80-60bf-11eb-935e-2b3d30cb2073.mov


