### PR TITLE
fix(storefront): BCTHEME-507 Translation Gap: Account -> Wish List -> Name required message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Translation Gap: Account -> Wish List -> Name required message. [#2060](https://github.com/bigcommerce/cornerstone/pull/2060)
 - Added settings for payment banners. [#2021](https://github.com/bigcommerce/cornerstone/pull/2021)
 - Use https:// for schema markup. [#2039](https://github.com/bigcommerce/cornerstone/pull/2039)
 - Update focus tooltip styles contrast to achieve accessibility AA Complaince. [#2047](https://github.com/bigcommerce/cornerstone/pull/2047)

--- a/assets/js/theme/wishlist.js
+++ b/assets/js/theme/wishlist.js
@@ -45,7 +45,7 @@ export default class WishList extends PageManager {
 
                     cb(result);
                 },
-                errorMessage: 'You must enter a wishlist name.',
+                errorMessage: this.context.enterWishlistNameError,
             },
         ]);
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -474,7 +474,8 @@
             "save": "Save Wish List",
             "delete_alert": "Are you sure you want to delete your Wish List(s)? This action cannot be undone.",
             "create_new": "Create New Wish List",
-            "add_to_default": "Add to My Wish List"
+            "add_to_default": "Add to My Wish List",
+            "enter_wishlist_name_error": "You must enter a wishlist name."
         }
     },
     "page": {

--- a/templates/components/account/add-wishlist.html
+++ b/templates/components/account/add-wishlist.html
@@ -1,3 +1,5 @@
+{{inject 'enterWishlistNameError' (lang 'account.wishlists.enter_wishlist_name_error')}}
+
 <div class="wishlist-add">
     <header class="wishlist-header">
         {{#if forms.wishlist.id}}


### PR DESCRIPTION
@BC-tymurbiedukhin @yurytut1993 @bc-alexsaiannyi 
#### What?

It is expected that after adding files with translations (for example it.json), translations are applied to the error message when creating a new wishlist without a wishlist name.

#### Tickets / Documentation

- [BCTHEME-507](https://jira.bigcommerce.com/browse/BCTHEME-507)

#### Screenshots (if appropriate)
<img width="1397" alt="create_wishlist" src="https://user-images.githubusercontent.com/82589781/118633415-24051b00-b7da-11eb-8b83-e57e4582b326.png">
<img width="1278" alt="eng_wishlist" src="https://user-images.githubusercontent.com/82589781/118633439-29626580-b7da-11eb-97f8-ba4a910e53e1.png">
<img width="1229" alt="it_wishlist" src="https://user-images.githubusercontent.com/82589781/118633458-2e271980-b7da-11eb-81e6-bc89b95d15aa.png">

