### PR TITLE
fix(storefront): BCTHEME-465 Payment methods are not centered in the Cart page and Cart preview form.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Payment methods are not centered in the Cart page and Cart preview form. [#2073](https://github.com/bigcommerce/cornerstone/pull/2073)
 
 ## 5.7.0 (07-01-2021)
 - Implement CEV language files into Cornerstone. [#2084](https://github.com/bigcommerce/cornerstone/pull/2084)

--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -20,31 +20,6 @@ $cart-thumbnail-paddingVertical:        0.5rem;
 $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-spacing;
 $card-preview-zoom-bottom-offset:       6rem;
 
-//
-// Shared styles for additional checkout buttons
-// -----------------------------------------------------------------------------
-
-%additionalCheckoutButtons {
-    @include clearfix;
-
-    // scss-lint:disable SelectorFormat
-    .FloatRight {
-        @include clearfix;
-
-        // scss-lint:disable SelectorDepth, NestingDepth
-        p {
-            // scss-lint:disable ImportantRule
-            float: none !important;
-            margin: spacing("third") 0;
-            text-align: right;
-        }
-
-        div {
-            float: right;
-        }
-    }
-}
-
 // Cart layout
 // -----------------------------------------------------------------------------
 //
@@ -209,6 +184,10 @@ $card-preview-zoom-bottom-offset:       6rem;
 // -----------------------------------------------------------------------------
 .cart-content-padding-right {
     padding-right: $cart-content-padding-right;
+
+    @media (max-width: $screen-small) {
+        padding-right: 0;
+    }
 }
 
 .cart-header-quantity,
@@ -540,13 +519,42 @@ $card-preview-zoom-bottom-offset:       6rem;
 }
 
 .cart-additionalCheckoutButtons {
-    @extend %additionalCheckoutButtons;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    text-align: right;
+
+    @media (max-width: $screen-medium) {
+        > div {
+            div {
+                z-index: $zIndex-lowest;
+            }
+        }
+    }
+
+    @media (max-width: $screen-small) {
+        align-items: center;
+        text-align: center;
+
+        > div {
+            width: 100% !important;
+        }
+    }
 }
 
 .previewCart-additionalCheckoutButtons {
-    @extend %additionalCheckoutButtons;
-    padding-right: spacing('single');
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0 (spacing('half') + spacing("quarter"));
     padding-bottom: spacing('single');
+    text-align: center;
+
+    @media (max-width: $screen-small) {
+        > div {
+            width: 100% !important;
+        }
+    }
 }
 
 // Cart Preview


### PR DESCRIPTION
@BC-tymurbiedukhin @yurytut1993 @bc-alexsaiannyi 

#### What?

This PR centers the checkout buttons on the cart popup and on small (mobile) screens.

#### Tickets / Documentation

- [BCTHEME-465](https://jira.bigcommerce.com/browse/BCTHEME-465)
- [BCTHEME-469](https://jira.bigcommerce.com/browse/BCTHEME-469) - parent ticket

#### Screenshots (if appropriate)
<img width="971" alt="469-465_desktop" src="https://user-images.githubusercontent.com/82589781/120784068-5c279000-c534-11eb-97bc-41ac7b9a26de.png">
<img width="378" alt="469-465_mobile" src="https://user-images.githubusercontent.com/82589781/120784080-6053ad80-c534-11eb-8431-4faa8d0d690f.png">

