### PR TITLE
fix(storefront): BCTHEME-398 Make every product option group id unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-- Fixed required checkbox message displaying. [1963](https://github.com/bigcommerce/cornerstone/pull/1963)
-
 ## Draft
+- Make every product option group id unique. [#1979](https://github.com/bigcommerce/cornerstone/pull/1979)
+- Fixed required checkbox message displaying. [1963](https://github.com/bigcommerce/cornerstone/pull/1963)
 - If multiple Pick List Options are applied, customers cannot select "none" on both. [#1975](https://github.com/bigcommerce/cornerstone/pull/1975)
 - Moved phrase from compare.html to en.json for increasing localization. [#1972](https://github.com/bigcommerce/cornerstone/pull/1972)
 - Fixed focus for sort by dropdown on reloading page. [#1964](https://github.com/bigcommerce/cornerstone/pull/1964)

--- a/templates/components/products/options/set-radio.html
+++ b/templates/components/products/options/set-radio.html
@@ -1,5 +1,5 @@
-<div class="form-field" data-product-attribute="set-radio" role="radiogroup" aria-labelledby="radio-group-label">
-    <label class="form-label form-label--alternate form-label--inlineSmall" id="radio-group-label">
+<div class="form-field" data-product-attribute="set-radio" role="radiogroup" aria-labelledby="radio-group-label-{{id}}">
+    <label class="form-label form-label--alternate form-label--inlineSmall" id="radio-group-label-{{id}}">
         {{ this.display_name }}:
 
         {{> components/common/requireness-msg}}


### PR DESCRIPTION
#### What?

Preventing duplicate ids in case of more than one radio groups

#### Tickets / Documentation

[Jira](https://jira.bigcommerce.com/browse/BCTHEME-398)

#### Screenshots (if appropriate)

<img width="1677" alt="Screenshot 2021-02-08 at 12 06 49" src="https://user-images.githubusercontent.com/66319629/107205110-23ecc680-6a06-11eb-8b49-394a53249ca3.png">

