### PR TITLE
fix(storefront): BCTHEME-470 Payment methods buttons have different size.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Payment methods are not centered in the Cart page and Cart preview form. [#2073](https://github.com/bigcommerce/cornerstone/pull/2073)
 
 ## 5.7.0 (07-01-2021)
 - Implement CEV language files into Cornerstone. [#2084](https://github.com/bigcommerce/cornerstone/pull/2084)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- Payment methods buttons have different size. [#2091](https://github.com/bigcommerce/cornerstone/pull/2091)
 - Payment methods are not centered in the Cart page and Cart preview form. [#2073](https://github.com/bigcommerce/cornerstone/pull/2073)
 
 ## 5.7.0 (07-01-2021)

--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -20,31 +20,6 @@ $cart-thumbnail-paddingVertical:        0.5rem;
 $cart-item-label-offset:                $cart-thumbnail-maxWidth + $cart-item-spacing;
 $card-preview-zoom-bottom-offset:       6rem;
 
-//
-// Shared styles for additional checkout buttons
-// -----------------------------------------------------------------------------
-
-%additionalCheckoutButtons {
-    @include clearfix;
-
-    // scss-lint:disable SelectorFormat
-    .FloatRight {
-        @include clearfix;
-
-        // scss-lint:disable SelectorDepth, NestingDepth
-        p {
-            // scss-lint:disable ImportantRule
-            float: none !important;
-            margin: spacing("third") 0;
-            text-align: right;
-        }
-
-        div {
-            float: right;
-        }
-    }
-}
-
 // Cart layout
 // -----------------------------------------------------------------------------
 //
@@ -209,6 +184,10 @@ $card-preview-zoom-bottom-offset:       6rem;
 // -----------------------------------------------------------------------------
 .cart-content-padding-right {
     padding-right: $cart-content-padding-right;
+
+    @media (max-width: $screen-small) {
+        padding-right: 0;
+    }
 }
 
 .cart-header-quantity,
@@ -540,13 +519,42 @@ $card-preview-zoom-bottom-offset:       6rem;
 }
 
 .cart-additionalCheckoutButtons {
-    @extend %additionalCheckoutButtons;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    text-align: right;
+
+    @media (max-width: $screen-medium) {
+        > div {
+            div {
+                z-index: $zIndex-lowest;
+            }
+        }
+    }
+
+    @media (max-width: $screen-small) {
+        align-items: center;
+        text-align: center;
+
+        > div {
+            width: 100% !important;
+        }
+    }
 }
 
 .previewCart-additionalCheckoutButtons {
-    @extend %additionalCheckoutButtons;
-    padding-right: spacing('single');
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0 (spacing('half') + spacing("quarter"));
     padding-bottom: spacing('single');
+    text-align: center;
+
+    @media (max-width: $screen-small) {
+        > div {
+            width: 100% !important;
+        }
+    }
 }
 
 // Cart Preview

--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -502,11 +502,20 @@ $card-preview-zoom-bottom-offset:       6rem;
 
     .button {
         display: block;
+        width: 25%;
         margin-bottom: 0;
 
         @include breakpoint("small") {
             display: inline-block;
             float: right;
+        }
+
+        @media (max-width: $screen-medium) {
+            width: 35%;
+        }
+
+        @media (max-width: $screen-small) {
+            width: 100%;
         }
     }
 
@@ -524,8 +533,19 @@ $card-preview-zoom-bottom-offset:       6rem;
     align-items: flex-end;
     text-align: right;
 
+    > div {
+        width: 25% !important;
+
+        div, button {
+            width: 100% !important;
+            max-width: 100% !important;
+        }
+    }
+
     @media (max-width: $screen-medium) {
         > div {
+            width: 35% !important;
+            
             div {
                 z-index: $zIndex-lowest;
             }
@@ -550,9 +570,12 @@ $card-preview-zoom-bottom-offset:       6rem;
     padding-bottom: spacing('single');
     text-align: center;
 
-    @media (max-width: $screen-small) {
-        > div {
+    > div {
+        width: 100% !important;
+
+        div, button {
             width: 100% !important;
+            max-width: 100% !important;
         }
     }
 }


### PR DESCRIPTION
#### What?
This PR makes the payment buttons the same size.

#### Tickets / Documentation
- [BCTHEME-470](https://jira.bigcommerce.com/browse/BCTHEME-470)
- [BCTHEME-469](https://jira.bigcommerce.com/browse/BCTHEME-469) - parent ticket


#### Screenshots
Desktop:
<img width="682" alt="470_desk_btns_size" src="https://user-images.githubusercontent.com/82589781/125453901-36a14ae5-3659-4502-b221-c037c149b0ef.png">

Tablet:
<img width="523" alt="470_tab_btns_size" src="https://user-images.githubusercontent.com/82589781/125453954-4ca6350f-0073-4b03-8a6e-659cdae26c05.png">

Mobile:
<img width="394" alt="470_mob_btns_size" src="https://user-images.githubusercontent.com/82589781/125453981-b90784a1-00b5-4420-a7ff-838c6f93ab6c.png">


