### PR TITLE
fix(storefront): BCTHEME-362 fix cut off cart button on zooming 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed cut off on Cart button when Zooming up to 400%. [#1988](https://github.com/bigcommerce/cornerstone/pull/1988)
 - Make every product option group id unique. [#1979](https://github.com/bigcommerce/cornerstone/pull/1979)
 - Fixed required checkbox message displaying. [1963](https://github.com/bigcommerce/cornerstone/pull/1963)
 - Provided sufficient & informative text along with the color swatches [#1976](https://github.com/bigcommerce/cornerstone/pull/1976)

--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -608,6 +608,16 @@ $card-preview-zoom-bottom-offset:       6rem;
     }
 
     @include lazy-loaded-padding('productthumb_size');
+    
+    &:after {
+        @include breakpoint("xxsmall") {
+            padding-bottom: 75%;
+        }
+
+        @include breakpoint("xsmall") {
+            padding-bottom: 100%;
+        }
+    }
 }
 
 .previewCartItem-content {
@@ -640,7 +650,14 @@ $card-preview-zoom-bottom-offset:       6rem;
     @include grid-row;
     border-top: container("border");
     display: block;
-    padding: spacing("single") spacing("half");
+
+    @include breakpoint("xxsmall") {
+        padding: spacing("half") spacing("quarter");
+    }
+
+    @include breakpoint("xsmall") {
+        padding: spacing("single") spacing("half");
+    }
 
     .button {
         margin: 0;


### PR DESCRIPTION
#### What?

This PR fixes a cut off on Cart button when using browser zooming up to 400%.

#### Tickets / Documentation

- [BCTHEME-362](https://jira.bigcommerce.com/browse/BCTHEME-362)

#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/67792608/108060908-38f9d300-7060-11eb-8697-6f72d0a6c2a5.mp4


https://user-images.githubusercontent.com/67792608/108060915-3a2b0000-7060-11eb-8f8f-8c6f20a8c31e.mov


https://user-images.githubusercontent.com/67792608/108060918-3bf4c380-7060-11eb-88bc-05098b6e9bcc.mov


