### PR TITLE
fix(storefront): BCTHEME-392 fixed line breaks on Dropdown Menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed line breaks on Dropdown menu display mode. [#1996](https://github.com/bigcommerce/cornerstone/pull/1996)
 
 ## 5.2.0 (02-22-2021)
 - Fixed cut off on Cart button when Zooming up to 400%. [#1988](https://github.com/bigcommerce/cornerstone/pull/1988)

--- a/assets/scss/components/stencil/navPages/_navPages.scss
+++ b/assets/scss/components/stencil/navPages/_navPages.scss
@@ -379,6 +379,8 @@
 }
 
 .navPage-subMenu-item {
+    padding: spacing("half") 0;
+
     @include breakpoint("medium") {
         // scss-lint:disable ImportantRule
         @include grid-column(3);
@@ -428,7 +430,6 @@
         height: 100%;
         width: 100%;
         box-sizing: content-box;
-        padding: spacing("half") 0;
         display: inline-block;
         text-align: right;
 


### PR DESCRIPTION
#### What?

Moved padding styles to `.navPage-subMenu-item` which will provide equal distance between dropdown menu categories.

#### Tickets / Documentation

- [BCTHEME-392](https://jira.bigcommerce.com/browse/BCTHEME-392)


#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/67792608/109015446-cb801f00-76bd-11eb-9409-f64c0ef1ae02.mov


https://user-images.githubusercontent.com/67792608/109015468-cfac3c80-76bd-11eb-97d4-4dea7aef5d48.mov



https://user-images.githubusercontent.com/67792608/109032067-fd00e680-76cd-11eb-9beb-6bc247d7a273.mov

