### PR TITLE
fix(storefront): BCTHEME-434 Hamburger Menu Icon missing on Google AMP Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Hamburger Menu Icon missing on Google AMP Pages. [#2022](https://github.com/bigcommerce/cornerstone/pull/2022)
 
 ## 5.3.0 (03-25-2021)
 - Remove AddThis for social sharing, replace with provider sharing links. [#1997](https://github.com/bigcommerce/cornerstone/pull/1997)

--- a/templates/components/amp/css/header.html
+++ b/templates/components/amp/css/header.html
@@ -1,6 +1,6 @@
 .amp-menu-button {
     background-color: transparent;
-    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-3 -6 24 24"><path fill="#4f4f4f" d="M0 12h18v-2H0v2M0 7h18V5H0v2M0 0v2h18V0H0"/></svg>');
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-3 -6 24 24"><path fill="%234f4f4f" d="M0 12h18v-2H0v2M0 7h18V5H0v2M0 0v2h18V0H0"/></svg>');
     background-repeat: no-repeat;
     background-size: 2rem 1.8rem;
     background-position: center center;


### PR DESCRIPTION

#### What?
This PR has fix for missing Hamburger Menu Icon on Google AMP Pages. It was implemented via background image with svg burger icon. '#' in URLs starts a fragment identifier. '#' was changed to %23. That is the value of escaped '#' character.

#### Tickets / Documentation

[BCTHEME-434](https://jira.bigcommerce.com/browse/BCTHEME-434)

#### Screenshots (if appropriate)
<img width="541" alt="samsung-int-on-galaxy" src="https://user-images.githubusercontent.com/66325265/112647963-b4b22100-8e51-11eb-9f19-1ced736aba5d.png">
<img width="541" alt="chrome-on-google-pixel" src="https://user-images.githubusercontent.com/66325265/112647973-b67be480-8e51-11eb-81dd-b73212ec23fd.png">
<img width="541" alt="safari-on-iphone11" src="https://user-images.githubusercontent.com/66325265/112647983-b845a800-8e51-11eb-9716-439899ac7c4f.png">
<img width="541" alt="chrome-on-iphone12promax" src="https://user-images.githubusercontent.com/66325265/112647992-ba0f6b80-8e51-11eb-8b24-84c2a5de72f1.png">
