### PR TITLE
fix(storefront): BCTHEME-401 Category pages are creating alt attribute within the span tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Category pages are creating alt attribute within the span tag. [1987](https://github.com/bigcommerce/cornerstone/pull/1987)
 - Make every product option group id unique. [#1979](https://github.com/bigcommerce/cornerstone/pull/1979)
 - Fixed required checkbox message displaying. [1963](https://github.com/bigcommerce/cornerstone/pull/1963)
 - Provided sufficient & informative text along with the color swatches [#1976](https://github.com/bigcommerce/cornerstone/pull/1976)

--- a/templates/components/amp/products/ratings.html
+++ b/templates/components/amp/products/ratings.html
@@ -1,6 +1,5 @@
 <span role="img"
-      alt="{{lang 'products.reviews.rating_aria_label' current_rating=rating max_rating=5}}"
-      title="{{lang 'products.reviews.rating_aria_label' current_rating=rating max_rating=5}}"
+      aria-label="{{lang 'products.reviews.rating_aria_label' current_rating=rating max_rating=5}}"
 >
     {{#for 1 5}}
         {{#if ../this.rating '>=' $index}}

--- a/templates/components/products/ratings.html
+++ b/templates/components/products/ratings.html
@@ -1,6 +1,5 @@
 <span role="img"
-      alt="{{lang 'products.reviews.rating_aria_label' current_rating=rating max_rating=5}}"
-      title="{{lang 'products.reviews.rating_aria_label' current_rating=rating max_rating=5}}"
+      aria-label="{{lang 'products.reviews.rating_aria_label' current_rating=rating max_rating=5}}"
 >
     {{#for 1 5}}
         {{#if ../this.rating '>=' $index}}


### PR DESCRIPTION
#### What?

Due to [w3c](https://www.w3.org/TR/wai-aria-1.1/#img) alt text is acceptable for role image, but if it affects validation we can use second approach - aria-label attribute for element with role image. It has the same result for screen reader and successfully pass validation. Due to [mdn](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Role_Img) alt also acceptable, but all examples using aria-label, so it should be the best solution.
 

#### Tickets / Documentation

 [BCTHEME-401](https://jira.bigcommerce.com/browse/BCTHEME-401)

#### Screenshots (if appropriate)

<img width="1448" alt="amp-validation" src="https://user-images.githubusercontent.com/66325265/108044382-dd711a80-704a-11eb-8dc0-afa1d0ecf151.png">

<img width="1463" alt="amp-garden-item-rating" src="https://user-images.githubusercontent.com/66325265/108044835-6ee08c80-704b-11eb-958a-cf5fb00798f4.png">

<img width="1528" alt="garden-item-rating" src="https://user-images.githubusercontent.com/66325265/108044397-e2ce6500-704a-11eb-8947-d766e436cee7.png">

<img width="1528" alt="jar-rating" src="https://user-images.githubusercontent.com/66325265/108044414-e5c95580-704a-11eb-90d3-be30ab7b2098.png">
