### PR TITLE
feat(payment): ADYEN-242 Added notice to Adyen vaulted cards at My account page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Draft
 - Google AMP feature request - Add in release date info for preorder products. [#2107](https://github.com/bigcommerce/cornerstone/pull/2107)
 - Translation for states select field on account signup page. [#2105](https://github.com/bigcommerce/cornerstone/pull/2105)
+- Added description field below payment provider name on "My Account" -> "Payment Methods" page. [#2111](https://github.com/bigcommerce/cornerstone/pull/2111)
 
 ## 6.0.0 (08-06-2021)
 - Translation mechanism for config.json has been updated. [#2089](https://github.com/bigcommerce/cornerstone/pull/2089)

--- a/templates/components/account/payment-methods-list.html
+++ b/templates/components/account/payment-methods-list.html
@@ -8,6 +8,9 @@
         <h4 class="paymentMethodsTitle">
             {{display_name}}
         </h4>
+        {{#if description}}
+            <p>{{description}}</p>
+        {{/if}}
         <div class="paymentMethodsGrid">
             {{#each stored_instruments}}
                 <div class="paymentMethodsGrid-item">


### PR DESCRIPTION
#### What?

As for current realisation, AdyenV2 (ent) customers will not be allowed to edit or add cards at "My Account" -> "Payment Methods" section. However, they are able to see card details and delete cards. That is why we should clarify these circumstances for them.

To do so, we need to add description below "Adyen" name (retrieved from "display_name" at payment method data)

#### Tickets / Documentation

[ADYEN-242](https://jira.bigcommerce.com/browse/ADYEN-242)

#### Screenshots (if appropriate)
**Before:**
![image](https://user-images.githubusercontent.com/79574476/130458857-9de428d1-695c-4606-b43d-cf617fa3a6dc.png)
**After:**
![image](https://user-images.githubusercontent.com/79574476/130458967-9c34420c-f33c-4cc4-bf2d-9270c95ea905.png)
![image](https://user-images.githubusercontent.com/79574476/130459011-da6b699d-ba83-45fe-8ebc-e9df09336c8e.png)

