### PR TITLE
fix(storefront): BCTHEME-535 Translation Gap: Cart -> Shipping estimator error messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Translation Gap: Cart -> Shipping estimator error messages. [#2066](https://github.com/bigcommerce/cornerstone/pull/2066)
 - Added settings for payment banners. [#2021](https://github.com/bigcommerce/cornerstone/pull/2021)
 - Use https:// for schema markup. [#2039](https://github.com/bigcommerce/cornerstone/pull/2039)
 - Update focus tooltip styles contrast to achieve accessibility AA Complaince. [#2047](https://github.com/bigcommerce/cornerstone/pull/2047)

--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -456,6 +456,10 @@ export default class Cart extends PageManager {
         this.bindGiftCertificateEvents();
 
         // initiate shipping estimator module
-        this.shippingEstimator = new ShippingEstimator($('[data-shipping-estimator]'));
+        const shippingErrorMessages = {
+            country: this.context.shippingCountryErrorMessage,
+            province: this.context.shippingProvinceErrorMessage
+        }
+        this.shippingEstimator = new ShippingEstimator($('[data-shipping-estimator]'), shippingErrorMessages);
     }
 }

--- a/assets/js/theme/cart/shipping-estimator.js
+++ b/assets/js/theme/cart/shipping-estimator.js
@@ -6,11 +6,12 @@ import collapsibleFactory from '../common/collapsible';
 import swal from '../global/sweet-alert';
 
 export default class ShippingEstimator {
-    constructor($element) {
+    constructor($element, shippingErrorMessages) {
         this.$element = $element;
 
         this.$state = $('[data-field-type="State"]', this.$element);
         this.isEstimatorFormOpened = false;
+        this.shippingErrorMessages = shippingErrorMessages;
         this.initFormValidation();
         this.bindStateCountryChange();
         this.bindEstimatorEvents();
@@ -63,7 +64,7 @@ export default class ShippingEstimator {
 
                     cb(result);
                 },
-                errorMessage: 'The \'Country\' field cannot be blank.',
+                errorMessage: this.shippingErrorMessages.country
             },
         ]);
     }
@@ -85,7 +86,7 @@ export default class ShippingEstimator {
 
                     cb(result);
                 },
-                errorMessage: 'The \'State/Province\' field cannot be blank.',
+                errorMessage: this.shippingErrorMessages.province
             },
         ]);
     }

--- a/lang/en.json
+++ b/lang/en.json
@@ -105,7 +105,9 @@
             "zip_postal_code": "Zip/postcode",
             "free_shipping": "Free shipping",
             "hide_ups_rates": "Hide UPS Rates",
-            "show_ups_rates": "Show UPS Rates"
+            "show_ups_rates": "Show UPS Rates",
+            "empty_country_error": "The Country field cannot be blank.",
+            "empty_province_error": "The State/Province field cannot be blank."
         },
         "gift_wrapping": {
             "title": "Gift Wrapping",

--- a/templates/components/cart/shipping-estimator.html
+++ b/templates/components/cart/shipping-estimator.html
@@ -1,3 +1,6 @@
+{{inject 'shippingCountryErrorMessage' (lang 'cart.shipping_estimator.empty_country_error')}}
+{{inject 'shippingProvinceErrorMessage' (lang 'cart.shipping_estimator.empty_province_error')}}
+
 {{#if shipping_cost}}
     <div class="cart-total-value">
         <div class="subtotal shipping-estimate-show">


### PR DESCRIPTION
@BC-tymurbiedukhin @yurytut1993 @bc-alexsaiannyi 

#### What?

It is expected that after adding files with translations (for example it.json), translations are applied to the shipping error messages.

#### Tickets / Documentation

- [BCTHEME-535](https://jira.bigcommerce.com/browse/BCTHEME-535)

#### Screenshots (if appropriate)

<img width="1104" alt="535_country_no_translate" src="https://user-images.githubusercontent.com/82589781/119525489-39a0b480-bd87-11eb-8d4b-776faa42a2d8.png">
<img width="1101" alt="535_province_no_translate" src="https://user-images.githubusercontent.com/82589781/119525522-402f2c00-bd87-11eb-80bb-bad1a758d5e8.png">
<img width="1107" alt="535_country_translate" src="https://user-images.githubusercontent.com/82589781/119525552-46250d00-bd87-11eb-8058-7c8f95b4dd04.png">
<img width="1100" alt="535_province_translate" src="https://user-images.githubusercontent.com/82589781/119525592-4c1aee00-bd87-11eb-865e-6d5301300b05.png">
