### PR TITLE
feat(storefront) BCTHEME-381 add sufficient & informative text along with the color swatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Provided sufficient & informative text along with the color swatches [#1976](https://github.com/bigcommerce/cornerstone/pull/1976)
 
 ## 5.1.0 (01-26-2021)
 - Updated Cornerstone theme and respected variants to meet the verticals/industries documented in BCTHEME-387

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -17,11 +17,23 @@ export default class ProductDetails extends ProductDetailsBase {
         this.imageGallery = new ImageGallery($('[data-image-gallery]', this.$scope));
         this.imageGallery.init();
         this.listenQuantityChange();
+        this.$swatchOptionMessage = $('.swatch-option-message');
+        this.swatchOptionMessageInitText = this.$swatchOptionMessage.text();
 
         const $form = $('form[data-cart-item-add]', $scope);
         const $productOptionsElement = $('[data-product-option-change]', $form);
         const hasOptions = $productOptionsElement.html().trim().length;
         const hasDefaultOptions = $productOptionsElement.find('[data-default]').length;
+        const $productSwatchGroup = $('[id*="attribute_swatch"]', $form);
+
+        if (context.showSwatchNames) {
+            this.$swatchOptionMessage.removeClass('u-hidden');
+            $productSwatchGroup.on('change', ({ target }) => this.showSwatchNameOnOption($(target)));
+
+            $.each($productSwatchGroup, (_, element) => {
+                if ($(element).is(':checked')) this.showSwatchNameOnOption($(element));
+            });
+        }
 
         $productOptionsElement.on('change', event => {
             this.productOptionsChanged(event);
@@ -187,6 +199,25 @@ export default class ProductDetails extends ProductDetailsBase {
         });
     }
 
+    /**
+     * if this setting is enabled in Page Builder
+     * show name for swatch option
+     */
+    showSwatchNameOnOption($swatch) {
+        const swatchName = $swatch.attr('aria-label');
+
+        $('[data-product-attribute="swatch"] [data-option-value]').text(swatchName);
+        this.$swatchOptionMessage.text(`${this.swatchOptionMessageInitText} ${swatchName}`);
+        this.setLiveRegionAttributes(this.$swatchOptionMessage, 'status', 'assertive');
+    }
+
+    setLiveRegionAttributes($element, roleType, ariaLiveStatus) {
+        $element.attr({
+            role: roleType,
+            'aria-live': ariaLiveStatus,
+        });
+    }
+
     showProductImage(image) {
         if (isPlainObject(image)) {
             const zoomImageUrl = utils.tools.imageSrcset.getSrcset(
@@ -338,10 +369,7 @@ export default class ProductDetails extends ProductDetailsBase {
             }
         });
 
-        $addToCartBtn.next().attr({
-            role: 'status',
-            'aria-live': 'polite',
-        });
+        this.setLiveRegionAttributes($addToCartBtn.next(), 'status', 'polite');
     }
 
     /**

--- a/config.json
+++ b/config.json
@@ -87,6 +87,7 @@
     "show_custom_fields_tabs": false,
     "show_product_weight": true,
     "show_product_dimensions": false,
+    "show_product_swatch_names": true,
     "product_list_display_mode": "grid",
     "logo-position": "center",
     "logo_size": "250x100",

--- a/lang/en.json
+++ b/lang/en.json
@@ -741,6 +741,7 @@
         "upc": "UPC:",
         "condition": "Condition:",
         "availability": "Availability:",
+        "swatch_option_announcement": "Selected {swatch_name} is",
         "shipping": "Shipping:",
         "shipping_fixed": "{amount} (Fixed Shipping Cost)",
         "shipping_free": "Free Shipping",

--- a/schema.json
+++ b/schema.json
@@ -1402,6 +1402,12 @@
       },
       {
         "type": "checkbox",
+        "label": "i18n.ShowProductSwatchNames",
+        "force_reload": true,
+        "id": "show_product_swatch_names"
+      },
+      {
+        "type": "checkbox",
         "label": "i18n.ShowShopByPriceIn",
         "force_reload": true,
         "id": "shop_by_price_visibility"

--- a/schemaTranslations.json
+++ b/schemaTranslations.json
@@ -1216,6 +1216,13 @@
     "uk": "Показати розміри продукту",
     "zh": "显示产品尺寸"
   },
+  "i18n.ShowProductSwatchNames": {
+    "default": "Show product swatch names",
+    "fr": "Show product swatch names",
+    "it": "Show product swatch names",
+    "uk": "Показати назви зразків продукту",
+    "zh": "Show product swatch names"
+  },
   "i18n.ShowShopByPriceIn": {
     "default": "Show \"Shop by Price\" in filters",
     "fr": "Afficher \"Acheter par prix\" dans les filtres",

--- a/templates/components/common/requireness-msg.html
+++ b/templates/components/common/requireness-msg.html
@@ -1,3 +1,7 @@
 <small>
-    {{#if required}}{{lang 'common.required'}}{{else}}{{lang 'common.optional'}}{{/if}}
+    {{#if required}}
+    ({{lang 'common.required'}})
+    {{else}}
+    {{lang 'common.optional'}}
+    {{/if}}
 </small>

--- a/templates/components/products/options/swatch.html
+++ b/templates/components/products/options/swatch.html
@@ -5,6 +5,10 @@
 
         {{> components/common/requireness-msg}}
     </label>
+    <span 
+        class="swatch-option-message aria-description--hidden u-hidden">
+        {{ lang 'products.swatch_option_announcement' swatch_name=this.display_name}}
+    </span>
 
     {{#unless required}}
         <input

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -220,6 +220,7 @@
                 <input type="hidden" name="action" value="add">
                 <input type="hidden" name="product_id" value="{{product.id}}"/>
                 <div data-product-option-change style="display:none;">
+                    {{inject 'showSwatchNames' theme_settings.show_product_swatch_names}}
                     {{#each product.options}}
                         {{{dynamicComponent 'components/products/options'}}}
                     {{/each}}


### PR DESCRIPTION
#### What?

This PR adds setting to Page builder that provides/hides a text along with color swatches on  a Store. When it's set to 'Show' User'll see swatch name on picking an option. Screen Reader will announce it as well. All this will do Shopper Experience much better.
To achieve this handlebars logic has been divided on 2 parts:
-using dynamicComponent for all options except Swatches,
-add explicitly swatch component with flag that can be manipulate of  Show swatch name setting.


#### Tickets / Documentation
- [BCTHEME-381](https://jira.bigcommerce.com/browse/BCTHEME-381)


#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/67792608/106276306-12563280-6240-11eb-97de-249d9ff2f142.mov

https://user-images.githubusercontent.com/67792608/106276322-17b37d00-6240-11eb-9480-d953b9a33a33.mov

https://user-images.githubusercontent.com/67792608/106276282-0a968e00-6240-11eb-8934-c6e30a88b893.mov

