### PR TITLE
fix(storefront): BCTHEME-400 If product options are not required, the 'None' option will remain selected even if another option is chosen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed required checkbox message displaying. [1963](https://github.com/bigcommerce/cornerstone/pull/1963)
 
 ## Draft
+- For non-required options, when the "None" option displays on the storefront it should be deselected when another option is chosen. [#1980](https://github.com/bigcommerce/cornerstone/pull/1980)
 - If multiple Pick List Options are applied, customers cannot select "none" on both. [#1975](https://github.com/bigcommerce/cornerstone/pull/1975)
 - Moved phrase from compare.html to en.json for increasing localization. [#1972](https://github.com/bigcommerce/cornerstone/pull/1972)
 - Fixed focus for sort by dropdown on reloading page. [#1964](https://github.com/bigcommerce/cornerstone/pull/1964)

--- a/templates/components/products/options/set-radio.html
+++ b/templates/components/products/options/set-radio.html
@@ -9,12 +9,12 @@
         <input
             class="form-radio"
             type="radio"
-            id="attribute_radio_{{../id}}_none"
-            name="attribute[{{../id}}]"
+            id="attribute_radio_{{id}}_none"
+            name="attribute[{{id}}]"
             value=""
             checked="{{#if defaultValue '==' ''}}checked{{/if}}"
         >
-        <label class="form-label" for="attribute_radio_{{../id}}_none">{{lang 'products.none'}}</label>
+        <label class="form-label" for="attribute_radio_{{id}}_none">{{lang 'products.none'}}</label>
     {{/unless}}
 
     {{#each this.values}}


### PR DESCRIPTION
#### What?

If options are not required, on the storefront the "None" option is selected automatically and cannot be deselected if another option is chosen.

#### Tickets / Documentation

[Jira](https://jira.bigcommerce.com/browse/BCTHEME-400)

#### Screenshots (if appropriate)

<img width="1680" alt="Screenshot 2021-02-08 at 12 20 21" src="https://user-images.githubusercontent.com/66319629/107206685-0882bb00-6a08-11eb-95a5-a2f6abbce671.png">
