### PR TITLE
feat(storefront): BCTHEME-391 Move focus on filter items Modal after show more button was clicked and accessibility refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed focus for sort by dropdown on reloading page. [#1964](https://github.com/bigcommerce/cornerstone/pull/1964)
 - Fixed filtered selection not announced by screen reader. [#1966](https://github.com/bigcommerce/cornerstone/pull/1966)
 - Integrate accessibility scripts to product images slider on PDP. [#1965](https://github.com/bigcommerce/cornerstone/pull/1965)
+- Move focus on filter items Modal after show more button was clicked and accessibility refactoring. [#1977](https://github.com/bigcommerce/cornerstone/pull/1977)
 
 ## 5.1.0 (01-26-2021)
 - Updated Cornerstone theme and respected variants to meet the verticals/industries documented in BCTHEME-387

--- a/assets/js/theme/common/faceted-search.js
+++ b/assets/js/theme/common/faceted-search.js
@@ -2,10 +2,13 @@ import { hooks, api } from '@bigcommerce/stencil-utils';
 import _ from 'lodash';
 import Url from 'url';
 import urlUtils from './utils/url-utils';
-import modalFactory from '../global/modal';
+import modalFactory, { modalTypes, ModalEvents } from '../global/modal';
 import collapsibleFactory from './collapsible';
 import { Validators } from './utils/form-utils';
 import nod from './nod';
+
+const { SHOW_MORE_OPTIONS } = modalTypes;
+const { opened } = ModalEvents;
 
 const defaultOptions = {
     accordionToggleSelector: '#facetedSearch .accordion-navigation, #facetedSearch .facetedSearch-toggle',
@@ -55,6 +58,15 @@ class FacetedSearch {
         this.options = _.extend({}, defaultOptions, options);
         this.collapsedFacets = [];
         this.collapsedFacetItems = [];
+
+        if (this.options.modal) {
+            this.options.modal.$modal.on(opened, event => {
+                const $filterItems = $(event.target).find('#facetedSearch-filterItems');
+                if ($filterItems.length) {
+                    this.options.modal.setupFocusableElements(SHOW_MORE_OPTIONS);
+                }
+            });
+        }
 
         // Init collapsibles
         collapsibleFactory();

--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -67,7 +67,7 @@
         <button
             type="button"
             class="heroCarousel-play-pause-button js-hero-play-pause-button"
-            aria-label="{{lang 'carousel.playPauseButton.ariaPause'}}"
+            aria-label="{{lang 'carousel.playPauseButtonAriaPause'}}"
             data-play="true"
             data-labels='{
                 "play": "{{lang 'carousel.playPauseButtonPlay'}}",


### PR DESCRIPTION

#### What?

This PR adds focus trap on show more modal with filter options

#### Tickets / Documentation

[BCTHEME-391
](https://jira.bigcommerce.com/browse/BCTHEME-391)

#### Screenshots (if appropriate)

This flow can be present on PLP

https://user-images.githubusercontent.com/66325265/106426431-42831880-646e-11eb-8d58-ab0ad35df03b.mov

search page

https://user-images.githubusercontent.com/66325265/106426472-5169cb00-646e-11eb-9d3c-e79a94d60749.mov

and brands

https://user-images.githubusercontent.com/66325265/106426487-5af33300-646e-11eb-8221-b6dfdd0de070.mov

