### PR TITLE
fix(storefront): IE11 - Clicking on Search Does Not Display Search Bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- IE11 - Clicking on Search Does Not Display Search Bar. [#2017](https://github.com/bigcommerce/cornerstone/pull/2017)
 - Add placeholder for failed to load carousel images and update scalability. [#2009](https://github.com/bigcommerce/cornerstone/pull/2009)
 - Fixed insufficient button label on cart page from action controls. [#2013](https://github.com/bigcommerce/cornerstone/pull/2013)
 - "Skip to main content" now is visible when top banned is absent. [#2010](https://github.com/bigcommerce/cornerstone/pull/2010)

--- a/assets/scss/components/stencil/navUser/_navUser.scss
+++ b/assets/scss/components/stencil/navUser/_navUser.scss
@@ -291,7 +291,7 @@
     }
 
     &.is-open {
-        display: initial;
+        display: block;
         // scss-lint:disable ImportantRule
         left: 0 !important; // 1
         outline: none;


### PR DESCRIPTION
#### What?

After this PR merged Search input will appear after clicking on top menu Search button 

#### Tickets / Documentation

[BCTHEME-403](https://jira.bigcommerce.com/browse/BCTHEME-403)

#### Screenshots (if appropriate)

![search-bar-ie](https://user-images.githubusercontent.com/66325265/111758656-6dea8700-88a5-11eb-858d-71e873ea5e10.jpg)
