### PR TITLE
add changelog requirements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,10 @@
 
 A description about what this pull request implements and its purpose. Try to be detailed and describe any technical details to simplify the job of the reviewer and the individual on production support.
 
+#### Requirements
+
+- [ ] CHANGELOG.md entry added (required for code changes only)
+
 #### Tickets / Documentation
 
 Add links to any relevant tickets and documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ Unsure where to begin contributing to Stencil? Check our [forums](https://forum.
 * Fill in [the required template](https://github.com/bigcommerce/cornerstone/pull/new/master)
 * Include screenshots and animated GIFs in your pull request whenever possible.
 * End files with a newline.
+* Update CHANGELOG.md with a reference to your pull request if changing code
 
 ## Styleguides
 


### PR DESCRIPTION
#### What?

one of my earlier prs sat for a long time as it was blocked on a changelog entry

this adds this requirement to the contributing documentation and the pr template
this will allow new contributors to make pull requests that meet requirements
and prevent delays

#### Tickets / Documentation

- [PR 1920](https://github.com/bigcommerce/cornerstone/pull/1920)