### PR TITLE
Use srcset for store logo so it looks good in more conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Quick View modal "X" button focus bubble being slightly off center [#2130](https://github.com/bigcommerce/cornerstone/pull/2130)
 - Apply dependency updates (jest & lighthouse). [#2132](https://github.com/bigcommerce/cornerstone/pull/2132)
 - Update lang file for FR locale. [#2139](https://github.com/bigcommerce/cornerstone/pull/2139)
+- Update store logo to use `srcset`. [#2136](https://github.com/bigcommerce/cornerstone/pull/2136)
 
 ## 6.1.1 (10-01-2021)
 - Fix product images on PDP has clipped outline. [#2124](https://github.com/bigcommerce/cornerstone/pull/2124)

--- a/templates/components/common/store-logo.html
+++ b/templates/components/common/store-logo.html
@@ -1,13 +1,20 @@
 <a href="{{urls.home}}" class="header-logo__link" data-header-logo-link>
     {{#if settings.store_logo.image}}
         {{#if theme_settings.logo_size '===' 'original'}}
-            <img class="header-logo-image-unknown-size" src="{{getImage settings.store_logo.image 'logo_size'}}" alt="{{settings.store_logo.title}}" title="{{settings.store_logo.title}}">
+        <img class="header-logo-image-unknown-size"
+             src="{{getImage settings.store_logo.image 'logo_size'}}"
+             alt="{{settings.store_logo.title}}"
+             title="{{settings.store_logo.title}}">
         {{else}}
-            <div class="header-logo-image-container">
-                <img class="header-logo-image" src="{{getImage settings.store_logo.image 'logo_size'}}" alt="{{settings.store_logo.title}}" title="{{settings.store_logo.title}}">
-            </div>
+        <div class="header-logo-image-container">
+            <img class="header-logo-image"
+                 src="{{getImage settings.store_logo.image 'logo_size'}}"
+                 srcset="{{getImageSrcset1x2x settings.store_logo.image theme_settings.logo_size}}"
+                 alt="{{settings.store_logo.title}}"
+                 title="{{settings.store_logo.title}}">
+        </div>
         {{/if}}
     {{else}}
-        <span class="header-logo-text">{{settings.store_logo.title}}</span>
+    <span class="header-logo-text">{{settings.store_logo.title}}</span>
     {{/if}}
 </a>


### PR DESCRIPTION
#### What?

Update logo to use `srcset` to make sure the logo looks good at all screen sizes and pixel densities.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [STRF-9454](https://jira.bigcommerce.com/browse/STRF-9454)

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/8922457/138509557-618044e1-8eea-4b41-b48c-986f99165a9c.png)
