### PR TITLE
feat(storefront): BCTHEME-674 Make Hero Carousel both slide and button clickable when button enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Make Hero Carousel both slide and button clickable when button enabled. [#2098](https://github.com/bigcommerce/cornerstone/pull/2098)
 - Reviews pagination navigation buttons reload page and does not open the Reviews tab. [#2048](https://github.com/bigcommerce/cornerstone/pull/2048)
 - Fix social share links for product pages and blog posts [#2082](https://github.com/bigcommerce/cornerstone/pull/2082)
 - 'undefined' is announced with screen reader while changing Product quantity on PDP. [#2094](https://github.com/bigcommerce/cornerstone/pull/2094)

--- a/assets/js/theme/common/carousel/utils/getActiveSlideInfo.js
+++ b/assets/js/theme/common/carousel/utils/getActiveSlideInfo.js
@@ -6,11 +6,13 @@ export default ({ $slider }, isAnalyzedDataAttr) => {
 
     const $activeSlideImg = $activeSlide.find('.heroCarousel-image');
     const activeSlideImgNode = $activeSlideImg[0];
+    const $activeSlideAndClones = $slider.find(`[data-hero-slide=${$activeSlide.data('hero-slide')}]`);
 
     return {
         $slider,
         $activeSlide,
         $activeSlideImg,
         activeSlideImgNode,
+        $activeSlideAndClones,
     };
 };

--- a/assets/js/theme/common/carousel/utils/handleImageAspectRatio.js
+++ b/assets/js/theme/common/carousel/utils/handleImageAspectRatio.js
@@ -21,22 +21,21 @@ const setAspectRatioClass = (imageNode, $slides) => {
     if (imageNode.naturalHeight <= 1) return;
 
     const imageAspectRatio = imageNode.naturalHeight / imageNode.naturalWidth;
-    $slides.each((idx, slide) => $(slide).addClass(defineAspectRatioClass(imageAspectRatio)));
+    $slides.addClass(defineAspectRatioClass(imageAspectRatio));
 };
 
 export default ({ delegateTarget }, carouselObj) => {
     const {
         isAnalyzedSlide,
-        $slider,
         $activeSlide,
         $activeSlideImg,
         activeSlideImgNode,
+        $activeSlideAndClones,
     } = getActiveSlideInfo(carouselObj || delegateTarget.slick, IS_ANALYZED_DATA_ATTR);
 
     if (isAnalyzedSlide) return;
 
-    const $activeSlideAndClones = $slider.find(`[data-hero-slide=${$activeSlide.data('hero-slide')}]`);
-    $activeSlideAndClones.each((idx, slide) => $(slide).data(IS_ANALYZED_DATA_ATTR, true));
+    $activeSlideAndClones.data(IS_ANALYZED_DATA_ATTR, true);
 
     if ($activeSlide.find('.heroCarousel-content').length) return;
 

--- a/assets/js/theme/common/carousel/utils/handleImageLoad.js
+++ b/assets/js/theme/common/carousel/utils/handleImageLoad.js
@@ -4,44 +4,44 @@ import getActiveSlideInfo from './getActiveSlideInfo';
 const IMAGE_ERROR_CLASS = 'is-image-error';
 const IS_ANALYZED_DATA_ATTR = 'image-load-analyzed';
 
-const generateImage = ($slide, $image) => {
+const generateImage = ($image, $slides) => {
     $('<img />')
-        .on('error', () => $slide.addClass(IMAGE_ERROR_CLASS))
+        .on('error', () => $slides.addClass(IMAGE_ERROR_CLASS))
         .attr('src', $image.attr('src'));
 };
 
 export default (e, carouselObj) => {
     const {
         isAnalyzedSlide,
-        $activeSlide,
         $activeSlideImg,
         activeSlideImgNode,
+        $activeSlideAndClones,
     } = getActiveSlideInfo(carouselObj, IS_ANALYZED_DATA_ATTR);
 
     if (isAnalyzedSlide) return;
 
-    $activeSlide.data(IS_ANALYZED_DATA_ATTR, true);
+    $activeSlideAndClones.data(IS_ANALYZED_DATA_ATTR, true);
 
     if (activeSlideImgNode.complete) {
         if (activeSlideImgNode.naturalHeight === 0) {
-            $activeSlide.addClass(IMAGE_ERROR_CLASS);
+            $activeSlideAndClones.addClass(IMAGE_ERROR_CLASS);
         } else if (activeSlideImgNode.naturalHeight === 1) {
             // only base64 image from srcset was loaded
-            $activeSlideImg.on('error', () => $activeSlide.addClass(IMAGE_ERROR_CLASS));
+            $activeSlideImg.on('error', () => $activeSlideAndClones.addClass(IMAGE_ERROR_CLASS));
         }
 
         return;
     }
 
     if (!$activeSlideImg.attr('src')) {
-        $activeSlide.addClass(IMAGE_ERROR_CLASS);
+        $activeSlideAndClones.addClass(IMAGE_ERROR_CLASS);
         return;
     }
 
     if (isBrowserIE) {
-        generateImage($activeSlide, $activeSlideImg);
+        generateImage($activeSlideImg, $activeSlideAndClones);
         return;
     }
 
-    $activeSlideImg.on('error', () => $activeSlide.addClass(IMAGE_ERROR_CLASS));
+    $activeSlideImg.on('error', () => $activeSlideAndClones.addClass(IMAGE_ERROR_CLASS));
 };

--- a/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
+++ b/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
@@ -195,6 +195,12 @@
 
         &.heroCarousel-content--empty {
             background-color: transparent;
+            left: 50%;
+            overflow: visible;
+            padding: 0;
+            right: auto;
+            transform: translateX(-50%) translateY(-50%);
+            width: auto;
         }
     }
 }
@@ -202,7 +208,7 @@
 .heroCarousel-title {
     color: $carousel-title-color;
     font-size: fontSize("small");
-    margin-top: 0;
+    margin: 0;
 
     @include breakpoint("medium") {
         font-size: fontSize("hero");
@@ -212,6 +218,7 @@
 .heroCarousel-description {
     color: $carousel-description-color;
     font-size: fontSize("tiny");
+    margin: 0;
 
     @include breakpoint("small") {
         font-size: fontSize("smallest");
@@ -223,9 +230,5 @@
 }
 
 .heroCarousel-action {
-    margin: 0;
-
-    @include breakpoint("medium") {
-        margin-top: spacing("single");
-    }
+    margin: spacing("single") 0 0;
 }

--- a/templates/components/carousel-content.html
+++ b/templates/components/carousel-content.html
@@ -1,6 +1,10 @@
-<div class="heroCarousel-content{{#unless show_background}} heroCarousel-content--empty{{/unless}}">
-    <span class="heroCarousel-title">{{{heading}}}</span>
-    <p class="heroCarousel-description">{{{text}}}</p>
+<div class="heroCarousel-content{{#and (if heading '==' false) (if text '==' false)}} heroCarousel-content--empty{{/and}}">
+    {{#if heading}}
+        <p class="heroCarousel-title">{{{heading}}}</p>
+    {{/if}}
+    {{#if text}}
+        <p class="heroCarousel-description">{{{text}}}</p>
+    {{/if}}
     {{#if button_text}}
         <a href="{{url}}" aria-label="{{#if this.alt_text.length '!=' 0}}{{this.alt_text}}{{else}}{{lang 'carousel.slide_number' slide_number=(add @index 1)}}{{/if}}, {{button_text}}" class="heroCarousel-action button button--primary button--large">{{button_text}}</a>
     {{/if}}

--- a/templates/components/carousel.html
+++ b/templates/components/carousel.html
@@ -16,7 +16,11 @@
     <a href="{{url}}" data-hero-slide="{{@index}}" aria-label="{{#if this.alt_text.length '!=' 0}}{{this.alt_text}}{{else}}{{lang 'carousel.slide_number' slide_number=(add @index 1)}}{{/if}}">
     {{/if}}
         <div class="heroCarousel-slide {{#if ../theme_settings.homepage_stretch_carousel_images}}stretch{{/if}} {{#if @first}}heroCarousel-slide--first{{/if}}">
+            {{#if button_text}}
+            <a href="{{url}}" class="heroCarousel-image-wrapper">
+            {{else}}
             <div class="heroCarousel-image-wrapper">
+            {{/if}}
             {{#if @first}}
                 {{> components/common/responsive-img
                     image=stencil_image
@@ -32,18 +36,14 @@
                     lazyload='lazyload'
                 }}
             {{/if}}
-            </div>
-            {{#if heading}}
-                {{> components/carousel-content show_background=true}}
+            {{#if button_text}}
+            </a>
             {{else}}
-                {{#if text}}
-                    {{> components/carousel-content show_background=true}}
-                {{else}}
-                    {{#if button_text}}
-                        {{> components/carousel-content show_background=false}}
-                    {{/if}}
-                {{/if}}
+            </div>
             {{/if}}
+            {{#or heading text button_text}}
+                {{> components/carousel-content}}
+            {{/or}}
         </div>
     {{#if button_text}}
     </div>


### PR DESCRIPTION
#### What?

This PR adds update for slide images and buttons so they can be both clickable on the same slide.
Also minor code updates were added to handlers related to slide images.

#### Requirements

#### Tickets / Documentation

[BCTHEME-674](https://jira.bigcommerce.com/browse/BCTHEME-674)

#### Screenshots (if appropriate)

<img width="1653" alt="slide-with-button" src="https://user-images.githubusercontent.com/66325265/126752304-eb634013-0ede-4f64-a0e4-9a0fdfa58eb2.png">
<img width="1653" alt="slide-without-button" src="https://user-images.githubusercontent.com/66325265/126752322-ae392cb0-7680-4551-81b1-b74f4239b6e1.png">
