### PR TITLE
fix(storefront): BCTHEME-457 Update focus tooltip styles contrast to achieve accessibility AA Complaince

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Update focus tooltip styles contrast to achieve accessibility AA Complaince. [#2047](https://github.com/bigcommerce/cornerstone/pull/2047)
 - Incorrect focus order for product carousels. [#2034](https://github.com/bigcommerce/cornerstone/pull/2034)
 - Removed duplicates of main tag.[#2032](https://github.com/bigcommerce/cornerstone/pull/2032)
 - Hamburger Menu Icon missing on Google AMP Pages. [#2022](https://github.com/bigcommerce/cornerstone/pull/2022)

--- a/assets/scss/common/_focus-tooltip.scss
+++ b/assets/scss/common/_focus-tooltip.scss
@@ -6,14 +6,14 @@
             top: 50%;
             border-width: remCalc(10px);
             border-style: solid;
-            border-color: transparent transparent $adminBar-tooltip-bg-backgroundColor transparent;
+            border-color: transparent transparent $focusTooltip-backgroundColor transparent;
         }
 
         &:after {
             content: attr($attr);
             padding: remCalc(4px) remCalc(6px);
-            background-color: $adminBar-tooltip-bg-backgroundColor;
-            color: white;
+            background-color: $focusTooltip-backgroundColor;
+            color: $focusTooltip-textColor;
             position: absolute;
             font-size: 1rem;
             white-space: nowrap;

--- a/assets/scss/settings/global/color/_color.scss
+++ b/assets/scss/settings/global/color/_color.scss
@@ -67,3 +67,9 @@ $color-textSecondary-active:        stencilColor("color-textSecondary--active");
 $color-textLink:                    stencilColor("color-textLink");
 $color-textLink-hover:              stencilColor("color-textLink--hover");
 $color-textLink-active:             stencilColor("color-textLink--active");
+
+
+// Tooltips
+// -----------------------------------------------------------------------------
+$focusTooltip-textColor:            stencilColor("focusTooltip-textColor");
+$focusTooltip-backgroundColor:      stencilColor("focusTooltip-backgroundColor");

--- a/config.json
+++ b/config.json
@@ -309,6 +309,8 @@
     "color_badge_product_sold_out_badges": "#007dc6",
     "color_text_product_sold_out_badges": "#ffffff",
     "color_hover_product_sold_out_badges": "#000000",
+    "focusTooltip-textColor": "#ffffff",
+    "focusTooltip-backgroundColor": "#313440",
     "restrict_to_login": false,
     "swatch_option_size": "22x22",
     "social_icon_placement_top": false,
@@ -593,7 +595,9 @@
         "color_hover_product_sale_badges": "#000000",
         "color_badge_product_sold_out_badges": "#007dc6",
         "color_text_product_sold_out_badges": "#ffffff",
-        "color_hover_product_sold_out_badges": "#000000"
+        "color_hover_product_sold_out_badges": "#000000",
+        "focusTooltip-textColor": "#666666",
+        "focusTooltip-backgroundColor": "#ffffff"
       }
     },
     {
@@ -801,7 +805,9 @@
         "color_hover_product_sale_badges": "#000000",
         "color_badge_product_sold_out_badges": "#007dc6",
         "color_text_product_sold_out_badges": "#ffffff",
-        "color_hover_product_sold_out_badges": "#000000"
+        "color_hover_product_sold_out_badges": "#000000",
+        "focusTooltip-textColor": "#ffffff",
+        "focusTooltip-backgroundColor": "#313440"
       }
     }
   ]


### PR DESCRIPTION
@bc-alexsaiannyi @BC-tymurbiedukhin @yurytut1993 @bc-azvierieva 
#### What?

This PR fixes the problem of low contrast of the tooltip to achieve accessibility AA Complaince. Updated color for tooltip in dark CornerStone theme.

#### Tickets / Documentation

- [BCTHEME-457](https://jira.bigcommerce.com/browse/BCTHEME-457)

#### Screenshots (if appropriate)
Bold(dark) theme:
![tooltip-bold-theme](https://user-images.githubusercontent.com/82589781/116255129-a3bf3d00-a77a-11eb-8ef2-693663be21ab.png)

![contrast-checker-bold-theme](https://user-images.githubusercontent.com/82589781/116255185-afaaff00-a77a-11eb-9c99-bb31ec3569e5.png)

Light and Warm themes:
![tooltip-light-theme](https://user-images.githubusercontent.com/82589781/116255279-c3eefc00-a77a-11eb-88af-b3359a09a1c5.png)
![tooltip-warm-theme](https://user-images.githubusercontent.com/82589781/116255945-64452080-a77b-11eb-87b2-4b36125447b7.png)

![contrast-checker-light-and-warm-theme](https://user-images.githubusercontent.com/82589781/116255321-cd786400-a77a-11eb-83df-003b75a4cf72.png)



