### PR TITLE
fix(storefront): BCTHEME-334 Add alt attribute for no image placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Add alt attribute for no image placeholders. [#1984](https://github.com/bigcommerce/cornerstone/pull/1984)
 - Make every product option group id unique. [#1979](https://github.com/bigcommerce/cornerstone/pull/1979)
 - Fixed required checkbox message displaying. [1963](https://github.com/bigcommerce/cornerstone/pull/1963)
 - Provided sufficient & informative text along with the color swatches [#1976](https://github.com/bigcommerce/cornerstone/pull/1976)

--- a/lang/en.json
+++ b/lang/en.json
@@ -787,7 +787,8 @@
             "percent": "and get {discount} off",
             "price": "and get {discount} off",
             "fixed": "and pay only {discount} each"
-        }
+        },
+        "card_default_image_alt": "Image coming soon"
     },
     "invoice": {
         "for_order": "{name} Invoice for Order #{id}",

--- a/templates/components/common/responsive-img.html
+++ b/templates/components/common/responsive-img.html
@@ -55,7 +55,7 @@ Generate the srcset string using the default sizes defined in the helper. This w
 pick the best-sized image based on its own understanding of how it will render the page.
 --}}
 {{#unless lazyload '==' 'disabled'}}data-{{/unless}}srcset="{{getImageSrcset image use_default_sizes=true }}"
-{{else if default_image}}src="{{cdn default_image}}"{{/if}}
+{{else if default_image}}src="{{cdn default_image}}" alt="{{lang 'products.card_default_image_alt'}}"{{/if}}
 class="{{#unless lazyload '==' 'disabled'}}lazyload{{/unless}}{{#if class}} {{class}}{{/if}}"
 {{#if lazyload '==' 'lazyload'}}loading="lazy"{{/if}}
 {{otherAttributes}} />


### PR DESCRIPTION
#### What?

Add alt attribute for no image placeholders

#### Tickets / Documentation

[Jira](https://jira.bigcommerce.com/browse/BCTHEME-334)

#### Screenshots (if appropriate)

<img width="1680" alt="Screenshot 2021-02-12 at 12 54 49" src="https://user-images.githubusercontent.com/66319629/107759812-82c97d00-6d31-11eb-902c-53effd5642c7.png">
