### PR TITLE
Fix conditional display of Apple Pay in Preview Cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fixed email address validation in forms. [#2029](https://github.com/bigcommerce/cornerstone/pull/2029)
 - Fixed unnecessary horizontal scroll on swatch options on PDP. [#2023](https://github.com/bigcommerce/cornerstone/pull/2023)
 - Always showing product counts for Category facet in the faceted search results page. [#2035](https://github.com/bigcommerce/cornerstone/pull/2035)
+- Fix conditional display of Apple Pay button in preview cart. [#2036](https://github.com/bigcommerce/cornerstone/pull/2036)
 
 ## 5.3.0 (03-25-2021)
 - Remove AddThis for social sharing, replace with provider sharing links. [#1997](https://github.com/bigcommerce/cornerstone/pull/1997)

--- a/assets/scss/components/stencil/applePay/_applePay.scss
+++ b/assets/scss/components/stencil/applePay/_applePay.scss
@@ -40,8 +40,14 @@
 
 .previewCartCheckout {
     .apple-pay-checkout-button {
-        display: inline-block;
         float: none;
         margin-top: spacing("half");
     }
 }
+
+.apple-pay-supported .previewCartCheckout {
+    .apple-pay-checkout-button {
+        display: inline-block;
+    }
+}
+


### PR DESCRIPTION
#### What?

Inline block display for preview cart button styling overrode conditional display of Apple Pay button and resulted in an empty button when Apple Pay was not available. Applied conditional rules used from cart styling to preview cart.


#### Tickets / Documentation

N/A

#### Screenshots (if appropriate)

![before2](https://user-images.githubusercontent.com/950448/114552226-5bf4cd80-9c32-11eb-9e87-00b4ef18fd82.png)
![after2](https://user-images.githubusercontent.com/950448/114552225-5bf4cd80-9c32-11eb-837b-417e0012e5b5.png)
![before-apple](https://user-images.githubusercontent.com/950448/114552224-5bf4cd80-9c32-11eb-92a5-67bdaf855f9b.png)
![after-apple](https://user-images.githubusercontent.com/950448/114552223-5bf4cd80-9c32-11eb-8fd9-73d3383595f8.png)



