### PR TITLE
fix(storefront): BCTHEME-355 fix additional checkout buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- additional checkout buttons don't work on applying 100% discount coupon. [#2109](https://github.com/bigcommerce/cornerstone/pull/2109)
 
 ## 6.0.0 (08-06-2021)
 - Translation mechanism for config.json has been updated. [#2089](https://github.com/bigcommerce/cornerstone/pull/2089)

--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -15,6 +15,7 @@ export default class Cart extends PageManager {
         this.$cartContent = $('[data-cart-content]');
         this.$cartMessages = $('[data-cart-status]');
         this.$cartTotals = $('[data-cart-totals]');
+        this.$cartAdditionalCheckoutBtns = $('[data-cart-additional-checkout-buttons]');
         this.$overlay = $('[data-cart] .loadingOverlay')
             .hide(); // TODO: temporary until roper pulls in his cart components
         this.$activeCartItemId = null;
@@ -221,6 +222,7 @@ export default class Cart extends PageManager {
                 totals: 'cart/totals',
                 pageTitle: 'cart/page-title',
                 statusMessages: 'cart/status-messages',
+                additionalCheckoutButtons: 'cart/additional-checkout-buttons',
             },
         };
 
@@ -235,6 +237,7 @@ export default class Cart extends PageManager {
             this.$cartContent.html(response.content);
             this.$cartTotals.html(response.totals);
             this.$cartMessages.html(response.statusMessages);
+            this.$cartAdditionalCheckoutBtns.html(response.additionalCheckoutButtons);
 
             $cartPageTitle.replaceWith(response.pageTitle);
             this.bindEvents();

--- a/templates/components/cart/additional-checkout-buttons.html
+++ b/templates/components/cart/additional-checkout-buttons.html
@@ -1,0 +1,5 @@
+{{#if cart.additional_checkout_buttons}}
+    {{#each cart.additional_checkout_buttons}}
+        {{{this}}}
+    {{/each}}
+{{/if}}

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -43,13 +43,10 @@ cart: true
                 </div>
             {{/if}}
 
-            {{#if cart.additional_checkout_buttons}}
-                <div class="cart-additionalCheckoutButtons cart-content-padding-right">
-                    {{#each cart.additional_checkout_buttons}}
-                        {{{this}}}
-                    {{/each}}
-                </div>
-            {{/if}}
+            <div data-cart-additional-checkout-buttons class="cart-additionalCheckoutButtons cart-content-padding-right">
+                {{> components/cart/additional-checkout-buttons}}
+            </div>
+
         {{else}}
             <h3 tabindex="0">{{lang 'cart.checkout.empty_cart'}}</h3>
         {{/if}}


### PR DESCRIPTION
#### What?

This PR relates to an issue with additional checkout buttons that should disappear on applying 100% discount coupon and assists [PR](https://github.com/bigcommerce/bigcommerce/pull/42616) from PayPal Team.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation
- [PAYPAL-1058](https://jira.bigcommerce.com/browse/PAYPAL-1058)


#### Screenshots (if appropriate)
<img width="1680" alt="Screenshot 2021-08-17 at 10 14 22" src="https://user-images.githubusercontent.com/67792608/129681036-dd752021-8789-4873-bc2b-521518ecdd06.png">
<img width="1616" alt="Screenshot 2021-08-17 at 10 14 54" src="https://user-images.githubusercontent.com/67792608/129681047-42e6e9cc-ee4b-4618-9e82-c4b1d55fd4df.png">
