### PR TITLE
fix(storefront): BCTHEME-477 Add to cart button and Wishlist should be on one line on desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Add to cart button and Wishlist should be on one line on desktop. [#2050](https://github.com/bigcommerce/cornerstone/pull/2050)
 - Added settings for payment banners. [#2021](https://github.com/bigcommerce/cornerstone/pull/2021)
 - Use https:// for schema markup. [#2039](https://github.com/bigcommerce/cornerstone/pull/2039)
 - Update focus tooltip styles contrast to achieve accessibility AA Complaince. [#2047](https://github.com/bigcommerce/cornerstone/pull/2047)

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -291,6 +291,10 @@
 
     .form {
         display: inline;
+
+        .add-to-cart-wrapper {
+            display: inline;
+        }
     }
 
     input[type="file"] {
@@ -333,7 +337,6 @@
         }
 
         @include breakpoint("medium") {
-            float: none;
             padding: 0;
             width: auto;
         }
@@ -347,10 +350,17 @@
         .button {
             width: 100%;
 
-            @include breakpoint("large") {
-                margin-right: spacing("half");
+            @include breakpoint("medium") {
                 width: auto;
             }
+
+            @include breakpoint("large") {
+                margin-right: spacing("half");
+            }
+        }
+
+        .button--primary {
+            margin-right: spacing("half");
         }
     }
 }

--- a/templates/components/products/add-to-cart.html
+++ b/templates/components/products/add-to-cart.html
@@ -1,4 +1,4 @@
-<div id="add-to-cart-wrapper" {{#unless product.can_purchase}}style="display: none"{{/unless}}>
+<div id="add-to-cart-wrapper" class="add-to-cart-wrapper" {{#unless product.can_purchase}}style="display: none"{{/unless}}>
     {{#if theme_settings.show_product_quantity_box}}
         <div class="form-field form-field--increments">
             <label class="form-label form-label--alternate"


### PR DESCRIPTION
@bc-alexsaiannyi @BC-tymurbiedukhin @yurytut1993 @bc-azvierieva 
#### What?

Fixed alignment of "Add to cart" and "Wishlist" buttons on all screen sizes.

#### Tickets / Documentation

- [BCTHEME-477](https://jira.bigcommerce.com/browse/BCTHEME-477)

#### Screenshots (if appropriate)

<img width="1401" alt="Снимок экрана 2021-05-05 в 16 04 20" src="https://user-images.githubusercontent.com/82589781/117145845-4485ac00-adbc-11eb-9ea5-4620a5976b7e.png">
<img width="554" alt="Снимок экрана 2021-05-05 в 16 03 38" src="https://user-images.githubusercontent.com/82589781/117145880-4bacba00-adbc-11eb-8b24-f58797b2b31e.png">
<img width="1403" alt="Снимок экрана 2021-05-05 в 15 58 47" src="https://user-images.githubusercontent.com/82589781/117145906-523b3180-adbc-11eb-9141-5ab80c8e8ad8.png">
<img width="555" alt="Снимок экрана 2021-05-05 в 16 00 11" src="https://user-images.githubusercontent.com/82589781/117145921-56ffe580-adbc-11eb-9012-5320b127027f.png">

