### PR TITLE
fix(storefront): DEV-426 Fix GitHub workflows for default storefront

### DIFF
--- a/.github/workflow-examples/automatic_deployment_production.yml
+++ b/.github/workflow-examples/automatic_deployment_production.yml
@@ -39,6 +39,8 @@ jobs:
 
 #
 # You must configure store credentials as secrets on your GitHub repo for automatic deployment via GitHub Actions
+# This defaults to pushing the theme to channel ID 1, which is the default storefront. If you wish to push to an
+# Alternate storefront, use a different channel ID
 #
 
     - name: Connect to store
@@ -48,4 +50,4 @@ jobs:
       run: stencil init -u $URL -t $TOKEN -p 3000
 
     - name: Push theme live, automatically deleting oldest theme if necessary
-      run: stencil push -a -d
+      run: stencil push -a -d -c 1

--- a/.github/workflow-examples/poll_for_changed_configuration.yml
+++ b/.github/workflow-examples/poll_for_changed_configuration.yml
@@ -49,8 +49,8 @@ jobs:
         TOKEN: ${{ secrets.STENCIL_ACCESS_TOKEN_PRODUCTION }}
       run: stencil init -u $URL -t $TOKEN -p 3000
 
-    - name: Check for an updated configuration on the live store
-      run: stencil pull
+    - name: Check for an updated configuration on the live default storefront (channel ID 1)
+      run: stencil pull -c 1
 
     - name: Create Pull Request
       id: cpr


### PR DESCRIPTION
#### What?

A recent release of stencil-cli broke these GitHub Actions examples, as the CLI arguments now require a channel ID in order to proceed without user interaction.

I am hardcoding this channel ID to `1`, which is the default storefront on every store. This will be the appropriate default for 99% of users for now, and those who wish to update it can adjust their functions accordingly.
