### PR TITLE
StoreFront - Fix search results heading is not rendering correctly #2122

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -839,8 +839,8 @@
         "results": {
             "form_label": "Search Keyword:",
             "form_button_text": "Search",
-            "count": "{ count, plural, one {# result} other {# results} } for '{ search_query }'",
-            "quick_count": "{ count, plural, one {# product result} other {# product results} } for '{ search_query }'",
+            "count": "{ count, plural, one {# result} other {# results} } for &#39;{ search_query }&#39;",          
+            "quick_count": "{ count, plural, one {# product result} other {# product results} } for &#39;{ search_query }&#39;",
             "quick_count_live": "product results for",
             "product_count": "Products ({count})",
             "content_count": "News & Information ({count})"


### PR DESCRIPTION
#### What?

This PR addresses an issue with search for keyword([search_query](https://cornerstone-light-demo.mybigcommerce.com/search.php?search_query=shoes)) on  Search results page.

**HTML Entities**

It's happening due to the HTML Entity.

Reserved characters in HTML must be replaced with character entities because. sometimes it's creating an issue while using with any language code. 

Some characters are reserved in HTML.

Character entities are used to display reserved characters in HTML.

A character entity looks like this:
`&entity_name;
OR
&#entity_number;`

EXxample
   - To display a less than sign (<) we must write: `&lt;` or `&#60;`
   - To display single quotation mark/apostrophe (') we must write: `&apos;` or `&#39;`

**Note:** Entity names are case sensitive. Browsers may not support all entity names, but the support for entity numbers is good.

#### Error

-- [Error #2122](https://github.com/bigcommerce/cornerstone/issues/2122)
-- [{ search_query }](https://cornerstone-light-demo.mybigcommerce.com/search.php?search_query=shoes)

#### Screenshot
![search_query](https://user-images.githubusercontent.com/41644520/134847639-0e88ec92-6873-4b24-93b5-14541b3052a1.PNG)

