### PR TITLE
fix(storefront): BCTHEME-431 remove horizontal scroll on swatch options PDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed unnecessary horizontal scroll on swatch options on PDP. [#2023](https://github.com/bigcommerce/cornerstone/pull/2023)
 
 ## 5.3.0 (03-24-2021)
 - IE11 - Clicking on Search Does Not Display Search Bar. [#2017](https://github.com/bigcommerce/cornerstone/pull/2017)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -25,6 +25,21 @@ export default class ProductDetails extends ProductDetailsBase {
         const hasOptions = $productOptionsElement.html().trim().length;
         const hasDefaultOptions = $productOptionsElement.find('[data-default]').length;
         const $productSwatchGroup = $('[id*="attribute_swatch"]', $form);
+        const $productSwatchLabels = $('.form-option-swatch', $form);
+        const placeSwatchLabelImage = (_, label) => {
+            const $optionImage = $('.form-option-expanded', $(label));
+            const optionImageWidth = $optionImage.outerWidth();
+            const extendedOptionImageOffsetLeft = 55;
+            const { right } = label.getBoundingClientRect();
+            const emptySpaceToScreenRightBorder = window.screen.width - right;
+            const shiftValue = optionImageWidth - emptySpaceToScreenRightBorder;
+
+            if (emptySpaceToScreenRightBorder < (optionImageWidth + extendedOptionImageOffsetLeft)) {
+                $optionImage.css('left', `${shiftValue > 0 ? -shiftValue : shiftValue}px`);
+            }
+        };
+
+        $(window).on('load', () => $.each($productSwatchLabels, placeSwatchLabelImage));
 
         if (context.showSwatchNames) {
             this.$swatchOptionMessage.removeClass('u-hidden');


### PR DESCRIPTION




#### What?

This PR removes extra horizontal scroll on swatch options and supports changes made in BCTHEME-395. The issue with scroll appears when product options are placed close to Viewport. Its scaled images at this time are visually hidden but take place in DOM  beyond a screen size. This causes a scroll. To fix this behaviour we add a function on loading a page and if the there is no enough space for scale images to be placed we move them to the left part of the screen.


#### Tickets / Documentation
- [BCTHEME-431](https://jira.bigcommerce.com/browse/BCTHEME-431)


#### Screenshots (if appropriate)

There are videos with behaviour on mobiles with iOS and Android platforms

https://user-images.githubusercontent.com/67792608/112800203-04723180-9078-11eb-96a1-79bea9dbdce7.mov


https://user-images.githubusercontent.com/67792608/112800342-31bedf80-9078-11eb-9521-45c9a154ef84.mov


https://user-images.githubusercontent.com/67792608/112800727-b578cc00-9078-11eb-9f06-8add9bc024f0.mov


https://user-images.githubusercontent.com/67792608/112819797-9d5f7780-908d-11eb-97de-433297570197.mov

