### PR TITLE
fix(storefront): BCTHEME-423 Search result on search page not notified by screen reader

### DIFF
--- a/assets/js/theme/search.js
+++ b/assets/js/theme/search.js
@@ -204,9 +204,15 @@ export default class Search extends CatalogPage {
             }
         });
 
-        setTimeout(() => {
-            $('[data-search-aria-message]').removeClass('u-hidden');
-        }, 100);
+        const $searchResultsMessage = $(`<p
+            class="aria-description--hidden"
+            tabindex="-1"
+            role="status"
+            aria-live="polite"
+            >${this.context.searchResultsCount}</p>`)
+            .prependTo('body');
+
+        setTimeout(() => $searchResultsMessage.focus(), 100);
     }
 
     loadTreeNodes(node, cb) {

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -4,6 +4,7 @@ product_results:
 ---
 {{inject 'categoryTree' forms.search.category_options}}
 {{inject 'searchProductsPerPage' theme_settings.searchpage_products_per_page}}
+{{inject 'searchResultsCount' (lang 'search.results.count' count=result_count search_query=(sanitize forms.search.query))}}
 {{#partial "head"}}
     {{#if pagination.product_results.previous}}
         <link rel="prev" href="{{pagination.product_results.previous}}">
@@ -124,14 +125,6 @@ product_results:
                 </div>
             </div>
         {{/if}}
-
-        <p role="status"
-           aria-live="polite"
-           class="quickSearchResultsAriaMessage aria-description--hidden u-hidden"
-           data-search-aria-message
-        >
-            {{{lang 'search.results.count' count=result_count search_query=(sanitize forms.search.query)}}}
-        </p>
 
         <div role="tabpanel" id="search-results-content" aria-labelledby="search-results-content-count" {{#if forms.search.section '!=' 'content'}}class="u-hidden"{{/if}}>
             {{> components/search/content-listing}}


### PR DESCRIPTION
#### What?
This PR adds announcement of search results on search page after page load

#### Tickets / Documentation

[BCTHEME-423](https://jira.bigcommerce.com/browse/BCTHEME-423)

#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/66325265/113125794-a6804e00-921f-11eb-92d3-20f75c101faf.mov

