### PR TITLE
fix(storefront): BCTHEME-543 Product images in quick view can be squashed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Product images in quick view can be squashed. [#2075](https://github.com/bigcommerce/cornerstone/pull/2075)
 - Fixed possibility to select 'None' on multi unrequired Swatch Options. [#2068](https://github.com/bigcommerce/cornerstone/pull/2068)
 - Translation Gap: Account -> Wish List -> Name required message. [#2060](https://github.com/bigcommerce/cornerstone/pull/2060)
 - Translation Gap: Cart -> Shipping estimator error messages. [#2066](https://github.com/bigcommerce/cornerstone/pull/2066)

--- a/assets/js/theme/global/quick-view.js
+++ b/assets/js/theme/global/quick-view.js
@@ -2,7 +2,7 @@ import 'foundation-sites/js/foundation/foundation';
 import 'foundation-sites/js/foundation/foundation.dropdown';
 import utils from '@bigcommerce/stencil-utils';
 import ProductDetails from '../common/product-details';
-import { defaultModal } from './modal';
+import { defaultModal, ModalEvents } from './modal';
 import 'slick-carousel';
 import { setCarouselState, onSlickCarouselChange, onUserCarouselChange } from '../common/carousel';
 
@@ -17,12 +17,13 @@ export default function (context) {
         modal.open({ size: 'large' });
 
         utils.api.product.getById(productId, { template: 'products/quick-view' }, (err, response) => {
+            if (err) return;
+
             modal.updateContent(response);
 
             modal.$content.find('.productView').addClass('productView--quickView');
 
             const $carousel = modal.$content.find('[data-slick]');
-
             if ($carousel.length) {
                 $carousel.on('init breakpoint swipe', setCarouselState);
                 $carousel.on('click', '.slick-arrow, .slick-dots', setCarouselState);
@@ -31,7 +32,13 @@ export default function (context) {
                 $carousel.on('click', '.slick-arrow, .slick-dots', $carousel, e => onUserCarouselChange(e, context));
                 $carousel.on('swipe', (e, carouselObj) => onUserCarouselChange(e, context, carouselObj.$slider));
 
-                $carousel.slick();
+                if (modal.$modal.hasClass('open')) {
+                    $carousel.slick();
+                } else {
+                    modal.$modal.one(ModalEvents.opened, () => {
+                        if ($.contains(document, $carousel[0])) $carousel.slick();
+                    });
+                }
             }
 
             return new ProductDetails(modal.$content.find('.quickView'), context);

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -64,6 +64,14 @@
     margin-left: -(spacing("quarter"));
     margin-right: -(spacing("quarter"));
 
+    &[data-slick] {
+        opacity: 0;
+
+        &.slick-initialized {
+            opacity: 1;
+        }
+    }
+
     .slick-list {
         margin-left: remCalc(40px);
         margin-right: remCalc(40px);


### PR DESCRIPTION

#### What?

This PR has fix for squashed slides - now slick activation works only after modal has display block and slick can calculate slide width

#### Tickets / Documentation

[BCTHEME-543](https://jira.bigcommerce.com/browse/BCTHEME-543)

#### Screenshots (if appropriate)

Attach images or add image links here.

<img width="1659" alt="before" src="https://user-images.githubusercontent.com/66325265/121306712-d75bbe00-c907-11eb-8326-5cf841d1b3b0.png">
<img width="1672" alt="after" src="https://user-images.githubusercontent.com/66325265/121306749-e5114380-c907-11eb-9059-a126f9e57a50.png">
