### PR TITLE
fix(storefront): BCTHEME-427 Insufficient button label on cart page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed insufficient button label on cart page from action controls. [#2013](https://github.com/bigcommerce/cornerstone/pull/2013)
 - "Skip to main content" now is visible when top banned is absent. [#2010](https://github.com/bigcommerce/cornerstone/pull/2010)
 - Announce subscribing email field as mandatory. [#2011](https://github.com/bigcommerce/cornerstone/pull/2011)
 - Changed insufficient link text for "Read More" links. [#2012](https://github.com/bigcommerce/cornerstone/pull/2012)

--- a/lang/en.json
+++ b/lang/en.json
@@ -76,7 +76,7 @@
         "freeshipping": "Free Shipping",
         "reconfigure_product": "Configure '{name}'",
         "shipping_peritem": "Per Item Shipping",
-        "remove_item": "Remove item from cart",
+        "remove_item": "Remove {name} from cart",
         "confirm_delete": "Are you sure you want to delete this item?",
         "coupons": {
             "empty_error": "Please enter your coupon code.",
@@ -691,8 +691,8 @@
     "products": {
         "current_stock": "Current Stock:",
         "quantity": "Quantity:",
-        "quantity_decrease": "Decrease Quantity:",
-        "quantity_increase": "Increase Quantity:",
+        "quantity_decrease": "Decrease Quantity of {name}",
+        "quantity_increase": "Increase Quantity of {name}",
         "purchase_units": "{quantity, plural, =0{0 units} one {# unit} other {# units}}",
         "max_purchase_quantity": "Maximum Purchase:",
         "min_purchase_quantity": "Minimum Purchase:",

--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -90,8 +90,12 @@
                     <label class="form-label cart-item-label" for="qty-{{id}}">{{lang 'products.quantity'}}</label>
                     <div class="form-increment">
                         {{#if can_modify}}
-                            <button class="button button--icon" data-cart-update data-cart-itemid="{{id}}" data-action="dec">
-                                <span class="is-srOnly">{{lang 'products.quantity_decrease'}}</span>
+                            <button class="button button--icon"
+                                    data-cart-update
+                                    data-cart-itemid="{{id}}"
+                                    data-action="dec"
+                            >
+                                <span class="is-srOnly">{{lang 'products.quantity_decrease' name=name}}</span>
                                 <i class="icon" aria-hidden="true"><svg><use xlink:href="#icon-keyboard-arrow-down" /></svg></i>
                             </button>
                         {{/if}}
@@ -110,8 +114,12 @@
                                data-action="manualQtyChange"
                                aria-live="polite"{{#unless can_modify}} disabled{{/unless}}>
                         {{#if can_modify}}
-                            <button class="button button--icon" data-cart-update data-cart-itemid="{{id}}" data-action="inc">
-                                <span class="is-srOnly">{{lang 'products.quantity_increase'}}</span>
+                            <button class="button button--icon"
+                                    data-cart-update
+                                    data-cart-itemid="{{id}}"
+                                    data-action="inc"
+                            >
+                                <span class="is-srOnly">{{lang 'products.quantity_increase' name=name}}</span>
                                 <i class="icon" aria-hidden="true"><svg><use xlink:href="#icon-keyboard-arrow-up" /></svg></i>
                             </button>
                         {{/if}}
@@ -133,7 +141,7 @@
                         <button class="cart-remove icon"
                                 data-cart-itemid="{{id}}"
                                 data-confirm-delete="{{lang 'cart.confirm_delete'}}"
-                                aria-label="{{lang 'cart.remove_item'}}"
+                                aria-label="{{lang 'cart.remove_item' name=name}}"
                         >
                             <svg><use xlink:href="#icon-close"></use></svg>
                         </button>


### PR DESCRIPTION
#### What?

The following button labels should be associated with respective product name:

- Increase quantity
- Decrease quantity
- Remove item from cart

#### Tickets / Documentation

[Jira](https://jira.bigcommerce.com/browse/BCTHEME-427)

#### Screenshots (if appropriate)

<img width="1217" alt="Screenshot 2021-03-18 at 11 01 28" src="https://user-images.githubusercontent.com/66319629/111600988-9b1e3300-87da-11eb-8dbe-8b45f69d8494.png">

<img width="1184" alt="Screenshot 2021-03-18 at 11 01 39" src="https://user-images.githubusercontent.com/66319629/111600995-9c4f6000-87da-11eb-8a01-19d4934cdf58.png">

<img width="1186" alt="Screenshot 2021-03-18 at 11 07 02" src="https://user-images.githubusercontent.com/66319629/111601002-9d808d00-87da-11eb-866e-c3508fcf3dad.png">

