### PR TITLE
fix(storefront): BCTHEME-708 fix wishlist dropdown shift in quickview modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Fixed wishlist dropdown shift on quick view modal. [#2102](https://github.com/bigcommerce/cornerstone/pull/2102)
 - No navigation back to wishlist tab when you are in a wishlist. [#2096](https://github.com/bigcommerce/cornerstone/pull/2096)
 - Reviews pagination navigation buttons reload page and does not open the Reviews tab. [#2048](https://github.com/bigcommerce/cornerstone/pull/2048)
 - Fix social share links for product pages and blog posts [#2082](https://github.com/bigcommerce/cornerstone/pull/2082)

--- a/assets/js/theme/global/quick-view.js
+++ b/assets/js/theme/global/quick-view.js
@@ -14,6 +14,14 @@ export default function (context) {
         event.preventDefault();
 
         const productId = $(event.currentTarget).data('productId');
+        const handleDropdownExpand = ({ currentTarget }) => {
+            const $dropdownMenu = $(currentTarget);
+            const dropdownBtnHeight = $dropdownMenu.prev().outerHeight();
+
+            $dropdownMenu.css('top', dropdownBtnHeight);
+
+            return modal.$modal.one(ModalEvents.close, () => $dropdownMenu.off('opened.fndtn.dropdown', handleDropdownExpand));
+        };
 
         modal.open({ size: 'large' });
 
@@ -22,6 +30,7 @@ export default function (context) {
 
             modal.updateContent(response);
 
+            $('#modal .dropdown-menu').on('opened.fndtn.dropdown', handleDropdownExpand);
             modal.$content.find('.productView').addClass('productView--quickView');
 
             const $carousel = modal.$content.find('[data-slick]');


### PR DESCRIPTION


#### What?
The issue relates to foundation dropdown lib miscalculation. Due to several  Wishlist’s dropdown on PDP once User makes attempt to open up one of them foundation.dropdown lib captures several ‘instances’ of them and makes calculation of css styles based on wrong ‘instance’. This leads that in quickview modal dropdown menu is separated  from button. As a solution we’ve added listener on foundation dropdown open Event  that rewrites  specific css style on its ‘original’ value. Once User leaves/closes  a Modal we clear our dropdown listener.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation


- [BCTHEME-708](https://jira.bigcommerce.com/browse/BCTHEME-708)


#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/67792608/127316138-8fca4399-e53b-4589-ad2a-c7d351eb7289.mov


