### PR TITLE
fix(storefront): BCTHEME-349 improve email validation for forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- fixed email address validation in forms. [#2029](https://github.com/bigcommerce/cornerstone/pull/2029)
 
 ## 5.3.0 (03-25-2021)
 - Remove AddThis for social sharing, replace with provider sharing links. [#1997](https://github.com/bigcommerce/cornerstone/pull/1997)

--- a/assets/js/theme/common/models/forms.js
+++ b/assets/js/theme/common/models/forms.js
@@ -1,6 +1,6 @@
 const forms = {
     email(value) {
-        const re = /^.+@.+\..+/;
+        const re = /^\S+@\S+\.\S+/;
         return re.test(value);
     },
 


### PR DESCRIPTION
#### What?
This PR fixes an issue when User could fill in an email address with spaces on creating New Account or Account Settings pages. If the entered email  is not valid(spaces, line breaks and tabs) User can not submit a form. The video how it works now is attached to the main ticket.

#### Tickets / Documentation
- [BCTHEME-349](https://jira.bigcommerce.com/browse/BCTHEME-349)

#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/67792608/113595290-7ed71e80-9641-11eb-9700-49d3b42bea74.mov


https://user-images.githubusercontent.com/67792608/113595438-ad54f980-9641-11eb-9be4-529182ab4983.mov


