### PR TITLE
fix(storefront): BCTHEME-856 Fixed images placeholder on hero carousel shifted on mobile when slide has content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Fixed images placeholder on hero carousel shifted on mobile when slide has content. [#2112](https://github.com/bigcommerce/cornerstone/pull/2112)
 - Google AMP feature request - Add in release date info for preorder products. [#2107](https://github.com/bigcommerce/cornerstone/pull/2107)
 - Translation for states select field on account signup page. [#2105](https://github.com/bigcommerce/cornerstone/pull/2105)
 - Added description field below payment provider name on "My Account" -> "Payment Methods" page. [#2111](https://github.com/bigcommerce/cornerstone/pull/2111)

--- a/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
+++ b/assets/scss/components/stencil/heroCarousel/_heroCarousel.scss
@@ -108,8 +108,10 @@
         }
 
         &.is-image-error {
-            background: url("../img/hero-carousel-image-load-error.svg") center center no-repeat;
-            background-size: contain;
+            .heroCarousel-image-wrapper {
+                background: url("../img/hero-carousel-image-load-error.svg") center center no-repeat;
+                background-size: contain;    
+            }
         }
     }
 }


### PR DESCRIPTION

#### What?

This PR adds style updates for correct positioning of carousel placeholder which appears if slide image failed to load

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

[BCTHEME-856](https://jira.bigcommerce.com/browse/BCTHEME-856)

#### Screenshots (if appropriate)

<img width="734" alt="shifted-placeholder" src="https://user-images.githubusercontent.com/66325265/131548818-9fc16f2b-0622-49b0-8576-ba5377bb0ab8.png">
<img width="734" alt="correct-positioned-placeholder" src="https://user-images.githubusercontent.com/66325265/131548834-28a97f9d-76c1-4137-bba1-737464a208c8.png">
