### PR TITLE
fix(storefront): BCTHEME-855 Sliding carousel with products cause footer headers flickering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Fix sliding carousel with products cause footer headers flickering. [#2119](https://github.com/bigcommerce/cornerstone/pull/2119)
+
 
 ## 6.1.0 (09-03-2021)
 - Fixed images placeholder on hero carousel shifted on mobile when slide has content. [#2112](https://github.com/bigcommerce/cornerstone/pull/2112)

--- a/assets/scss/layouts/footer/_footer.scss
+++ b/assets/scss/layouts/footer/_footer.scss
@@ -9,6 +9,7 @@
 // 1. To enable the grid's display: inline-block; to work properly, we need to
 //    remove the white-space that it creates between columns with font-size: 0;
 // 2. Re-set the font-size that was reduced to 0 in point 1 for children.
+// 3. Fix for text flickers on windows devices
 //
 // -----------------------------------------------------------------------------
 
@@ -17,6 +18,7 @@
     border-top: container("border");
     padding: spacing("double") 0;
     position: relative;
+    transform: translateZ(0); // 3
 }
 
 .footer-title-sr-only {
@@ -164,18 +166,6 @@
 
     svg {
         fill: stencilColor("icon-color");
-    }
-}
-
-.footer-geotrust-ssl-seal {
-    @include breakpoint("small") {
-        bottom: 0;
-        position: absolute;
-        right: 16px;
-    }
-
-    table {
-        margin: auto;
     }
 }
 

--- a/templates/components/common/geotrust-ssl-seal.html
+++ b/templates/components/common/geotrust-ssl-seal.html
@@ -1,8 +1,0 @@
-<table width="135" border="0" cellpadding="2" cellspacing="0" title="Click to Verify - This site chose GeoTrust SSL for secure e-commerce and confidential communications.">
-    <tr>
-        <td width="135" align="center" valign="top">
-            <script type="text/javascript" src="https://seal.geotrust.com/getgeotrustsslseal?host_name={{theme_settings.geotrust_ssl_common_name}}&amp;size={{theme_settings.geotrust_ssl_seal_size}}&amp;lang={{locale_name}}"></script><br />
-            <a href="http://www.geotrust.com/ssl/" target="_blank"  style="color:#000000; text-decoration:none; font:bold 7px verdana,sans-serif; letter-spacing:.5px; text-align:center; margin:0px; padding:0px;"></a>
-        </td>
-    </tr>
-</table>


### PR DESCRIPTION

#### What?

This PR has fix for flickering text content color when sliding carousel.
Also geotrast component and its related styles were removed here as they already not in use.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

[BCTHEME-855](https://jira.bigcommerce.com/browse/BCTHEME-855)

#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/66325265/133618925-3c3588c4-9221-47fd-857b-430e200c3ba7.mov

https://user-images.githubusercontent.com/66325265/133618957-ff70794b-9aa0-42ed-a9a1-eac72f197acc.mov