### PR TITLE
fix(search): ES-2071 removed adding selected filters for price filter since not needed

### DIFF
--- a/templates/components/faceted-search/facets/range.html
+++ b/templates/components/faceted-search/facets/range.html
@@ -3,9 +3,6 @@
 
     <div id="facetedSearch-content--{{dashcase facet}}" class="accordion-content{{#unless start_collapsed}} is-open{{/unless}}">
         <form id="facet-range-form" class="form" method="get" data-faceted-search-range novalidate>
-            {{#each current_selected_items}}
-                <input type="hidden" name="{{param_name}}[]" value="{{param_value}}"/>
-            {{/each}}
             <input type="hidden" name="search_query" value="{{search_query}}">
             {{#if this.sort}}
                 <input type="hidden" name="sort" value="{{this.sort}}">


### PR DESCRIPTION
#### What?
Removed adding selected facets to the `Price form` for faceted search. With these added in the code, on Price form submit, selected filters are added multiple times to the query string. Thus the selected filters section is showing wrong set of filters whenever we choose the Price filter in faceted search results page, Category Page. 

#### Tickets / Documentation
- [ES-2071] (https://jira.bigcommerce.com/browse/ES-2071)

#### Screenshots (if appropriate)
Soon... 

