### PR TITLE
feat(storefront): BCTHEME-425 Incorrect focus order for product carousels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Incorrect focus order for product carousels. [#2034](https://github.com/bigcommerce/cornerstone/pull/2034)
 - Removed duplicates of main tag.[#2032](https://github.com/bigcommerce/cornerstone/pull/2032)
 - Hamburger Menu Icon missing on Google AMP Pages. [#2022](https://github.com/bigcommerce/cornerstone/pull/2022)
 - Wish List drop down is truncated on product page. [#2001](https://github.com/bigcommerce/cornerstone/pull/2001)

--- a/assets/js/theme/common/carousel/constants.js
+++ b/assets/js/theme/common/carousel/constants.js
@@ -1,0 +1,1 @@
+export const FOCUSABLE_ELEMENTS_SELECTOR = '[href], button, input, textarea, select, details, [contenteditable="true"], [tabindex]';

--- a/assets/js/theme/common/carousel/index.js
+++ b/assets/js/theme/common/carousel/index.js
@@ -2,62 +2,61 @@ import 'slick-carousel';
 
 import {
     activatePlayPauseButton,
+    analizeSlides,
     arrowAriaLabling,
     dotsSetup,
     getActiveSlideIdxAndSlidesQuantity,
     handleImageAspectRatio,
     handleImageLoad,
-    setTabindexes,
-    tooltipSetup,
+    refreshFocus,
     updateTextWithLiveData,
 } from './utils';
 
-/**
- * returns activeSlideIdx and slidesQuantity
- * based on provided carousel settings
- * @param {Object} $slickSettings
- * @returns {Object}
- */
-const extractSlidesDetails = ({
-    slideCount, $slides, options: { slidesToShow, slidesToScroll },
-}) => getActiveSlideIdxAndSlidesQuantity(
-    slideCount,
-    slidesToShow,
-    slidesToScroll,
-    $slides,
-);
+export const setCarouselState = ({ delegateTarget }, carouselObj) => {
+    const carouselObjCurrent = carouselObj || delegateTarget.slick;
+    const { $slider } = carouselObjCurrent;
+
+    $slider.data('state', getActiveSlideIdxAndSlidesQuantity(carouselObjCurrent));
+};
 
 export const onUserCarouselChange = ({ data }, context, $slider) => {
     const $activeSlider = $slider || data;
-    const $parentContainer = $activeSlider.hasClass('productView-thumbnails') ? $('.productView-images') : $activeSlider;
-    const { activeSlideIdx, slidesQuantity } = extractSlidesDetails($activeSlider[0].slick);
+    const $parentContainer = $activeSlider.hasClass('productView-thumbnails') ? $activeSlider.parent('.productView-images') : $activeSlider;
+    const { activeSlideIdx, slidesQuantity } = $activeSlider.data('state');
     const $carouselContentElement = $('[data-carousel-content-change-message]', $parentContainer);
     const carouselContentAnnounceMessage = updateTextWithLiveData(context.carouselContentAnnounceMessage, (activeSlideIdx + 1), slidesQuantity);
 
     $carouselContentElement.text(carouselContentAnnounceMessage);
 };
 
-export const onSlickCarouselChange = (e, carousel, context) => {
+export const onSlickCarouselChange = (e, carouselObj, context) => {
     const {
         $dots,
         $slider,
         $prevArrow,
         $nextArrow,
-    } = carousel;
+        options: { infinite },
+    } = carouselObj;
 
-    const { activeSlideIdx, slidesQuantity } = extractSlidesDetails(carousel);
+    const { activeSlideIdx, slidesQuantity } = $slider.data('state') || getActiveSlideIdxAndSlidesQuantity(carouselObj);
 
     dotsSetup($dots, activeSlideIdx, slidesQuantity, context);
-    arrowAriaLabling($prevArrow, $nextArrow, activeSlideIdx, slidesQuantity, context.carouselArrowAndDotAriaLabel);
-    setTabindexes($slider.find('.slick-slide'));
-    tooltipSetup($prevArrow, $nextArrow, $dots);
-    activatePlayPauseButton(carousel, slidesQuantity, context);
+    arrowAriaLabling($prevArrow, $nextArrow, activeSlideIdx, slidesQuantity, infinite, context.carouselArrowAndDotAriaLabel);
+    analizeSlides($slider.find('.slick-slide'));
+    refreshFocus($prevArrow, $nextArrow, $dots, $slider, activeSlideIdx, slidesQuantity, infinite);
+
+    $slider.data('state', null);
 };
 
 export default function (context) {
     $('[data-slick]').each((idx, carousel) => {
         // getting element using find to pass jest test
         const $carousel = $(document).find(carousel);
+
+        $carousel.on('init breakpoint swipe', setCarouselState);
+        $carousel.on('click', '.slick-arrow, .slick-dots', setCarouselState);
+
+        $carousel.on('init breakpoint', (e, carouselObj) => activatePlayPauseButton(e, carouselObj, context));
         $carousel.on('init afterChange', (e, carouselObj) => onSlickCarouselChange(e, carouselObj, context));
         $carousel.on('click', '.slick-arrow, .slick-dots', $carousel, e => onUserCarouselChange(e, context));
         $carousel.on('swipe', (e, carouselObj) => onUserCarouselChange(e, context, carouselObj.$slider));
@@ -65,7 +64,7 @@ export default function (context) {
         if ($carousel.hasClass('heroCarousel')) {
             $carousel.on('init afterChange', handleImageLoad);
             $carousel.on('swipe', handleImageAspectRatio);
-            $carousel.on('click', '.slick-arrow, .slick-dots', $carousel, handleImageAspectRatio);
+            $carousel.on('click', '.slick-arrow, .slick-dots', handleImageAspectRatio);
 
             // Alternative image styling for IE, which doesn't support objectfit
             if (typeof document.documentElement.style.objectFit === 'undefined') {

--- a/assets/js/theme/common/carousel/utils/analizeSlides.js
+++ b/assets/js/theme/common/carousel/utils/analizeSlides.js
@@ -1,4 +1,4 @@
-const FOCUSABLE_ELEMENTS_SELECTOR = '[href], button, input, textarea, select, details, [contenteditable="true"], [tabindex]';
+import { FOCUSABLE_ELEMENTS_SELECTOR } from '../constants';
 
 export default ($slides) => {
     $slides.each((idx, slide) => {

--- a/assets/js/theme/common/carousel/utils/arrowAriaLabling.js
+++ b/assets/js/theme/common/carousel/utils/arrowAriaLabling.js
@@ -1,6 +1,7 @@
 import updateTextWithLiveData from './updateTextWithLiveData';
+import tooltipSetup from './tooltipSetup';
 
-export default ($prevArrow, $nextArrow, activeSlideIdx, slidesQuantity, ariaLabel) => {
+export default ($prevArrow, $nextArrow, activeSlideIdx, slidesQuantity, isInfinite, ariaLabel) => {
     if (slidesQuantity < 2 || !$prevArrow || !$nextArrow) return;
 
     const activeSlideNumber = activeSlideIdx + 1;
@@ -8,10 +9,18 @@ export default ($prevArrow, $nextArrow, activeSlideIdx, slidesQuantity, ariaLabe
     const prevSlideNumber = activeSlideIdx === 0 ? slidesQuantity : activeSlideNumber - 1;
     const arrowLeftText = updateTextWithLiveData(ariaLabel, prevSlideNumber, slidesQuantity);
 
-    $prevArrow.attr('aria-label', arrowLeftText);
+    $prevArrow.attr({
+        'aria-label': arrowLeftText,
+        tabindex: !isInfinite && activeSlideIdx === 0 ? -1 : 0,
+    });
+    tooltipSetup($prevArrow);
 
     const nextSlideNumber = activeSlideIdx === slidesQuantity - 1 ? 1 : activeSlideNumber + 1;
     const arrowRightText = updateTextWithLiveData(ariaLabel, nextSlideNumber, slidesQuantity);
 
-    $nextArrow.attr('aria-label', arrowRightText);
+    $nextArrow.attr({
+        'aria-label': arrowRightText,
+        tabindex: !isInfinite && activeSlideIdx === slidesQuantity - 1 ? -1 : 0,
+    });
+    tooltipSetup($nextArrow);
 };

--- a/assets/js/theme/common/carousel/utils/dotsSetup.js
+++ b/assets/js/theme/common/carousel/utils/dotsSetup.js
@@ -1,4 +1,5 @@
 import updateTextWithLiveData from './updateTextWithLiveData';
+import tooltipSetup from './tooltipSetup';
 
 export default ($dots, activeSlideIdx, slidesQuantity, { carouselArrowAndDotAriaLabel, carouselActiveDotAriaLabel }) => {
     if (!$dots) return;
@@ -14,7 +15,8 @@ export default ($dots, activeSlideIdx, slidesQuantity, { carouselArrowAndDotAria
         const dotLabelText = updateTextWithLiveData(carouselArrowAndDotAriaLabel, idx + 1, slidesQuantity);
         const dotSlideStatusText = idx === activeSlideIdx ? `, ${carouselActiveDotAriaLabel}` : '';
         const dotAriaLabel = `${dotLabelText}${dotSlideStatusText}`;
+        const $dotButton = $(dot).find('[data-carousel-dot]');
 
-        $(dot).find('[data-carousel-dot]').attr('aria-label', dotAriaLabel);
+        tooltipSetup($dotButton.attr('aria-label', dotAriaLabel));
     });
 };

--- a/assets/js/theme/common/carousel/utils/getActiveSlideIdxAndSlidesQuantity.js
+++ b/assets/js/theme/common/carousel/utils/getActiveSlideIdxAndSlidesQuantity.js
@@ -1,4 +1,4 @@
-export default (slideCount, slidesToShow, slidesToScroll, $slides) => {
+export default ({ slideCount, $slides, options: { slidesToShow, slidesToScroll } }) => {
     const lastVisibleIdx = $slides.get().reduce((acc, curr, idx) => {
         if ($(curr).hasClass('slick-active')) return idx;
         return acc;

--- a/assets/js/theme/common/carousel/utils/index.js
+++ b/assets/js/theme/common/carousel/utils/index.js
@@ -1,9 +1,9 @@
 export { default as activatePlayPauseButton } from './activatePlayPauseButton';
+export { default as analizeSlides } from './analizeSlides';
 export { default as arrowAriaLabling } from './arrowAriaLabling';
 export { default as dotsSetup } from './dotsSetup';
 export { default as getActiveSlideIdxAndSlidesQuantity } from './getActiveSlideIdxAndSlidesQuantity';
 export { default as handleImageAspectRatio } from './handleImageAspectRatio';
 export { default as handleImageLoad } from './handleImageLoad';
-export { default as setTabindexes } from './setTabindexes';
-export { default as tooltipSetup } from './tooltipSetup';
+export { default as refreshFocus } from './refreshFocus';
 export { default as updateTextWithLiveData } from './updateTextWithLiveData';

--- a/assets/js/theme/common/carousel/utils/refreshFocus.js
+++ b/assets/js/theme/common/carousel/utils/refreshFocus.js
@@ -1,0 +1,20 @@
+import { FOCUSABLE_ELEMENTS_SELECTOR } from '../constants';
+
+export default ($prevArrow, $nextArrow, $dots, $slider, activeSlideIdx, slidesQuantity, isInfinite) => {
+    if (isInfinite || !$prevArrow || !$nextArrow) return;
+
+    if (activeSlideIdx === 0 && $prevArrow.is(':focus')) {
+        $nextArrow.focus();
+    } else if (activeSlideIdx === slidesQuantity - 1 && $nextArrow.is(':focus')) {
+        if ($dots) {
+            $dots.children().first().find('[data-carousel-dot]').focus();
+            return;
+        }
+
+        const $firstActiveSlide = $slider.find('.slick-active').first();
+
+        if ($firstActiveSlide.is(FOCUSABLE_ELEMENTS_SELECTOR)) {
+            $firstActiveSlide.focus();
+        } else $firstActiveSlide.find(FOCUSABLE_ELEMENTS_SELECTOR).first().focus();
+    }
+};

--- a/assets/js/theme/common/carousel/utils/tooltipSetup.js
+++ b/assets/js/theme/common/carousel/utils/tooltipSetup.js
@@ -2,30 +2,12 @@ const TOOLTIP_DATA_SELECTOR = 'data-carousel-tooltip';
 const TOOLTIP_CLASS = 'carousel-tooltip';
 const TOOLTIP_NODE = `<span ${TOOLTIP_DATA_SELECTOR} class="${TOOLTIP_CLASS}"></span>`;
 
-const setupTooltipAriaLabel = ($node) => {
+export default ($node) => {
     const $existedTooltip = $node.find(`[${TOOLTIP_DATA_SELECTOR}]`);
     if ($existedTooltip.length) {
         $existedTooltip.attr('aria-label', $node.attr('aria-label'));
     } else {
         const $tooltip = $(TOOLTIP_NODE).attr('aria-label', $node.attr('aria-label'));
         $node.append($tooltip);
-    }
-};
-
-const setupArrowTooltips = (...arrowNodes) => {
-    arrowNodes.forEach($arrow => setupTooltipAriaLabel($arrow));
-};
-
-const setupDotTooltips = ($dots) => {
-    $dots.children().each((idx, dot) => setupTooltipAriaLabel($('[data-carousel-dot]', dot)));
-};
-
-export default ($prevArrow, $nextArrow, $dots) => {
-    if ($prevArrow && $nextArrow) {
-        setupArrowTooltips($prevArrow, $nextArrow);
-    }
-
-    if ($dots) {
-        setupDotTooltips($dots);
     }
 };

--- a/assets/js/theme/global/quick-view.js
+++ b/assets/js/theme/global/quick-view.js
@@ -4,7 +4,7 @@ import utils from '@bigcommerce/stencil-utils';
 import ProductDetails from '../common/product-details';
 import { defaultModal } from './modal';
 import 'slick-carousel';
-import { onSlickCarouselChange, onUserCarouselChange } from '../common/carousel';
+import { setCarouselState, onSlickCarouselChange, onUserCarouselChange } from '../common/carousel';
 
 export default function (context) {
     const modal = defaultModal();
@@ -24,7 +24,10 @@ export default function (context) {
             const $carousel = modal.$content.find('[data-slick]');
 
             if ($carousel.length) {
-                $carousel.on('init afterChange', (e, carousel) => onSlickCarouselChange(e, carousel, context));
+                $carousel.on('init breakpoint swipe', setCarouselState);
+                $carousel.on('click', '.slick-arrow, .slick-dots', setCarouselState);
+
+                $carousel.on('init afterChange', (e, carouselObj) => onSlickCarouselChange(e, carouselObj, context));
                 $carousel.on('click', '.slick-arrow, .slick-dots', $carousel, e => onUserCarouselChange(e, context));
                 $carousel.on('swipe', (e, carouselObj) => onUserCarouselChange(e, context, carouselObj.$slider));
 


### PR DESCRIPTION

#### What?

This PR implements control of focus behaviour on carousels. Also it has some performance updates that helped to implement correct focus order in all cases (for example on breakpoint event)

#### Tickets / Documentation

[BCTHEME-425](https://jira.bigcommerce.com/browse/BCTHEME-425)

#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/66325265/114144303-db765a00-991d-11eb-82d8-ca6379439619.mov

