### PR TITLE
fix(storefront): BCTHEME-668 Google AMP feature request - Add in release date info for preorder products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Google AMP feature request - Add in release date info for preorder products. [#2107](https://github.com/bigcommerce/cornerstone/pull/2107)
 
 ## 6.0.0 (08-06-2021)
 - Translation mechanism for config.json has been updated. [#2089](https://github.com/bigcommerce/cornerstone/pull/2089)

--- a/templates/components/amp/products/product-view-details.html
+++ b/templates/components/amp/products/product-view-details.html
@@ -20,6 +20,9 @@
         {{#if settings.show_product_rating}}
             {{> components/amp/products/ratings rating=product.rating}}
         {{/if}}
+        {{#if product.release_date }}
+            <p>{{product.release_date}}</p>
+        {{/if}}
         <dl class="productView-info">
             {{#if product.sku}}
                 <dt class="productView-info-name">{{lang 'products.sku'}}</dt>


### PR DESCRIPTION
#### What?

This PR adds functionality to display release date information for pre-order products on AMP pages.

#### Tickets / Documentation

- [BCTHEME-668](https://jira.bigcommerce.com/browse/BCTHEME-668)

#### Screenshots (if appropriate)

<img width="1674" alt="Снимок экрана 2021-08-12 в 13 09 18" src="https://user-images.githubusercontent.com/83779098/129181627-31334fa3-463d-4912-8556-303f808117d2.png">
<img width="1680" alt="Снимок экрана 2021-08-12 в 13 08 51" src="https://user-images.githubusercontent.com/83779098/129181641-5e000a5a-bc2a-4af6-aa22-c98e8e8e7bd4.png">

