### PR TITLE
fix(storefront): BCTHEME-325 Apple pay button displaying needs to be fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Apple pay button displaying needs to be fixed. [#2043](https://github.com/bigcommerce/cornerstone/pull/2043)
 - Incorrect focus order for product carousels. [#2034](https://github.com/bigcommerce/cornerstone/pull/2034)
 - Removed duplicates of main tag.[#2032](https://github.com/bigcommerce/cornerstone/pull/2032)
 - Hamburger Menu Icon missing on Google AMP Pages. [#2022](https://github.com/bigcommerce/cornerstone/pull/2022)

--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -10,6 +10,7 @@ import CartItemDetails from './common/cart-item-details';
 export default class Cart extends PageManager {
     onReady() {
         this.$modal = null;
+        this.$cartPageContent = $('[data-cart]');
         this.$cartContent = $('[data-cart-content]');
         this.$cartMessages = $('[data-cart-status]');
         this.$cartTotals = $('[data-cart-totals]');
@@ -18,7 +19,14 @@ export default class Cart extends PageManager {
         this.$activeCartItemId = null;
         this.$activeCartItemBtnAction = null;
 
+        this.setApplePaySupport();
         this.bindEvents();
+    }
+
+    setApplePaySupport() {
+        if (window.ApplePaySession) {
+            this.$cartPageContent.addClass('apple-pay-supported');
+        }
     }
 
     cartUpdate($target) {

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -377,7 +377,7 @@ export default class ProductDetails extends ProductDetailsBase {
                 this.previewModal.open();
 
                 if (window.ApplePaySession) {
-                    this.previewModal.getJqueryElement().addClass('apple-pay-supported');
+                    this.previewModal.$modal.addClass('apple-pay-supported');
                 }
 
                 if ($addToCartBtn.parents('.quickView').length === 0) this.previewModal.$preModalFocusedEl = $addToCartBtn;

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -376,6 +376,10 @@ export default class ProductDetails extends ProductDetailsBase {
             if (this.previewModal) {
                 this.previewModal.open();
 
+                if (window.ApplePaySession) {
+                    this.previewModal.getJqueryElement().addClass('apple-pay-supported');
+                }
+
                 if ($addToCartBtn.parents('.quickView').length === 0) this.previewModal.$preModalFocusedEl = $addToCartBtn;
                 this.updateCartContent(this.previewModal, response.data.cart_item.id, () => this.previewModal.setupFocusTrap());
             } else {

--- a/assets/js/theme/global/cart-preview.js
+++ b/assets/js/theme/global/cart-preview.js
@@ -15,6 +15,10 @@ export default function (secureBaseUrl, cartId) {
 
     const $body = $('body');
 
+    if (window.ApplePaySession) {
+        $cartDropdown.addClass('apple-pay-supported');
+    }
+
     $body.on('cart-quantity-update', (event, quantity) => {
         $cart.attr('aria-label', (_, prevValue) => prevValue.replace(/\d+/, quantity));
 

--- a/assets/js/theme/global/modal.js
+++ b/assets/js/theme/global/modal.js
@@ -232,10 +232,6 @@ export class Modal {
     onModalOpened() {
         restrainContentHeight(this.$content);
     }
-
-    getJqueryElement() {
-        return this.$modal;
-    }
 }
 
 /**

--- a/assets/js/theme/global/modal.js
+++ b/assets/js/theme/global/modal.js
@@ -232,6 +232,10 @@ export class Modal {
     onModalOpened() {
         restrainContentHeight(this.$content);
     }
+
+    getJqueryElement() {
+        return this.$modal;
+    }
 }
 
 /**

--- a/assets/scss/components/stencil/applePay/_applePay.scss
+++ b/assets/scss/components/stencil/applePay/_applePay.scss
@@ -36,12 +36,16 @@
         display: block;
         float: right;
     }
+
+    & .previewCartCheckout {
+        .apple-pay-checkout-button {
+            display: inline-block;
+        }
+    }
 }
 
 .previewCartCheckout {
     .apple-pay-checkout-button {
-        display: inline-block;
         float: none;
-        margin-top: spacing("half");
     }
 }

--- a/assets/scss/components/stencil/applePay/_applePay.scss
+++ b/assets/scss/components/stencil/applePay/_applePay.scss
@@ -37,15 +37,8 @@
         float: right;
     }
 
-    & .previewCartCheckout {
-        .apple-pay-checkout-button {
-            display: inline-block;
-        }
-    }
-}
-
-.previewCartCheckout {
-    .apple-pay-checkout-button {
+    & .previewCartCheckout .apple-pay-checkout-button {
+        display: inline-block;
         float: none;
     }
 }

--- a/assets/scss/components/stencil/applePay/_applePay.scss
+++ b/assets/scss/components/stencil/applePay/_applePay.scss
@@ -25,12 +25,6 @@
     }
 }
 
-.cart-additionalCheckoutButtons {
-    .apple-pay-checkout-button {
-        margin-top: spacing("half");
-    }
-}
-
 .apple-pay-supported {
     .apple-pay-checkout-button {
         display: block;

--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -43,18 +43,6 @@ $card-preview-zoom-bottom-offset:       6rem;
             float: right;
         }
     }
-
-    .CheckoutButton {
-        margin-bottom: spacing("base");
-
-        &:first-child {
-            margin-top: spacing("single");
-        }
-
-        &:last-child {
-            margin-bottom: spacing("single");
-        }
-    }
 }
 
 // Cart layout
@@ -557,7 +545,8 @@ $card-preview-zoom-bottom-offset:       6rem;
 
 .previewCart-additionalCheckoutButtons {
     @extend %additionalCheckoutButtons;
-    padding-right: 1.5rem;
+    padding-right: spacing('single');
+    padding-bottom: spacing('single');
 }
 
 // Cart Preview
@@ -608,7 +597,7 @@ $card-preview-zoom-bottom-offset:       6rem;
     }
 
     @include lazy-loaded-padding('productthumb_size');
-    
+
     &:after {
         @include breakpoint("xxsmall") {
             padding-bottom: 75%;

--- a/assets/scss/components/stencil/previewCart/_previewCart.scss
+++ b/assets/scss/components/stencil/previewCart/_previewCart.scss
@@ -56,9 +56,12 @@
         width: 100%;
 
         // scss-lint:disable NestingDepth
-        + .button,
         + p {
             margin-top: spacing("half");
+        }
+
+        &:not(:last-child) {
+            margin-bottom: spacing("half");
         }
     }
 }


### PR DESCRIPTION
#### What?

Inline block display for preview cart button styling overrode conditional display of Apple Pay button and resulted in an empty button when Apple Pay was not available. Applied conditional rules used from cart styling to preview cart.

#### Tickets / Documentation

[Jira](https://jira.bigcommerce.com/browse/BCTHEME-325)

#### Screenshots (if appropriate)

Apple Pay disabled 
<img width="1282" alt="Screenshot 2021-04-26 at 13 29 19" src="https://user-images.githubusercontent.com/66319629/116069051-a4c96f00-a693-11eb-9c0a-42c5462151c0.png">

Apple pay enabled
<img width="1257" alt="Screenshot 2021-04-26 at 13 29 11" src="https://user-images.githubusercontent.com/66319629/116069067-ab57e680-a693-11eb-97e0-444175e34651.png">

