### PR TITLE
fix(storefront): BCTHEME-671 Empty email input in newsletter field does not trigger an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Empty email input in newsletter field should trigger an error. [#2101](https://github.com/bigcommerce/cornerstone/pull/2101)
 - No navigation back to wishlist tab when you are in a wishlist. [#2096](https://github.com/bigcommerce/cornerstone/pull/2096)
 - Reviews pagination navigation buttons reload page and does not open the Reviews tab. [#2048](https://github.com/bigcommerce/cornerstone/pull/2048)
 - Fix social share links for product pages and blog posts [#2082](https://github.com/bigcommerce/cornerstone/pull/2082)

--- a/templates/components/common/subscription-form.html
+++ b/templates/components/common/subscription-form.html
@@ -17,6 +17,7 @@
                        placeholder="{{lang 'newsletter.email_placeholder'}}"
                        aria-describedby="alertBox-message-text"
                        aria-required="true"
+                       required
                 >
                 <input class="button button--primary form-prefixPostfix-button--postfix"
                        type="submit"


### PR DESCRIPTION
#### What?

Entering in a blank email address in the newsletter field is accepted and takes the customer to a thanks for subscribing page. The redirect with success message is to subscriber.php whereas using a valid email in the field works as expected and redirects to subscriber.php?result=success

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

[Jira](https://jira.bigcommerce.com/browse/BCTHEME-671)

#### Screenshots (if appropriate)

<img width="452" alt="Screenshot 2021-07-28 at 10 34 51" src="https://user-images.githubusercontent.com/66319629/127282716-58820bab-f0cf-4f2b-8def-57b33c57eee9.png">

