### PR TITLE
Use https:// for schema markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Use https:// for schema markup. [#2039](https://github.com/bigcommerce/cornerstone/pull/2039)
 - Apple pay button displaying needs to be fixed. [#2043](https://github.com/bigcommerce/cornerstone/pull/2043)
 
 ## 5.4.0 (04-26-2021)

--- a/templates/components/amp/products/product-view-details.html
+++ b/templates/components/amp/products/product-view-details.html
@@ -2,7 +2,7 @@
     <div class="productView-product">
         <h1 class="productView-title" {{#if schema}}itemprop="name"{{/if}}>{{product.title}}</h1>
         {{#if product.brand }}
-        <h2 class="productView-brand"{{#if schema}} itemprop="brand" itemscope itemtype="http://schema.org/Brand"{{/if}}>
+        <h2 class="productView-brand"{{#if schema}} itemprop="brand" itemscope itemtype="https://schema.org/Brand"{{/if}}>
             <a href="{{product.brand.url}}"{{#if schema}} itemprop="url"{{/if}}><span{{#if schema}} itemprop="name"{{/if}}>{{product.brand.name}}</span></a>
         </h2>
         {{/if}}

--- a/templates/components/amp/products/reviews.html
+++ b/templates/components/amp/products/reviews.html
@@ -7,9 +7,9 @@
             <ul class="productReviews-list" id="productReviews-list">
                 {{#each reviews.list}}
                 <li class="productReview">
-                    <article itemprop="review" itemscope itemtype="http://schema.org/Review">
+                    <article itemprop="review" itemscope itemtype="https://schema.org/Review">
                         <header>
-                            <span class="productReview-rating rating--small" itemprop="reviewRating" itemscope itemtype="http://schema.org/Rating">
+                            <span class="productReview-rating rating--small" itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating">
                                 {{> components/amp/products/ratings rating=rating}}
                                 <span class="productReview-ratingNumber" itemprop="ratingValue">{{ rating }}</span>
                             </span>

--- a/templates/components/common/breadcrumbs.html
+++ b/templates/components/common/breadcrumbs.html
@@ -1,8 +1,8 @@
 <nav aria-label="Breadcrumb">
-    <ol class="breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">
+    <ol class="breadcrumbs" itemscope itemtype="https://schema.org/BreadcrumbList">
         {{#unless theme_settings.hide_breadcrumbs }}
             {{#each breadcrumbs}}
-                <li class="breadcrumb {{#if @last}}is-active{{/if}}" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+                <li class="breadcrumb {{#if @last}}is-active{{/if}}" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
                     <a class="breadcrumb-label"
                        itemprop="item"
                        href="{{url}}"

--- a/templates/components/products/price-range.html
+++ b/templates/components/products/price-range.html
@@ -21,7 +21,7 @@
             {{price.non_sale_price_with_tax.formatted}}
         </span>
     </div>
-    <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+    <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="https://schema.org/Offer"{{/if}}>
         <span class="price-label">{{theme_settings.pdp-price-label}}</span>
         <span class="price-now-label" style="display: none;">{{theme_settings.pdp-sale-price-label}}</span>
         <span data-product-price-with-tax class="price price--withTax">{{price.price_range.min.with_tax.formatted}} - {{price.price_range.max.with_tax.formatted}}</span>
@@ -29,12 +29,12 @@
             <abbr title="{{lang 'products.including_tax'}}">{{lang 'products.price_with_tax' tax_label=price.price_range.min.tax_label}}</abbr>
         {{/and}}
         {{#if schema_org}}
-            <meta itemprop="availability" itemtype="http://schema.org/ItemAvailability"
-                    content="http://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
-            <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
+            <meta itemprop="availability" itemtype="https://schema.org/ItemAvailability"
+                    content="https://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
+            <meta itemprop="itemCondition" itemtype="https://schema.org/OfferItemCondition" content="https://schema.org/{{product.condition}}Condition">
             <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
             <meta itemprop="url" content="{{product.url}}">
-            <div itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
+            <div itemprop="priceSpecification" itemscope itemtype="https://schema.org/PriceSpecification">
                 <meta itemprop="minPrice" content="{{price_range.min.with_tax.value}}"  />
                 <meta itemprop="price" content="{{price_range.min.with_tax.value}}">
                 <meta itemprop="maxPrice" content="{{price_range.max.with_tax.value}}"  />
@@ -67,7 +67,7 @@
             {{price.non_sale_price_without_tax.formatted}}
         </span>
     </div>
-    <div class="price-section price-section--withoutTax{{#and price_range.min.with_tax price_range.max.with_tax}} price-section--minor{{/and}}" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+    <div class="price-section price-section--withoutTax{{#and price_range.min.with_tax price_range.max.with_tax}} price-section--minor{{/and}}" {{#if schema_org}}itemprop="offers" itemscope itemtype="https://schema.org/Offer"{{/if}}>
         <span class="price-label">{{theme_settings.pdp-price-label}}</span>
         <span class="price-now-label" style="display: none;">{{theme_settings.pdp-sale-price-label}}</span>
         <span data-product-price-without-tax class="price price--withoutTax">{{price.price_range.min.without_tax.formatted}} - {{price.price_range.max.without_tax.formatted}}</span>
@@ -75,12 +75,12 @@
             <abbr title="{{lang 'products.excluding_tax'}}">{{lang 'products.price_without_tax' tax_label=price.price_range.min.tax_label}}</abbr>
         {{/and}}
         {{#if schema_org}}
-            <meta itemprop="availability" itemtype="http://schema.org/ItemAvailability"
-                    content="http://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
-            <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
+            <meta itemprop="availability" itemtype="https://schema.org/ItemAvailability"
+                    content="https://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
+            <meta itemprop="itemCondition" itemtype="https://schema.org/OfferItemCondition" content="https://schema.org/{{product.condition}}Condition">
             <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
             <meta itemprop="url" content="{{product.url}}">
-            <div itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
+            <div itemprop="priceSpecification" itemscope itemtype="https://schema.org/PriceSpecification">
                 <meta itemprop="minPrice" content="{{price.price_range.min.without_tax.value}}"  />
                 <meta itemprop="price" content="{{price.price_range.min.without_tax.value}}">
                 <meta itemprop="maxPrice" content="{{price.price_range.max.without_tax.value}}"  />

--- a/templates/components/products/price.html
+++ b/templates/components/products/price.html
@@ -20,7 +20,7 @@ If you are making a change here or in price-range.html, you probably want to mak
                 {{price.non_sale_price_with_tax.formatted}}
             </span>
         </div>
-        <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+        <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="https://schema.org/Offer"{{/if}}>
             <span class="price-label" {{#if price.non_sale_price_with_tax}}style="display: none;"{{/if}}>
                 {{theme_settings.pdp-price-label}}
             </span>
@@ -29,12 +29,12 @@ If you are making a change here or in price-range.html, you probably want to mak
             </span>
             <span data-product-price-with-tax class="price price--withTax">{{price.with_tax.formatted}}</span>
             {{#if schema_org}}
-                <meta itemprop="availability" itemtype="http://schema.org/ItemAvailability" 
-                	content="http://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
-                <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
+                <meta itemprop="availability" itemtype="https://schema.org/ItemAvailability" 
+                	content="https://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
+                <meta itemprop="itemCondition" itemtype="https://schema.org/OfferItemCondition" content="https://schema.org/{{product.condition}}Condition">
                 <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
                 <meta itemprop="url" content="{{product.url}}">
-                <div itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
+                <div itemprop="priceSpecification" itemscope itemtype="https://schema.org/PriceSpecification">
                     <meta itemprop="price" content="{{price.with_tax.value}}">
                     <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
                     <meta itemprop="valueAddedTaxIncluded" content="true">
@@ -58,7 +58,7 @@ If you are making a change here or in price-range.html, you probably want to mak
                 {{price.non_sale_price_without_tax.formatted}}
             </span>
         </div>
-        <div class="price-section price-section--withoutTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+        <div class="price-section price-section--withoutTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="https://schema.org/Offer"{{/if}}>
             <span class="price-label" {{#if price.non_sale_price_without_tax}}style="display: none;"{{/if}}>
                 {{theme_settings.pdp-price-label}}
             </span>
@@ -67,12 +67,12 @@ If you are making a change here or in price-range.html, you probably want to mak
             </span>
             <span data-product-price-without-tax class="price price--withoutTax{{#if price.with_tax}} price-section--minor{{/if}}">{{price.without_tax.formatted}}</span>
             {{#if schema_org}}
-                <meta itemprop="availability" itemtype="http://schema.org/ItemAvailability"
-                    content="http://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
-                <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/{{product.condition}}Condition">
+                <meta itemprop="availability" itemtype="https://schema.org/ItemAvailability"
+                    content="https://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
+                <meta itemprop="itemCondition" itemtype="https://schema.org/OfferItemCondition" content="https://schema.org/{{product.condition}}Condition">
                 <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
                 <meta itemprop="url" content="{{product.url}}">
-                <div itemprop="priceSpecification" itemscope itemtype="http://schema.org/PriceSpecification">
+                <div itemprop="priceSpecification" itemscope itemtype="https://schema.org/PriceSpecification">
                     <meta itemprop="price" content="{{price.without_tax.value}}">
                     <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
                     <meta itemprop="valueAddedTaxIncluded" content="false">

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -75,7 +75,7 @@
         <div class="productView-product">
             <h1 class="productView-title" {{#if schema}}itemprop="name"{{/if}}>{{product.title}}</h1>
             {{#if product.brand}}
-                <h2 class="productView-brand"{{#if schema}} itemprop="brand" itemscope itemtype="http://schema.org/Brand"{{/if}}>
+                <h2 class="productView-brand"{{#if schema}} itemprop="brand" itemscope itemtype="https://schema.org/Brand"{{/if}}>
                     <a href="{{product.brand.url}}"{{#if schema}} itemprop="url"{{/if}}><span{{#if schema}} itemprop="name"{{/if}}>{{product.brand.name}}</span></a>
                 </h2>
             {{/if}}
@@ -92,7 +92,7 @@
                 {{/or}}
             </div>
             {{{region name="product_below_price"}}}
-            <div class="productView-rating"{{#if product.num_reviews '>' 0}}{{#if schema}} itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating"{{/if}}{{/if}}>
+            <div class="productView-rating"{{#if product.num_reviews '>' 0}}{{#if schema}} itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating"{{/if}}{{/if}}>
                 {{#if settings.show_product_rating}}
                     {{#if product.num_reviews '>' 0}}
                         {{#if schema}}

--- a/templates/components/products/reviews.html
+++ b/templates/components/products/reviews.html
@@ -17,9 +17,9 @@
         <ul class="productReviews-list" id="productReviews-list">
             {{#each reviews.list}}
             <li class="productReview">
-                <article itemprop="review" itemscope itemtype="http://schema.org/Review">
+                <article itemprop="review" itemscope itemtype="https://schema.org/Review">
                     <header>
-                        <span class="productReview-rating rating--small" itemprop="reviewRating" itemscope itemtype="http://schema.org/Rating">
+                        <span class="productReview-rating rating--small" itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating">
                             {{> components/products/ratings rating=rating}}
                             <span class="productReview-ratingNumber" itemprop="ratingValue">{{ rating }}</span>
                         </span>

--- a/templates/pages/amp/product.html
+++ b/templates/pages/amp/product.html
@@ -23,7 +23,7 @@ product:
 {{/partial}}
 {{#partial "page"}}
     {{> components/amp/common/header }}
-    <div itemscope itemtype="http://schema.org/Product">
+    <div itemscope itemtype="https://schema.org/Product">
         {{> components/amp/products/product-view schema=true}}
     </div>
     {{#if settings.amp_analytics_id}}

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -19,7 +19,7 @@ product:
         {{> components/common/alert/alert-info message}}
     {{/each}}
 
-    <div itemscope itemtype="http://schema.org/Product">
+    <div itemscope itemtype="https://schema.org/Product">
         {{> components/products/product-view schema=true  }}
 
         {{{region name="product_below_content"}}}


### PR DESCRIPTION
#### What?

This PR changes http://schema.org for https://schema.org. `http://` will be supported for the foreseeable future, but figured why wait for that to be phased out.

#### Tickets / Documentation

- [Schema.org FAQ (#19 Should we write 'https://schema.org' or 'http://schema.org' in our markup?)](https://schema.org/docs/faq.html#19)
- #2038 