### PR TITLE
fix(storefront): BCTHEME-724 An authorized user must remain on the Product detail page after adding the product to the wishlist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Draft
+- An authorized user must remain on the Product detail page after adding the product to the wishlist. [#2099](https://github.com/bigcommerce/cornerstone/pull/2099)
 
 ## 5.7.1 (07-09-2021)
 - Update lang files for some locales. [#2086](https://github.com/bigcommerce/cornerstone/pull/2086)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -11,6 +11,7 @@ import forms from '../common/models/forms';
 import { normalizeFormData } from './utils/api';
 import { isBrowserIE, convertIntoArray } from './utils/ie-helpers';
 import bannerUtils from './utils/banner-utils';
+import urlUtils from './utils/url-utils';
 
 export default class ProductDetails extends ProductDetailsBase {
     constructor($scope, context, productAttributesData = {}) {
@@ -441,6 +442,45 @@ export default class ProductDetails extends ProductDetailsBase {
         });
 
         this.setLiveRegionAttributes($addToCartBtn.next(), 'status', 'polite');
+    }
+
+    /**
+     *
+     * Add a product to the wishlist for authorized users on the product page
+     *
+     */
+    addProductToWishlist() {
+        const $addToWishlistForm = $('.productView-options .form-wishlist');
+
+        $addToWishlistForm.on('submit', event => {
+            event.preventDefault();
+
+            const customerWishlists = !!this.context.customerWishlists;
+            const wishlistId = $(event.originalEvent.submitter).attr('data-wishlist-id');
+            const productId = this.context.productId;
+
+            utils.api.wishlist.itemAdd(wishlistId, productId, (err, response) => {
+                const errorMessage = err || response.error;
+
+                if(errorMessage) {
+                    const $messageBox = $('#alertBox-error-message');
+                    $messageBox.show();
+                    return;
+                }
+
+                const $messageBox = $('#alertBox-success-message');
+                
+                if(customerWishlists) {
+                    const $wishlistDetailsLink = $('#alertBox-success-message a');
+                    const storeName = urlUtils.getOrigin();
+                    const viewUrl = `${storeName}/wishlist.php?action=viewwishlistitems&wishlistid=${wishlistId}`;
+
+                    $wishlistDetailsLink.attr('href', viewUrl);
+                }
+
+                $messageBox.show();
+            });
+        });
     }
 
     /**

--- a/assets/js/theme/common/utils/url-utils.js
+++ b/assets/js/theme/common/utils/url-utils.js
@@ -3,6 +3,8 @@ import Url from 'url';
 const urlUtils = {
     getUrl: () => `${window.location.pathname}${window.location.search}`,
 
+    getOrigin: () => window.location.origin,
+
     goToUrl: (url) => {
         window.history.pushState({}, document.title, url);
         $(window).trigger('statechange');

--- a/assets/js/theme/product.js
+++ b/assets/js/theme/product.js
@@ -33,6 +33,7 @@ export default class Product extends PageManager {
 
         this.productDetails = new ProductDetails($('.productView'), this.context, window.BCData.product_attributes);
         this.productDetails.setProductVariant();
+        this.productDetails.addProductToWishlist();
 
         videoGallery();
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -743,6 +743,7 @@
         },
         "add_to_cart": "Add to Cart",
         "adding_to_cart": "Adding to cart…",
+        "add_to_wishlist_success_message": "The product has been successfully added to the wishlist. Show <a href=\"{wishlistPath}\">more details</a>.",
         "options": "Options",
         "none": "None",
         "sku": "SKU:",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigcommerce-cornerstone",
-  "version": "5.6.0",
+  "version": "5.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1048,9 +1048,9 @@
       "dev": true
     },
     "@bigcommerce/stencil-utils": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-6.8.1.tgz",
-      "integrity": "sha512-17+6itcocte+ma69ul90BghNVi5bOqF0AQb+u9s4XRxC9HyFFJG5nB7kd7CtInk8reVj8R8IYPbrFtgRQxJ4wQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-6.11.0.tgz",
+      "integrity": "sha512-ULhqJPrzZEap+ZoGbnx/VkXwEEcopspQ9kSFwZpBmBqgrp/QA7H6ElLeVHUUA9ImL2QF0OF80fxjRoWwYXHnOA==",
       "requires": {
         "eventemitter3": "^4.0.4",
         "whatwg-fetch": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "BigCommerce",
   "license": "MIT",
   "dependencies": {
-    "@bigcommerce/stencil-utils": "^6.8.1",
+    "@bigcommerce/stencil-utils": "^6.11.0",
     "core-js": "^3.9.0",
     "creditcards": "^3.0.1",
     "easyzoom": "^2.5.3",

--- a/templates/components/common/wishlist-dropdown.html
+++ b/templates/components/common/wishlist-dropdown.html
@@ -1,3 +1,5 @@
+{{inject 'customerWishlists' this.customer.wishlists}}
+
 <form action="{{product.add_to_wishlist_url}}" class="form form-wishlist form-action" data-wishlist-add method="post">
     <a aria-controls="wishlist-dropdown"
        aria-expanded="false"
@@ -20,6 +22,7 @@
                            formaction="{{this.add_url}}&product_id={{../product.id}}"
                            type="submit"
                            value="{{this.name}}"
+                           data-wishlist-id="{{this.id}}"
                     >
                 </li>
             {{/each}}

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -249,6 +249,14 @@
                 {{> components/common/wishlist-dropdown}}
             {{/if}}
         </div>
+
+        <div id="alertBox-success-message" style="display:none">
+            {{> components/common/alert/alert-success (lang 'products.add_to_wishlist_success_message' wishlistPath=urls.account.wishlists.all)}}
+        </div>
+        <div id="alertBox-error-message" style="display:none">
+            {{> components/common/alert/alert-error (lang 'common.generic_error')}}
+        </div>
+
         {{> components/common/share url=product.url}}
     </section>
 


### PR DESCRIPTION
#### What?
This PR cancels user redirection to another page after adding the product to the wishlist. [BCTHEME-724]
Also, this PR adds notifications about the successful addition of a product to the wishlist. [BCTHEME-725]

#### Tickets / Documentation

[BCTHEME-466](https://jira.bigcommerce.com/browse/BCTHEME-466) - parent ticket
[BCTHEME-724](https://jira.bigcommerce.com/browse/BCTHEME-724)
[BCTHEME-725](https://jira.bigcommerce.com/browse/BCTHEME-725)

#### Screenshots
<img width="1483" alt="466_724+725_screen1" src="https://user-images.githubusercontent.com/82589781/128336794-dbcdde53-61da-4af2-b45f-f706687bf80c.png">
<img width="1481" alt="466_724+725_screen2" src="https://user-images.githubusercontent.com/82589781/128336815-5cc580c2-820f-4f4c-b424-c5ad68cb6c2a.png">
<img width="1486" alt="466_724+725_screen3" src="https://user-images.githubusercontent.com/82589781/128336825-08074223-7afc-4263-89ab-2d039ec6dd53.png">