### PR TITLE
fix(storefront): BCTHEME-490 Translation Gap: Compare products error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Translation Gap: Compare products error message. [#2061](https://github.com/bigcommerce/cornerstone/pull/2061)
 - Fixed displaying swatch name for multiple swatch options on page. [#2040](https://github.com/bigcommerce/cornerstone/pull/2040)
 - Added settings for payment banners. [#2021](https://github.com/bigcommerce/cornerstone/pull/2021)
 - Use https:// for schema markup. [#2039](https://github.com/bigcommerce/cornerstone/pull/2039)

--- a/assets/js/theme/account.js
+++ b/assets/js/theme/account.js
@@ -33,7 +33,7 @@ export default class Account extends PageManager {
         const $reorderForm = classifyForm('[data-account-reorder-form]');
         const $invoiceButton = $('[data-print-invoice]');
 
-        compareProducts(this.context.urls);
+        compareProducts(this.context);
 
         // Injected via template
         this.passwordRequirements = this.context.passwordRequirements;

--- a/assets/js/theme/brand.js
+++ b/assets/js/theme/brand.js
@@ -11,7 +11,7 @@ export default class Brand extends CatalogPage {
     }
 
     onReady() {
-        compareProducts(this.context.urls);
+        compareProducts(this.context);
 
         if ($('#facetedSearch').length > 0) {
             this.initFacetedSearch();

--- a/assets/js/theme/category.js
+++ b/assets/js/theme/category.js
@@ -34,7 +34,7 @@ export default class Category extends CatalogPage {
 
         this.makeShopByPriceFilterAccessible();
 
-        compareProducts(this.context.urls);
+        compareProducts(this.context);
 
         if ($('#facetedSearch').length > 0) {
             this.initFacetedSearch();

--- a/assets/js/theme/compare.js
+++ b/assets/js/theme/compare.js
@@ -4,7 +4,7 @@ import compareProducts from './global/compare-products';
 
 export default class Compare extends PageManager {
     onReady() {
-        compareProducts(this.context.urls);
+        compareProducts(this.context);
 
         const message = this.context.compareRemoveMessage;
 

--- a/assets/js/theme/global/compare-products.js
+++ b/assets/js/theme/global/compare-products.js
@@ -12,19 +12,19 @@ function incrementCounter(counter, item) {
     counter.push(item);
 }
 
-function updateCounterNav(counter, $link, urlContext) {
+function updateCounterNav(counter, $link, urls) {
     if (counter.length !== 0) {
         if (!$link.is('visible')) {
             $link.addClass('show');
         }
-        $link.attr('href', `${urlContext.compare}/${counter.join('/')}`);
+        $link.attr('href', `${urls.compare}/${counter.join('/')}`);
         $link.find('span.countPill').html(counter.length);
     } else {
         $link.removeClass('show');
     }
 }
 
-export default function (urlContext) {
+export default function ({ noCompareMessage, urls }) {
     let compareCounter = [];
 
     const $compareLink = $('a[data-compare-nav]');
@@ -33,7 +33,7 @@ export default function (urlContext) {
         const $checked = $('body').find('input[name="products\[\]"]:checked');
 
         compareCounter = $checked.length ? $checked.map((index, element) => element.value).get() : [];
-        updateCounterNav(compareCounter, $compareLink, urlContext);
+        updateCounterNav(compareCounter, $compareLink, urls);
     });
 
     $('body').triggerHandler('compareReset');
@@ -48,7 +48,7 @@ export default function (urlContext) {
             decrementCounter(compareCounter, product);
         }
 
-        updateCounterNav(compareCounter, $clickedCompareLink, urlContext);
+        updateCounterNav(compareCounter, $clickedCompareLink, urls);
     });
 
     $('body').on('submit', '[data-product-compare]', event => {
@@ -56,7 +56,7 @@ export default function (urlContext) {
         const productsToCompare = $this.find('input[name="products\[\]"]:checked');
 
         if (productsToCompare.length <= 1) {
-            showAlertModal('You must select at least two products to compare');
+            showAlertModal(noCompareMessage);
             event.preventDefault();
         }
     });
@@ -65,7 +65,7 @@ export default function (urlContext) {
         const $clickedCheckedInput = $('body').find('input[name="products\[\]"]:checked');
 
         if ($clickedCheckedInput.length <= 1) {
-            showAlertModal('You must select at least two products to compare');
+            showAlertModal(noCompareMessage);
             return false;
         }
     });

--- a/assets/js/theme/search.js
+++ b/assets/js/theme/search.js
@@ -134,7 +134,7 @@ export default class Search extends CatalogPage {
     }
 
     onReady() {
-        compareProducts(this.context.urls);
+        compareProducts(this.context);
         this.arrangeFocusOnSortBy();
 
         const $searchForm = $('[data-advanced-search-form]');

--- a/lang/en.json
+++ b/lang/en.json
@@ -213,7 +213,8 @@
         "header": "Comparing {products, plural, one {# Product} other {# Products}}",
         "remove": "Remove",
         "no_remove": "At least 2 products are needed to make a valid comparison.",
-        "add_to_cart": "Add to cart"
+        "add_to_cart": "Add to cart",
+        "no_compare": "You must select at least two products to compare"
     },
     "category": {
         "label": "Categories",

--- a/templates/components/brand/product-listing.html
+++ b/templates/components/brand/product-listing.html
@@ -1,3 +1,5 @@
+{{inject 'noCompareMessage' (lang 'compare.no_compare')}}
+
 {{> components/products/filter sort=pagination.brand.sort}}
 
 <form action="{{urls.compare}}" method='POST' {{#if settings.data_tag_enabled}} data-list-name="Brand: {{brand.name}}" {{/if}} data-product-compare>

--- a/templates/components/category/product-listing.html
+++ b/templates/components/category/product-listing.html
@@ -1,3 +1,5 @@
+{{inject 'noCompareMessage' (lang 'compare.no_compare')}}
+
 {{#if category.products}}
     {{> components/products/filter sort=pagination.category.sort}}
 

--- a/templates/components/search/product-listing.html
+++ b/templates/components/search/product-listing.html
@@ -1,3 +1,5 @@
+{{inject 'noCompareMessage' (lang 'compare.no_compare')}}
+
 {{#if product_results.products.length}}
     {{> components/products/filter sort=pagination.product_results.sort}}
 {{/if}}


### PR DESCRIPTION
@BC-tymurbiedukhin 
@bc-alexsaiannyi 
@yurytut1993 
#### What?

It is expected that after adding files with translations (for example it.json), the translations will be applied to the error message that will appear when you select one product and click on the "Compare" button.

#### Tickets / Documentation

- [BCTHEME-490](https://jira.bigcommerce.com/browse/BCTHEME-490)

#### Screenshots (if appropriate)

![hardcoded-message](https://user-images.githubusercontent.com/83779098/118682530-35b1e700-b809-11eb-9778-625b681d102f.png)
<img width="978" alt="Screenshot 2021-05-05 at 17 00 22" src="https://user-images.githubusercontent.com/83779098/118682535-36e31400-b809-11eb-8538-61cc9adf512f.png">
<img width="1680" alt="Снимок экрана 2021-05-18 в 18 45 50" src="https://user-images.githubusercontent.com/83779098/118684107-9beb3980-b80a-11eb-9f85-a447cbb57ad0.png">
<img width="695" alt="Снимок экрана 2021-05-18 в 18 46 19" src="https://user-images.githubusercontent.com/83779098/118684112-9c83d000-b80a-11eb-8816-8ab1ca7f9fb8.png">
<img width="687" alt="Снимок экрана 2021-05-18 в 18 54 29" src="https://user-images.githubusercontent.com/83779098/118684115-9db4fd00-b80a-11eb-8731-e0ae814e7cfc.png">


