### PR TITLE
fix(storefront): BCTHEME-512 add translation for invalid quantity value error on cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Added translation for invalid quantity value error on Cart. [#2062](https://github.com/bigcommerce/cornerstone/pull/2062)
 - Fixed displaying swatch name for multiple swatch options on page. [#2040](https://github.com/bigcommerce/cornerstone/pull/2040)
 - Added settings for payment banners. [#2021](https://github.com/bigcommerce/cornerstone/pull/2021)
 - Use https:// for schema markup. [#2039](https://github.com/bigcommerce/cornerstone/pull/2039)

--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -90,7 +90,7 @@ export default class Cart extends PageManager {
             invalidEntry = $el.val();
             $el.val(oldQty);
             return swal.fire({
-                text: `${invalidEntry} is not a valid entry`,
+                text: this.context.invalidEntryMessage.replace('[ENTRY]', invalidEntry),
                 icon: 'error',
             });
         } else if (newQty < minQty) {

--- a/lang/en.json
+++ b/lang/en.json
@@ -67,6 +67,7 @@
         },
         "label": "Your Cart ({quantity, plural, one {# item} other {# items}})",
         "is_empty": "Your cart is empty",
+        "invalid_entry_message": "[ENTRY] is not a valid entry",
         "coupon_code": "Coupon Code",
         "discount": "Discount",
         "included_in_total": " Included in Total",

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -2,6 +2,7 @@
 cart: true
 ---
 {{#partial "page"}}
+{{inject 'invalidEntryMessage' (lang 'cart.invalid_entry_message')}}
 <div class="page">
 
     <div class="page-content" data-cart>


### PR DESCRIPTION

#### What?

This PR adds a translation instead of hard-coded text. 

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [BCTHEME-512](https://jira.bigcommerce.com/browse/BCTHEME-512)

#### Screenshots (if appropriate)
<img width="1136" alt="translation_fix" src="https://user-images.githubusercontent.com/67792608/118678333-9808e880-b805-11eb-8c81-192ddee81ab4.png">

