### PR TITLE
fix(search): ES-2439 change debounce wait time for search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Changed debounce wait time for search. [#2115](https://github.com/bigcommerce/cornerstone/pull/2115)
 
 ## 6.1.0 (09-03-2021)
 - Fixed images placeholder on hero carousel shifted on mobile when slide has content. [#2112](https://github.com/bigcommerce/cornerstone/pull/2112)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
-- Changed debounce wait time for search. [#2115](https://github.com/bigcommerce/cornerstone/pull/2115)
+- Changed debounce wait time for search to 1200 ms from 200 ms. [#2115](https://github.com/bigcommerce/cornerstone/pull/2115)
 
 ## 6.1.0 (09-03-2021)
 - Fixed images placeholder on hero carousel shifted on mobile when slide has content. [#2112](https://github.com/bigcommerce/cornerstone/pull/2112)

--- a/assets/js/theme/global/quick-search.js
+++ b/assets/js/theme/global/quick-search.js
@@ -32,7 +32,7 @@ export default function () {
         }
     };
 
-    // stagger searching for 200ms after last input
+    // stagger searching for 1200ms after last input
     const debounceWaitTime = 1200;
     const doSearch = _.debounce((searchQuery) => {
         utils.api.search.search(searchQuery, { template: 'search/quick-results' }, (err, response) => {

--- a/assets/js/theme/global/quick-search.js
+++ b/assets/js/theme/global/quick-search.js
@@ -33,6 +33,7 @@ export default function () {
     };
 
     // stagger searching for 200ms after last input
+    const debounceWaitTime = 1200;
     const doSearch = _.debounce((searchQuery) => {
         utils.api.search.search(searchQuery, { template: 'search/quick-results' }, (err, response) => {
             if (err) {
@@ -62,7 +63,7 @@ export default function () {
                 }, 100);
             }
         });
-    }, 1200);
+    }, debounceWaitTime);
 
     utils.hooks.on('search-quick', (event, currentTarget) => {
         const searchQuery = $(currentTarget).val();

--- a/assets/js/theme/global/quick-search.js
+++ b/assets/js/theme/global/quick-search.js
@@ -62,7 +62,7 @@ export default function () {
                 }, 100);
             }
         });
-    }, 200);
+    }, 1200);
 
     utils.hooks.on('search-quick', (event, currentTarget) => {
         const searchQuery = $(currentTarget).val();


### PR DESCRIPTION
#### What?

The low debounce time on the search query is causing the search api to be hit after every character. Bump up the debounce time to lessen the frequency. 

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

https://jira.bigcommerce.com/browse/ES-2439


#### Screenshots (if appropriate)

N/A
