### PR TITLE
fix(search): ES-2138 fixed count showing issue for category facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Draft
 - Fixed unnecessary horizontal scroll on swatch options on PDP. [#2023](https://github.com/bigcommerce/cornerstone/pull/2023)
+- Always showing product counts for Category facet in the faceted search results page. [#2035](https://github.com/bigcommerce/cornerstone/pull/2035)
 
 ## 5.3.0 (03-25-2021)
 - Remove AddThis for social sharing, replace with provider sharing links. [#1997](https://github.com/bigcommerce/cornerstone/pull/1997)

--- a/templates/components/faceted-search/facets/hierarchy.html
+++ b/templates/components/faceted-search/facets/hierarchy.html
@@ -14,9 +14,7 @@
                         data-faceted-search-facet>
                         {{{sanitize title}}}
                         {{#if ../show_product_counts}}
-                            {{#if count}}
-                                <span>({{count}})</span>
-                            {{/if}}
+                            <span>({{count}})</span>
                         {{/if}}
                     </a>
                     {{#if children}}


### PR DESCRIPTION
#### What?
Category facet does not show product count next to it when the count is `0`.  

#### Why? 
In theme file we have a check to show product count for `Category` facet only if it is greater than `0`. Since, for our use case the count is `0`, it's not shown. So, I have removed the `if` block to show the count always. For all other facets we show the count always. Only for `Category` it is different. To keep consistency across all facets this fix is made.

#### Tickets / Documentation
- [ES-2138](https://jira.bigcommerce.com/browse/ES-2138)

#### Screenshots (if appropriate)
_Note: Please use the theme file (`Cornerstone-5.3.0_ES-2138_Fix.zip`) uploaded to ES-2138._ 

Steps:
Login to CP
Navigate to Storefront -> My Themes, upload the theme file & apply it
Follow the steps provided in the ticket 
Observe that product count is shown next to `Category` facet


**After Fix:**
![image](https://user-images.githubusercontent.com/39140274/114144260-fcad5b00-98c9-11eb-8a34-84d895fc87b6.png)

**Before Fix:**
![image](https://user-images.githubusercontent.com/39140274/114144490-3d0cd900-98ca-11eb-9b3e-b573b2fef097.png)

