### PR TITLE
fix(search): ES-2031 add error message for when star search is not av…

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -28,10 +28,12 @@
         "maintenance_message": "This store is currently unavailable due to maintenance. It should be available again shortly. We apologize for any inconvenience caused."
     },
     "brands": {
-        "no_products": "There are no products listed under this brand."
+        "no_products": "There are no products listed under this brand.",
+        "search_error": "There was a problem retrieving the products on this page. Please try again at a later time"
     },
     "categories": {
-        "no_products": "There are no products listed under this category."
+        "no_products": "There are no products listed under this category.",
+        "search_error": "There was a problem retrieving the products on this page. Please try again at a later time"
     },
     "checkout": {
         "title": "Checkout"

--- a/templates/components/brand/product-listing.html
+++ b/templates/components/brand/product-listing.html
@@ -1,10 +1,14 @@
 {{> components/products/filter sort=pagination.brand.sort}}
 
 <form action="{{urls.compare}}" method='POST' {{#if settings.data_tag_enabled}} data-list-name="Brand: {{brand.name}}" {{/if}} data-product-compare>
-    {{#if theme_settings.product_list_display_mode '===' 'grid'}}
-        {{> components/products/grid products=brand.products show_compare=brand.show_compare theme_settings=theme_settings event="list"}}
+    {{#if brands.search_error}}
+        {{lang 'brands.search_error'}}
     {{else}}
-        {{> components/products/list products=brand.products show_compare=brand.show_compare theme_settings=theme_settings event="list"}}
+        {{#if theme_settings.product_list_display_mode '===' 'grid'}}
+            {{> components/products/grid products=brand.products show_compare=brand.show_compare theme_settings=theme_settings event="list"}}
+        {{else}}
+            {{> components/products/list products=brand.products show_compare=brand.show_compare theme_settings=theme_settings event="list"}}
+        {{/if}}
     {{/if}}
 </form>
 

--- a/templates/components/category/product-listing.html
+++ b/templates/components/category/product-listing.html
@@ -19,11 +19,15 @@
 
     {{> components/common/paginator pagination.category}}
 {{else}}
-    <p data-no-products-notification
-       role="alert"
-       aria-live="assertive"
-       tabindex="-1"
-    >
-        {{lang 'categories.no_products'}}
-    </p>
+    {{#if category.search_error}}
+        {{lang 'categories.search_error'}}
+    {{else}}
+        <p data-no-products-notification
+           role="alert"
+           aria-live="assertive"
+           tabindex="-1"
+        >
+            {{lang 'categories.no_products'}}
+        </p>
+    {{/if}}
 {{/if}}


### PR DESCRIPTION

## What?
When star search is unavailable for any reasons make sure we have a nice fall back with an appropriate message. 

## Why?
Right now bcapp just throws 500 in storefront that is not a nice way to take care of failed request

## Testing / Proof
For testing run bundle stencil to create new theme with cornerstone changes. Locally stop star search to make requests failed. Enable faceted search experiment. Access Sategory and Brands page and make sure you see message like: "There was a problem retrieving the products on this page. Please try again at a later time"

## How can this change be undone in case of failure?
Turn off star search faceted search experiment

ping @bigcommerce/artemis-dt 

