### PR TITLE
fix(storefront): BCTHEME-851 Product images on PDP has clipped outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Fix product images on PDP has clipped outline. [#2124](https://github.com/bigcommerce/cornerstone/pull/2124)
 
 ## 6.1.0 (09-03-2021)
 - Fixed images placeholder on hero carousel shifted on mobile when slide has content. [#2112](https://github.com/bigcommerce/cornerstone/pull/2112)

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -51,7 +51,7 @@
         @include lazy-loaded-img;
         /* Object-fit polyfill */
         font-family: "object-fit: contain;";
-        max-height: 100%;
+        height: 100%;
         object-fit: contain;
         width: 100%;
     }
@@ -98,8 +98,7 @@
 
 .productView-thumbnail {
     @include grid-column(3);
-    padding-left: spacing("quarter");
-    padding-right: spacing("quarter");
+    padding: spacing("quarter");
     text-align: center;
 
     @include breakpoint("large") {
@@ -110,7 +109,7 @@
 .productView-thumbnail-link {
     border: container("border");
     box-sizing: content-box;
-    display: inline-flex;
+    display: flex;
     height: 67px;
     justify-content: center;
     max-width: 75px;


### PR DESCRIPTION
#### What?

This PR has fix for cutted outline of product images inslide slick slider.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

[BCTHEME-851](https://jira.bigcommerce.com/browse/BCTHEME-851)
Also while fixing this issue another bug was found - in some cases page can jump when user click on product images on PDP (which can be wrapped by slick). [BCTHEME-894](https://jira.bigcommerce.com/browse/BCTHEME-894) was created and resloved here. 

#### Screenshots (if appropriate)
<img width="904" alt="outline-bug" src="https://user-images.githubusercontent.com/66325265/134302772-feb0b46d-0744-487b-b160-d1abf78f6a49.png">

<img width="904" alt="outline-fix" src="https://user-images.githubusercontent.com/66325265/134302795-7eaad2e1-2611-4aa0-ae03-82700e517aa9.png">

https://user-images.githubusercontent.com/66325265/134634899-9a00beb4-8855-40e7-a7f1-5bbfd8ce773d.mov

https://user-images.githubusercontent.com/66325265/134634925-408649d2-ba53-4eab-817f-63a9a1d4dc26.mov


