### PR TITLE
feat(storefront): BCTHEME-445 replace page builder ssl settings with new global region for html widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Replace SSL settings in Page builder with global region for SSL certificate. [#2026](https://github.com/bigcommerce/cornerstone/pull/2026)
 
 ## 5.3.0 (03-25-2021)
 - Remove AddThis for social sharing, replace with provider sharing links. [#1997](https://github.com/bigcommerce/cornerstone/pull/1997)

--- a/config.json
+++ b/config.json
@@ -313,8 +313,6 @@
     "swatch_option_size": "22x22",
     "social_icon_placement_top": false,
     "social_icon_placement_bottom": "bottom_none",
-    "geotrust_ssl_common_name": "",
-    "geotrust_ssl_seal_size": "M",
     "navigation_design": "simple",
     "price_ranges": true,
     "pdp-price-label": "",

--- a/schema.json
+++ b/schema.json
@@ -938,36 +938,6 @@
         "label": "i18n.ShowKlarna",
         "force_reload": true,
         "id": "show_accept_klarna"
-      },
-      {
-        "type": "heading",
-        "content": "i18n.GeoTrustSSL"
-      },
-      {
-        "type": "paragraph",
-        "content": "i18n.IfYouvePurchasedAGeoTrust"
-      },
-      {
-        "type": "text",
-        "label": "i18n.SSLCommonName",
-        "force_reload": true,
-        "id": "geotrust_ssl_common_name"
-      },
-      {
-        "type": "select",
-        "label": "i18n.SealSize",
-        "id": "geotrust_ssl_seal_size",
-        "options": [
-          {
-            "value": "M",
-            "label": "i18n.Medium"
-          },
-          {
-            "value": "S",
-            "label": "i18n.Small"
-          }
-        ],
-        "force_reload": true
       }
     ]
   },

--- a/schemaTranslations.json
+++ b/schemaTranslations.json
@@ -866,34 +866,6 @@
     "uk": "Показати Klarna",
     "zh": "显示 Klarna"
   },
-  "i18n.GeoTrustSSL": {
-    "default": "GeoTrust SSL",
-    "fr": "SSL GeoTrust",
-    "it": "GeoTrust SSL",
-    "uk": "GeoTrust SSL",
-    "zh": "Geo信任SSL"
-  },
-  "i18n.IfYouvePurchasedAGeoTrust": {
-    "default": "If you've purchased a GeoTrust SSL from BigCommerce, check your BigCommerce Account Dashboard for the correct Common Name to use here.",
-    "fr": "Si vous avez acheté un SSL GeoTrust auprès de BigCommerce, consultez le tableau de bord de votre compte BigCommerce pour le nom commun correct à utiliser ici.",
-    "it": "Sei hai acquistato un SSL GeoTrust da BigCommerce, verifica sulla Dashboard del tuo Account BigCommerce il corretto Nome Comune da utilizzare qui.",
-    "uk": "Якщо ви придбали GeoTrust SSL у BigCommerce, перевірте на панелі керування облікового запису BigCommerce правильну загальну назву, яку тут можна використовувати.",
-    "zh": "如果您有在Bigcommerce中购买Geo信任SSL，检查您的Bigcommerce账户的控制面板，获得在这里使用的正确的公共名称。"
-  },
-  "i18n.SSLCommonName": {
-    "default": "SSL Common Name",
-    "fr": "Nom commun du SSL",
-    "it": "Nome Comune SSL",
-    "uk": "Загальна назва SSL",
-    "zh": "SSL公共名称"
-  },
-  "i18n.SealSize": {
-    "default": "Seal size",
-    "fr": "Taille du sceau",
-    "it": "Dimensioni sigillo",
-    "uk": "Розмір печатки",
-    "zh": "标志尺寸"
-  },
   "i18n.Medium": {
     "default": "Medium",
     "fr": "Moyen",

--- a/templates/components/common/footer.html
+++ b/templates/components/common/footer.html
@@ -87,11 +87,6 @@
                 {{> components/common/payment-icons}}
             </article>
         </section>
-        {{#if theme_settings.geotrust_ssl_common_name}}
-            <div class="footer-geotrust-ssl-seal">
-                {{> components/common/geotrust-ssl-seal}}
-            </div>
-        {{/if}}
         {{#if settings.paypal_commerce_credit_message}}
         <div class="footer-copyright">
             <p class="paypal-credit">{{nl2br settings.paypal_commerce_credit_message}}</p>
@@ -108,4 +103,5 @@
             </div>
         {{/if}}
     </div>
+    {{{region name="ssl_site_seal--global"}}}
 </footer>


### PR DESCRIPTION

#### What?

This PR addresses the issue with SSL Site Seal that is described in [BCTHEME-118](https://jira.bigcommerce.com/browse/BCTHEME-118)
Current solution consists from 2 step:
1. we deprecate  previous settings in Page Builder for SSL Seal;
2. add new global region for SSL Site Seal where a html widget can be placed.

#### Tickets / Documentation
- [BCTHEME-445](https://jira.bigcommerce.com/browse/BCTHEME-445)


#### Screenshots (if appropriate)
<img width="1680" alt="bc445_ssl_settings_before" src="https://user-images.githubusercontent.com/67792608/113261062-a80d4d00-92d7-11eb-8f21-71aec5225aea.png">
<img width="1679" alt="bc445_removed_ssl_settings" src="https://user-images.githubusercontent.com/67792608/113261090-b2c7e200-92d7-11eb-9d94-c23803ca1825.png">
<img width="1679" alt="bc445_global_region" src="https://user-images.githubusercontent.com/67792608/113261116-b9eef000-92d7-11eb-8965-28555b7b10fc.png">
<img width="1275" alt="bc445_region_html" src="https://user-images.githubusercontent.com/67792608/113261141-c2472b00-92d7-11eb-8194-4ea30a50c0bb.png">


