### PR TITLE
fix(storefront): BCTHEME-452 Unable to select 'None' on unrequired Swatch Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Fixed possibility to select 'None' on multi unrequired Swatch Options. [#2068](https://github.com/bigcommerce/cornerstone/pull/2068)
 - Translation Gap: Compare products error message. [#2061](https://github.com/bigcommerce/cornerstone/pull/2061)
 - Translation Gap: Gift Certificate -> Code required message. [#2064](https://github.com/bigcommerce/cornerstone/pull/2064)
 - Added translation for invalid quantity value error on Cart. [#2062](https://github.com/bigcommerce/cornerstone/pull/2062)

--- a/templates/components/products/options/swatch.html
+++ b/templates/components/products/options/swatch.html
@@ -5,7 +5,7 @@
 
         {{> components/common/requireness-msg}}
     </label>
-    <span 
+    <span
         class="swatch-option-message aria-description--hidden u-hidden">
         {{ lang 'products.swatch_option_announcement' swatch_name=this.display_name}}
     </span>
@@ -14,13 +14,13 @@
         <input
             class="form-radio"
             type="radio"
-            name="attribute[{{../id}}]"
+            name="attribute[{{id}}]"
             value=""
-            id="attribute_swatch_{{../id}}_none"
+            id="attribute_swatch_{{id}}_none"
             checked="{{#if defaultValue '==' ''}}checked{{/if}}"
             aria-label="{{lang 'products.none'}}"
         >
-        <label class="form-option form-option-swatch" for="attribute_swatch_{{../id}}_none">
+        <label class="form-option form-option-swatch" for="attribute_swatch_{{id}}_none">
             <span class='form-option-variant form-option-variant--none' title="{{lang 'products.none'}}">{{lang 'products.none'}}</span>
         </label>
     {{/unless}}


### PR DESCRIPTION
#### What?

If you create an unrequired Swatch Option on a product, the "None" swatch is automatically added to the page, but is unable to be selected. When selecting "None", the action is ignored and the last valid swatch selection remains.

#### Tickets / Documentation

[Jira](https://jira.bigcommerce.com/browse/BCTHEME-452)

#### Screenshots (if appropriate)

**Production store**
<img width="1680" alt="Screenshot 2021-05-28 at 14 05 29" src="https://user-images.githubusercontent.com/66319629/119975085-1dd32380-bfbe-11eb-8940-a05bd6345754.png">
**Localhost**
<img width="1680" alt="Screenshot 2021-05-28 at 14 06 04" src="https://user-images.githubusercontent.com/66319629/119975090-1f045080-bfbe-11eb-8986-a0cca526f471.png">
