### PR TITLE
fix(storefront): STRF-9126 Facebook social share returns an error for blog pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added translation for invalid quantity value error on Cart. [#2062](https://github.com/bigcommerce/cornerstone/pull/2062)
 - Translation Gap: Delete from Cart confirmation popup. [#2065](https://github.com/bigcommerce/cornerstone/pull/2065)
 - Fixed NaN error on increase/decrease product quantity by adding field validation. [#2052](https://github.com/bigcommerce/cornerstone/pull/2052)
+- Fixed social share links on blog post. [#2077](https://github.com/bigcommerce/cornerstone/pull/2077)
 
 ## 5.5.0 (05-20-2021)
 - Scale focus trap for all modals. [#2049](https://github.com/bigcommerce/cornerstone/pull/2049)

--- a/templates/components/common/share.html
+++ b/templates/components/common/share.html
@@ -1,5 +1,5 @@
 {{#if settings.add_this.buttons}}
-    {{assignVar 'encodedUrl' (encodeURI url)}}
+    {{assignVar 'encodedUrl' (encodeURI this.post.url)}}
     {{assignVar 'encodedTitle' (encodeURI head.title)}}
     <div>
         <ul class="socialLinks">


### PR DESCRIPTION
#### What?

Facebook social share was returning an error for blog pages, because ?u=`undefined`. getVar and assignVar works as expected, problem was in the url variable, that is undefined.

#### Tickets / Documentation

- [STRF-9126](https://jira.bigcommerce.com/browse/STRF-9126)

#### Screenshots (if appropriate)
<img width="598" alt="Screenshot 2021-06-10 at 17 34 17" src="https://user-images.githubusercontent.com/68893868/121544118-255ce880-ca12-11eb-80db-53d16695bb76.png">
