### PR TITLE
fix(storefront): BCTHEME-496 Translation Gap: Delete from Cart confirmation popup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Translation Gap: Delete from Cart confirmation popup. [#2065](https://github.com/bigcommerce/cornerstone/pull/2065)
 - Added settings for payment banners. [#2021](https://github.com/bigcommerce/cornerstone/pull/2021)
 - Use https:// for schema markup. [#2039](https://github.com/bigcommerce/cornerstone/pull/2039)
 - Update focus tooltip styles contrast to achieve accessibility AA Complaince. [#2047](https://github.com/bigcommerce/cornerstone/pull/2047)

--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -275,6 +275,7 @@ export default class Cart extends PageManager {
                 text: string,
                 icon: 'warning',
                 showCancelButton: true,
+                cancelButtonText: this.context.cancelButtonText
             }).then((result) => {
                 if (result.value) {
                     // remove item from cart

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -1,6 +1,7 @@
 ---
 cart: true
 ---
+{{inject 'cancelButtonText' (lang 'common.cancel')}}
 {{#partial "page"}}
 <div class="page">
 


### PR DESCRIPTION
@BC-tymurbiedukhin @bc-alexsaiannyi @yurytut1993 

#### What?

This PR fixed the gap of translating the cancel button on cart page inside the modal popup. It is expected that after adding files with translations (for example it.json), translations are applied to the names of the cancel button.

#### Tickets / Documentation

- [BCTHEME-496](https://jira.bigcommerce.com/browse/BCTHEME-496)

#### Screenshots (if appropriate)
<img width="1205" alt="496_no_translate" src="https://user-images.githubusercontent.com/82589781/118987371-df6bb200-b988-11eb-8288-72c75ea5c3d2.png">
<img width="1206" alt="496_translate" src="https://user-images.githubusercontent.com/82589781/118987402-e4c8fc80-b988-11eb-8dab-31c172e8b72b.png">