### PR TITLE
BCTHEME-422: Announce email field as mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Announce subscribing email field as mandatory. [#2011](https://github.com/bigcommerce/cornerstone/pull/2011)
 - Added sold out badge on products within PLP. [#2003](https://github.com/bigcommerce/cornerstone/pull/2003)
 - Update focus trap in Modal. [#1998](https://github.com/bigcommerce/cornerstone/pull/1998)
 - Added unique identifiers to product cards on product list pages. [#1999](https://github.com/bigcommerce/cornerstone/pull/1999)

--- a/templates/components/common/subscription-form.html
+++ b/templates/components/common/subscription-form.html
@@ -16,6 +16,7 @@
                        value="{{customer.email}}"
                        placeholder="{{lang 'newsletter.email_placeholder'}}"
                        aria-describedby="alertBox-message-text"
+                       aria-required="true"
                 >
                 <input class="button button--primary form-prefixPostfix-button--postfix"
                        type="submit"


### PR DESCRIPTION
#### What?

Screen reader doesn't read 'Your email address' for newsletter sign up as a mandatory edit field as required.

#### Tickets / Documentation

[Jira](https://jira.bigcommerce.com/browse/BCTHEME-422)

#### Screenshots (if appropriate)

<img width="1184" alt="Screenshot 2021-03-17 at 15 57 27" src="https://user-images.githubusercontent.com/66319629/111480200-63f84500-873a-11eb-8671-40f90f9c0da8.png">

