### PR TITLE
fix(storefront): BCTHEME-354 If multiple Pick List Options are applied, customers cannot select 'none' on both

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- If multiple Pick List Options are applied, customers cannot select "none" on both. [#1975](https://github.com/bigcommerce/cornerstone/pull/1975)
 
 ## 5.1.0 (01-26-2021)
 - Updated Cornerstone theme and respected variants to meet the verticals/industries documented in BCTHEME-387

--- a/templates/components/products/options/product-list.html
+++ b/templates/components/products/options/product-list.html
@@ -14,9 +14,9 @@
                            type="radio"
                            name="attribute[{{id}}]"
                            value=""
-                           id="attribute_productlist_{{../id}}_none"
+                           id="attribute_productlist_{{id}}_none"
                            checked="{{#if defaultValue '==' ''}}checked{{/if}}">
-                    <label class="form-label" for="attribute_productlist_{{../id}}_none">{{lang 'products.none'}}</label>
+                    <label class="form-label" for="attribute_productlist_{{id}}_none">{{lang 'products.none'}}</label>
                 </li>
             {{/unless}}
             {{#each values}}


### PR DESCRIPTION
#### What?

when a Product has multiple Pick List Options, the "none" option cannot be selected for both. This has been confirmed on both V2 and V3 Pick List Options

#### Tickets / Documentation

[Jira Ticket](https://jira.bigcommerce.com/browse/BCTHEME-354)

#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/66319629/106131081-e1f09480-616a-11eb-957d-8ec048e19906.mov


