### PR TITLE
fix(storefront): BCTHEME-449 remove main tag duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Removed duplicates of main tag.[#2032](https://github.com/bigcommerce/cornerstone/pull/2032)
 
 ## 5.3.0 (03-25-2021)
 - Remove AddThis for social sharing, replace with provider sharing links. [#1997](https://github.com/bigcommerce/cornerstone/pull/1997)

--- a/templates/components/common/body.html
+++ b/templates/components/common/body.html
@@ -1,4 +1,4 @@
-<main class="body" id='main-content' role='main' data-currency-code="{{currency_selector.active_currency_code}}">
+<main class="body" id="main-content" role="main" data-currency-code="{{currency_selector.active_currency_code}}">
     {{#block "hero"}} {{/block}}
     <div class="container">
         {{#block "page"}} {{/block}}

--- a/templates/pages/account/add-return.html
+++ b/templates/pages/account/add-return.html
@@ -4,7 +4,7 @@
 <h1 class="page-heading">{{lang 'account.returns.new_return' }}</h1>
 {{> components/account/navigation account_page='returns'}}
 
-<main class="account account--fixed account--addReturn">
+<div class="account account--fixed account--addReturn">
     <div class="account-body">
         <section class="account-content">
 
@@ -100,7 +100,7 @@
 
         </section>
     </div>
-</main>
+</div>
 
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/account/inbox.html
+++ b/templates/pages/account/inbox.html
@@ -4,7 +4,7 @@
 <h1 class="page-heading">{{lang 'account.messages.heading' }}</h1>
 {{> components/account/navigation account_page='messages'}}
 
-<main class="account account--fixed">
+<div class="account account--fixed">
     <div class="account-body">
         <section class="account-content">
             {{#if forms.inbox.error}}
@@ -17,7 +17,7 @@
             {{> components/account/messages-form}}
         </section>
     </div>
-</main>
+</div>
 
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/account/orders/all.html
+++ b/templates/pages/account/orders/all.html
@@ -10,7 +10,7 @@ customer:
 <h1 class="page-heading">{{lang 'account.orders.heading' }}</h1>
 {{> components/account/navigation account_page='orders'}}
 
-<main class="account account--fixed">
+<div class="account account--fixed">
     <div class="account-head">
         {{#if customer.store_credit.value '>' 0}}
             <div class="alertBox alertBox--storeCredit">
@@ -28,7 +28,7 @@ customer:
             {{/if}}
         </section>
     </div>
-</main>
+</div>
 
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/account/returns.html
+++ b/templates/pages/account/returns.html
@@ -4,7 +4,7 @@
 <h1 class="page-heading">{{lang 'account.returns.heading' }}</h1>
 {{> components/account/navigation account_page='returns'}}
 
-<main class="account account--fixed">
+<div class="account account--fixed">
     <div class="account-body">
         <section class="account-content">
             {{#if customer.returns}}
@@ -14,7 +14,7 @@
             {{/if}}
         </section>
     </div>
-</main>
+</div>
 
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/amp/category.html
+++ b/templates/pages/amp/category.html
@@ -28,13 +28,13 @@ category:
             {{category.name}}
         </h1>
     </div>
-    <main class="page-content" id="product-listing-container">
+    <div class="page-content" id="product-listing-container">
         {{#if category.products}}
             {{> components/amp/category/product-listing}}
         {{else}}
             <p>{{lang 'categories.no_products'}}</p>
         {{/if}}
-    </main>
+    </div>
     {{> components/amp/category/subcategories}}
     {{> components/amp/common/footer}}
     {{#if settings.amp_analytics_id}}

--- a/templates/pages/auth/account-created.html
+++ b/templates/pages/auth/account-created.html
@@ -1,10 +1,10 @@
 {{#partial "page"}}
     <section class="page">
-        <main class="page-content page-content--textCenter">
+        <div class="page-content page-content--textCenter">
             <h1 class="page-heading">{{lang 'create_account.created.heading'}}</h1>
             <p>{{{lang 'create_account.created.intro' store_name=settings.store_name email=customer.email}}}</p>
             <a class="button button--primary" href="{{create_account.continue_url}}">{{lang 'create_account.created.continue'}}</a>
-        </main>
+        </div>
     </section>
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/blog.html
+++ b/templates/pages/blog.html
@@ -9,7 +9,7 @@ blog:
 
 {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
 
-<main class="page">
+<section class="page">
     {{#unless theme_settings.hide_blog_page_heading }}
         <h1 class="page-heading">{{ blog.name }}</h1>
     {{/unless}}
@@ -19,7 +19,7 @@ blog:
     {{/each}}
 
     {{> components/common/paginator pagination.blog}}
-</main>
+</section>
 
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/brand.html
+++ b/templates/pages/brand.html
@@ -31,7 +31,7 @@ brand:
         {{> components/brand/sidebar}}
     </aside>
 
-    <main class="page-content" id="product-listing-container">
+    <div class="page-content" id="product-listing-container">
         {{#if brand.search_error }}
             <p>{{lang 'search.errorMessage'}}</p>
         {{else}}
@@ -42,7 +42,7 @@ brand:
             {{/if}}
             {{{region name="brand_below_content"}}}
         {{/if}}
-    </main>
+    </div>
 </div>
 
 {{/partial}}

--- a/templates/pages/brands.html
+++ b/templates/pages/brands.html
@@ -6,7 +6,7 @@ brands:
 
 {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
 
-<main class="page">
+<section class="page">
     <h1 class="page-heading">{{lang 'brand.label'}}</h1>
     {{{region name="brands_below_header"}}}
     <ul class="brandGrid">
@@ -37,6 +37,6 @@ brands:
     </ul>
     {{> components/common/paginator pagination.brands}}
     {{{region name="brands_below_content"}}}
-</main>
+</section>
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -4,7 +4,7 @@ cart: true
 {{#partial "page"}}
 <div class="page">
 
-    <main class="page-content" data-cart>
+    <div class="page-content" data-cart>
         {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
 
         {{> components/cart/page-title}}
@@ -52,7 +52,7 @@ cart: true
             <h3 tabindex="0">{{lang 'cart.checkout.empty_cart'}}</h3>
         {{/if}}
 
-    </main>
+    </div>
 </div>
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -48,10 +48,10 @@ category:
         {{/if}}
     {{/if}}
 
-    <main class="page-content" id="product-listing-container">
+    <div class="page-content" id="product-listing-container">
         {{> components/category/product-listing}}
         {{{region name="category_below_content"}}}
-    </main>
+    </div>
 </div>
 
 {{/partial}}

--- a/templates/pages/compare.html
+++ b/templates/pages/compare.html
@@ -4,7 +4,7 @@
 {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
 <h1 class="page-heading">{{lang 'compare.header' products=comparisons.length}}</h1>
 <div class="page">
-    <main class="page-content">
+    <div class="page-content">
 
         <table class="compareTable">
             <tr class="compareTable-row">
@@ -136,7 +136,7 @@
             </tr>
         </table>
 
-    </main>
+    </div>
 </div>
 
 {{/partial}}

--- a/templates/pages/contact-us.html
+++ b/templates/pages/contact-us.html
@@ -2,7 +2,7 @@
 
 {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
 
-<main class="page">
+<section class="page">
     {{#unless theme_settings.hide_contact_us_page_heading }}
         <h1 class="page-heading">{{page.title}}</h1>
     {{/unless}}
@@ -27,7 +27,7 @@
 
     </div>
 
-</main>
+</section>
 
 {{/partial}}
 

--- a/templates/pages/errors/403.html
+++ b/templates/pages/errors/403.html
@@ -2,7 +2,7 @@
 
 {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
 
-<main class="page">
+<div class="page">
     <section class="page-content page-content--centered">
         <h1 class="page-heading">{{lang 'forbidden.page_heading'}}</h1>
         <p class="u-textAlignCenter">
@@ -12,7 +12,7 @@
         </p>
         {{> components/common/search-box}}
     </section>
-</main>
+</div>
 
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/errors/404.html
+++ b/templates/pages/errors/404.html
@@ -2,7 +2,7 @@
 
 {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
 
-<main class="page">
+<div class="page">
     <section class="page-content page-content--centered">
         <h1 class="page-heading">{{lang 'page_not_found.page_heading'}}</h1>
         <p class="u-textAlignCenter">
@@ -11,7 +11,7 @@
 
         {{> components/common/search-box}}
     </section>
-</main>
+</div>
 
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/errors/generic.html
+++ b/templates/pages/errors/generic.html
@@ -1,13 +1,13 @@
 {{#partial "page"}}
 
-<main class="page">
+<div class="page">
     <section class="page-content page-content--centered">
         <h1 class="page-heading">{{lang 'server_error.page_heading'}}</h1>
         <p class="u-textAlignCenter">
             {{lang 'server_error.message'}}
         </p>
     </section>
-</main>
+</div>
 
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/gift-certificate/balance.html
+++ b/templates/pages/gift-certificate/balance.html
@@ -4,7 +4,7 @@
 <h1 class="page-heading">{{lang 'gift_certificate.heading' }}</h1>
 {{> components/gift-certificate/navigation gift_page='balance'}}
 
-<main class="account account--fixed">
+<div class="account account--fixed">
     <h3>{{lang 'gift_certificate.balance.heading'}}</h3>
     <p>
         <strong>{{lang 'gift_certificate.balance.intro' }}</strong>
@@ -31,6 +31,6 @@
             </div>
         </div>
     </form>
-</main>
+</div>
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/gift-certificate/purchase.html
+++ b/templates/pages/gift-certificate/purchase.html
@@ -4,7 +4,7 @@
 <h1 class="page-heading">{{lang 'gift_certificate.heading' }}</h1>
 {{> components/gift-certificate/navigation gift_page='purchase'}}
 
-<main class="account account--fixed">
+<div class="account account--fixed">
 
     {{#each forms.gift_certificate.errors}}
         {{> components/common/alert/alert-error this}}
@@ -120,6 +120,6 @@
                 value="{{lang 'forms.gift_certificate.purchase.submit_value' }}">
         </div>
     </form>
-</main>
+</div>
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/gift-certificate/redeem.html
+++ b/templates/pages/gift-certificate/redeem.html
@@ -4,7 +4,7 @@
 <h1 class="page-heading">{{lang 'gift_certificate.heading' }}</h1>
 {{> components/gift-certificate/navigation gift_page='redeem'}}
 
-<main class="account account--fixed">
+<div class="account account--fixed">
     <h3>{{lang 'gift_certificate.redeem.heading'}}</h3>
     <p><strong>{{lang 'gift_certificate.redeem.intro' store_name=settings.store_name }}</strong></p>
     <ol>
@@ -13,6 +13,6 @@
         <li>{{{lang 'gift_certificate.redeem.item3' cart_url=urls.cart }}}</li>
         <li>{{lang 'gift_certificate.redeem.item4' }}</li>
     </ol>
-</main>
+</div>
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/page.html
+++ b/templates/pages/page.html
@@ -2,7 +2,7 @@
 
 {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
 
-<main class="page">
+<section class="page">
     {{#unless theme_settings.hide_page_heading }}
         <h1 class="page-heading">{{ page.title }}</h1>
     {{/unless}}
@@ -37,7 +37,7 @@
             {{/each}}
         </ul>
     {{/if}}
-</main>
+</section>
 
 {{/partial}}
 

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -61,7 +61,7 @@ product_results:
             {{> components/faceted-search/index product_results}}
         </aside>
     {{/if}}
-    <main class="page-content">
+    <div class="page-content">
         {{#if forms.search.has_suggestions}}
             <div class="panel panel--large">
                 <div class="panel-body">
@@ -142,7 +142,7 @@ product_results:
         </div>
 
         {{{region name="search_below_content"}}}
-    </main>
+    </div>
 </section>
 
 {{/partial}}


### PR DESCRIPTION
#### What?

This PR removes duplicates for main tag on store pages due to using a main tag with elements that have id="main=content".

#### Tickets / Documentation
- [BCTHEME-449](https://jira.bigcommerce.com/browse/BCTHEME-449)


#### Screenshots (if appropriate)
<img width="1680" alt="bctheme-449_404_not_found" src="https://user-images.githubusercontent.com/67792608/113731119-2cf5cd80-9701-11eb-9c19-249db0d9f691.png">
<img width="1676" alt="bctheme-449_brands" src="https://user-images.githubusercontent.com/67792608/113731138-31ba8180-9701-11eb-8bbb-e43f818d4ffa.png">
<img width="1679" alt="bctheme-449_category" src="https://user-images.githubusercontent.com/67792608/113731153-35e69f00-9701-11eb-994e-25e53e391bdf.png">
<img width="1680" alt="bctheme-449_contact_us" src="https://user-images.githubusercontent.com/67792608/113731192-3f700700-9701-11eb-94ee-c48076f5000f.png">
<img width="1679" alt="bctheme-449_maintenance" src="https://user-images.githubusercontent.com/67792608/113731214-4434bb00-9701-11eb-8218-5a284a0c0751.png">
<img width="1680" alt="bctheme-449_search" src="https://user-images.githubusercontent.com/67792608/113731235-48f96f00-9701-11eb-98d6-846935fef0a9.png">

