### PR TITLE
fix(storefront): BCTHEME-479 Logo on AMP Product details page (PDP) does not fit header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Logo on AMP Product details page (PDP) doesn't fit header. [#2054](https://github.com/bigcommerce/cornerstone/pull/2054)
 - Added settings for payment banners. [#2021](https://github.com/bigcommerce/cornerstone/pull/2021)
 - Use https:// for schema markup. [#2039](https://github.com/bigcommerce/cornerstone/pull/2039)
 - Update focus tooltip styles contrast to achieve accessibility AA Complaince. [#2047](https://github.com/bigcommerce/cornerstone/pull/2047)

--- a/templates/components/amp/common/store-logo.html
+++ b/templates/components/amp/common/store-logo.html
@@ -10,7 +10,7 @@
                 {{#if (last (split theme_settings.logo_size 'x')) 'gtnum' (first (split theme_settings.logo_size 'x')) }}
                     sizes="(max-width: 360px) 100vw, 1vw"
                 {{else}}
-                    sizes="(max-width: 360px) 100vw, 10vw"
+                    sizes="(max-width: 768px) 15vw, 10vw"
                 {{/if}}
                 layout="responsive"
             {{/if}}

--- a/templates/components/amp/css/header.html
+++ b/templates/components/amp/css/header.html
@@ -25,15 +25,28 @@
     align-items: center;
 }
 
+.amp-header-logo {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-grow: 1;
+    max-height: 55px;
+    padding-right: 3.92857rem;
+}
+
 .amp-header-link {
     display: inline-block;
     text-decoration: none;
+    vertical-align: middle;
 }
 
-.amp-header-logo {
-    flex-grow: 1;
-    padding-right: 3.92857rem;
-    text-align: center;
+.amp-header-link amp-img {
+    max-height: 55px;
+}
+
+.amp-header-link amp-img img {
+    min-width: auto;
+    width: auto;
 }
 
 .amp-empty-space {


### PR DESCRIPTION
@BC-tymurbiedukhin @yurytut1993 @bc-alexsaiannyi 

#### What?
Fixed display of the logo for all screen sizes. Tested on horizontal and vertical logo variations.

#### Tickets / Documentation

- [BCTHEME-479](https://jira.bigcommerce.com/browse/BCTHEME-479)

#### Screenshots (if appropriate)
**Horizontal logo bug**:
<img width="336" alt="horizontal_sx_bug" src="https://user-images.githubusercontent.com/82589781/117811375-26f78d00-b269-11eb-8f29-862ff15ff22f.png">

**Horizontal logo fixed**:
<img width="346" alt="horizontal_sx" src="https://user-images.githubusercontent.com/82589781/117808472-979caa80-b265-11eb-856d-bffb22ccb642.png">
<img width="1031" alt="horizontal_md" src="https://user-images.githubusercontent.com/82589781/117808494-9d928b80-b265-11eb-9c7a-fff40e0bbdd1.png">
<img width="1044" alt="horizontal_lg" src="https://user-images.githubusercontent.com/82589781/117808509-a2573f80-b265-11eb-8ca7-18b9dc263759.png">

**Vertical logo bugs**:
<img width="342" alt="vertical_sx_bug" src="https://user-images.githubusercontent.com/82589781/117811449-3aa2f380-b269-11eb-9fb7-f0ce2c8e3d61.png">
<img width="1030" alt="vertical_md_bug" src="https://user-images.githubusercontent.com/82589781/117811466-41316b00-b269-11eb-9700-9a3eda073e1a.png">
<img width="1066" alt="vertical_lg_bug" src="https://user-images.githubusercontent.com/82589781/117811477-468eb580-b269-11eb-9176-5a495cca672b.png">

**Vertical logo fixed**:
<img width="345" alt="vertical_sx" src="https://user-images.githubusercontent.com/82589781/117808573-b9962d00-b265-11eb-820d-6654323dc1e9.png">
<img width="1031" alt="vertical_md" src="https://user-images.githubusercontent.com/82589781/117808589-be5ae100-b265-11eb-903d-0333d38ec8bc.png">
<img width="1045" alt="vertical_lg" src="https://user-images.githubusercontent.com/82589781/117808612-c581ef00-b265-11eb-9633-a8beb6f551f0.png">
