### PR TITLE
fix(storefront): BCTHEME-492 Translation Gap: Compare page fields (Description, Rating and Availability).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Translation Gap: Compare page fields (Description, Rating and Availability). [#2059](https://github.com/bigcommerce/cornerstone/pull/2059)
 - Added settings for payment banners. [#2021](https://github.com/bigcommerce/cornerstone/pull/2021)
 - Use https:// for schema markup. [#2039](https://github.com/bigcommerce/cornerstone/pull/2039)
 - Update focus tooltip styles contrast to achieve accessibility AA Complaince. [#2047](https://github.com/bigcommerce/cornerstone/pull/2047)

--- a/templates/pages/compare.html
+++ b/templates/pages/compare.html
@@ -80,7 +80,7 @@
             </tr>
             <tr class="compareTable-row">
                 <th class="compareTable-heading">
-                    <span class="compareTable-headingText">Description</span>
+                    <span class="compareTable-headingText">{{lang 'products.description'}}</span>
                 </th>
                 {{#each comparisons}}
                 <td class="compareTable-item">{{{ summary }}}</td>
@@ -89,7 +89,7 @@
             {{#if settings.show_product_rating}}
                 <tr class="compareTable-row">
                     <th class="compareTable-heading">
-                        <span class="compareTable-headingText">Rating</span>
+                        <span class="compareTable-headingText">{{lang 'products.reviews.rating_label'}}</span>
                     </th>
                     {{#each comparisons}}
                     <td class="compareTable-item">
@@ -104,7 +104,7 @@
             {{/if}}
             <tr class="compareTable-row">
                 <th class="compareTable-heading">
-                    <span class="compareTable-headingText">Availability</span>
+                    <span class="compareTable-headingText">{{lang 'products.availability'}}</span>
                 </th>
                 {{#each comparisons}}
                 <td class="compareTable-item">


### PR DESCRIPTION
@BC-tymurbiedukhin @yurytut1993 @bc-alexsaiannyi 
#### What?
It is expected that after adding files with translations (for example **it.json**), translations are applied to the names of the Description, Rating and Availability fields.

#### Tickets / Documentation

- [BCTHEME-492](https://jira.bigcommerce.com/browse/BCTHEME-492)

#### Screenshots (if appropriate)
For example, if the selected language is **Italian**:
<img width="1035" alt="Снимок экрана 2021-05-14 в 17 08 59" src="https://user-images.githubusercontent.com/82589781/118285529-3598ab00-b4da-11eb-9042-85b9ad3d4e79.png">
and if **english** is selected:
<img width="1037" alt="Снимок экрана 2021-05-14 в 17 08 03" src="https://user-images.githubusercontent.com/82589781/118285546-3b8e8c00-b4da-11eb-8028-444c8433b3a5.png">

