### PR TITLE
BCTHEME-426: Insufficient link text for "Read More" links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Changed insufficient link text for "Read More" links. [#2012](https://github.com/bigcommerce/cornerstone/pull/2012)
 - Added sold out badge on products within PLP. [#2003](https://github.com/bigcommerce/cornerstone/pull/2003)
 - Update focus trap in Modal. [#1998](https://github.com/bigcommerce/cornerstone/pull/1998)
 - Added unique identifiers to product cards on product list pages. [#1999](https://github.com/bigcommerce/cornerstone/pull/1999)

--- a/templates/components/blog/post.html
+++ b/templates/components/blog/post.html
@@ -27,7 +27,7 @@
             {{else}}
                 {{{post.summary}}}
                 {{#if post.show_read_more}}
-                    &hellip; <a href="{{url}}">{{lang 'blog.read_more'}}</a>
+                    &hellip; <a href="{{url}}" aria-label="{{post.title}} {{lang 'blog.read_more'}}">{{lang 'blog.read_more'}}</a>
                 {{/if}}
             {{/if}}
         </div>


### PR DESCRIPTION
#### What?

The 'read more' link text does not define complete purpose of the link. The blog heading should be associated with it.

#### Tickets / Documentation

[Jira](https://jira.bigcommerce.com/browse/BCTHEME-426)

#### Screenshots (if appropriate)

<img width="1172" alt="Screenshot 2021-03-17 at 16 30 27" src="https://user-images.githubusercontent.com/66319629/111485022-eedb3e80-873e-11eb-9e2e-6a66d5e2e563.png">

