### PR TITLE
BCTHEME-420: 'Skip to main content' is not visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- "Skip to main content" now is visible when top banned is absent. [#2010](https://github.com/bigcommerce/cornerstone/pull/2010)
 - Added sold out badge on products within PLP. [#2003](https://github.com/bigcommerce/cornerstone/pull/2003)
 - Update focus trap in Modal. [#1998](https://github.com/bigcommerce/cornerstone/pull/1998)
 - Added unique identifiers to product cards on product list pages. [#1999](https://github.com/bigcommerce/cornerstone/pull/1999)

--- a/assets/scss/layouts/header/_header.scss
+++ b/assets/scss/layouts/header/_header.scss
@@ -12,7 +12,7 @@
 // 5. When logo size is set to "original", we don't have advance knowledge of the
 //    image size, so we can't use absolute positioning + padding to reserve space
 //    for lazy loading.
-// 6. When logo size is set to "original" and switch to mobile version, it keeps 
+// 6. When logo size is set to "original" and switch to mobile version, it keeps
 //    content in center regardless its size.
 //
 // -----------------------------------------------------------------------------
@@ -26,6 +26,7 @@
     position: absolute;
     transform: translate(-50%, -100%);
     transition: transform 0.3s;
+    z-index: zIndex('highest');
 
     &:focus {
         transform: translate(-50%, 0%);
@@ -175,7 +176,7 @@
 .header-logo-image-container {
     position: relative;
     width: 100%;
-    
+
     @include breakpoint("medium") {
         min-height: get-height(stencilString('logo_size'));
     }


### PR DESCRIPTION
#### What?

The "Skip to main content" link is not visible when it receives focus on any page other than the home page.

#### Tickets / Documentation

[Jira](https://jira.bigcommerce.com/browse/BCTHEME-420)

#### Screenshots (if appropriate)

<img width="1381" alt="Screenshot 2021-03-17 at 15 47 55" src="https://user-images.githubusercontent.com/66319629/111477808-298da880-8738-11eb-8e37-67db053d43b0.png">

