### PR TITLE
fix(storefront): BCTHEME-447 extends keyboard support for radio buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Draft
-
+- Added keyboard support on radio buttons. [#2028](https://github.com/bigcommerce/cornerstone/pull/2028)
 ## 5.3.0 (03-25-2021)
 - Remove AddThis for social sharing, replace with provider sharing links. [#1997](https://github.com/bigcommerce/cornerstone/pull/1997)
 - IE11 - Clicking on Search Does Not Display Search Bar. [#2017](https://github.com/bigcommerce/cornerstone/pull/2017)

--- a/assets/js/theme/common/aria/radioOptions.js
+++ b/assets/js/theme/common/aria/radioOptions.js
@@ -9,6 +9,7 @@ const setCheckedRadioItem = (itemCollection, itemIdx) => {
         }
 
         $item.attr('aria-checked', true).prop('checked', true).focus();
+        $item.trigger('change');
     });
 };
 
@@ -31,21 +32,18 @@ const handleItemKeyDown = itemCollection => e => {
     }
 
     switch (keyCode) {
-    case ariaKeyCodes.RETURN:
-    case ariaKeyCodes.SPACE: {
-        setCheckedRadioItem(itemCollection, itemIdx);
-        break;
-    }
     case ariaKeyCodes.LEFT:
     case ariaKeyCodes.UP: {
         const prevItemIdx = calculateTargetItemPosition(lastCollectionItemIdx, itemIdx - 1);
         itemCollection.get(prevItemIdx).focus();
+        setCheckedRadioItem(itemCollection, itemIdx - 1);
         break;
     }
     case ariaKeyCodes.RIGHT:
     case ariaKeyCodes.DOWN: {
         const nextItemIdx = calculateTargetItemPosition(lastCollectionItemIdx, itemIdx + 1);
         itemCollection.get(nextItemIdx).focus();
+        setCheckedRadioItem(itemCollection, itemIdx + 1);
         break;
     }
 


### PR DESCRIPTION
#### What?

This PR adds extended keyboard support for radio buttons. Such behaviour is based on [W3C](https://www.w3.org/TR/wai-aria-practices/examples/radio/radio-1/radio-1.html) & includes:

- Pressing on right/down arrow keys moves focus and checks the next radio button in the group
- Pressing on left/up arrow keys | moves focus and checks the previous radio button in the group


#### Tickets / Documentation
- [BCTHEME-447](https://jira.bigcommerce.com/browse/BCTHEME-447)


#### Screenshots (if appropriate)
Here you can find a video before and after changes. Moving cross options is made with arrow keys.

https://user-images.githubusercontent.com/67792608/113392996-af4b5e00-939e-11eb-8006-e4ca01ad9eec.mov

https://user-images.githubusercontent.com/67792608/113393127-e1f55680-939e-11eb-9162-1b176a17eff6.mov




