### PR TITLE
Replace schema microdata with LD+JSON tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Draft
 - Fixed Quick View modal "X" button focus bubble being slightly off center [#2130](https://github.com/bigcommerce/cornerstone/pull/2130)
 - Apply dependency updates (jest & lighthouse). [#2132](https://github.com/bigcommerce/cornerstone/pull/2132)
+- Replace schema microdata with LD+JSON tag. [#2138](https://github.com/bigcommerce/cornerstone/pull/2138)
 
 ## 6.1.1 (10-01-2021)
 - Fix product images on PDP has clipped outline. [#2124](https://github.com/bigcommerce/cornerstone/pull/2124)

--- a/templates/components/amp/products/product-view-details.html
+++ b/templates/components/amp/products/product-view-details.html
@@ -1,9 +1,9 @@
 <section class="productView-details">
     <div class="productView-product">
-        <h1 class="productView-title" {{#if schema}}itemprop="name"{{/if}}>{{product.title}}</h1>
+        <h1 class="productView-title">{{product.title}}</h1>
         {{#if product.brand }}
-        <h2 class="productView-brand"{{#if schema}} itemprop="brand" itemscope itemtype="https://schema.org/Brand"{{/if}}>
-            <a href="{{product.brand.url}}"{{#if schema}} itemprop="url"{{/if}}><span{{#if schema}} itemprop="name"{{/if}}>{{product.brand.name}}</span></a>
+        <h2 class="productView-brand">
+            <a href="{{product.brand.url}}"><span>{{product.brand.name}}</span></a>
         </h2>
         {{/if}}
         {{#if product.call_for_price}}
@@ -13,7 +13,7 @@
         {{/if}}
         {{#if product.price}}
             <div class="productView-price">
-                {{> components/products/price price=product.price schema_org=schema}}
+                {{> components/products/price price=product.price}}
             </div>
         {{/if}}
         {{product.detail_messages}}

--- a/templates/components/amp/products/reviews.html
+++ b/templates/components/amp/products/reviews.html
@@ -7,15 +7,14 @@
             <ul class="productReviews-list" id="productReviews-list">
                 {{#each reviews.list}}
                 <li class="productReview">
-                    <article itemprop="review" itemscope itemtype="https://schema.org/Review">
+                    <article>
                         <header>
-                            <span class="productReview-rating rating--small" itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating">
+                            <span class="productReview-rating rating--small">
                                 {{> components/amp/products/ratings rating=rating}}
-                                <span class="productReview-ratingNumber" itemprop="ratingValue">{{ rating }}</span>
+                                <span class="productReview-ratingNumber">{{ rating }}</span>
                             </span>
-                            <h5 itemprop="name" class="productReview-title">{{ title }}</h5>
+                            <h5 class="productReview-title">{{ title }}</h5>
                             {{#if name}}
-                                <meta itemprop="author" content="{{name}}">
                                 <p class="productReview-author">
                                     {{lang 'products.reviews.post_on_by' date=date name=name }}
                                 </p>
@@ -25,7 +24,7 @@
                                 </p>
                             {{/if}}
                         </header>
-                        <p itemprop="reviewBody" class="productReview-body">{{nl2br text}}</p>
+                        <p class="productReview-body">{{nl2br text}}</p>
                     </article>
                 </li>
                 {{/each}}

--- a/templates/components/common/breadcrumbs.html
+++ b/templates/components/common/breadcrumbs.html
@@ -1,18 +1,36 @@
 <nav aria-label="Breadcrumb">
-    <ol class="breadcrumbs" itemscope itemtype="https://schema.org/BreadcrumbList">
+    <ol class="breadcrumbs">
         {{#unless theme_settings.hide_breadcrumbs }}
             {{#each breadcrumbs}}
-                <li class="breadcrumb {{#if @last}}is-active{{/if}}" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                <li class="breadcrumb {{#if @last}}is-active{{/if}}">
                     <a class="breadcrumb-label"
-                       itemprop="item"
                        href="{{url}}"
                        {{#if @last}}aria-current="page"{{/if}}
                     >
-                        <span itemprop="name">{{name}}</span>
+                        <span>{{name}}</span>
                     </a>
-                    <meta itemprop="position" content="{{add @index 1}}" />
                 </li>
             {{/each}}
         {{/unless}}
     </ol>
 </nav>
+
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement":
+    [
+        {{#each breadcrumbs}}
+        {
+            "@type": "ListItem",
+            "position": {{add @index 1}},
+            "item": {
+                "@id": {{{JSONstringify url}}},
+                "name": {{{JSONstringify name}}}
+            }
+        }{{#unless @last}},{{/unless}}
+        {{/each}}
+    ]
+}
+</script>

--- a/templates/components/products/price-range.html
+++ b/templates/components/products/price-range.html
@@ -36,7 +36,7 @@
             {{price.non_sale_price_with_tax.formatted}}
         </span>
     </div>
-    <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="https://schema.org/Offer"{{/if}}>
+    <div class="price-section price-section--withTax">
         <span class="price-label">{{theme_settings.pdp-price-label}}</span>
         <span class="price-now-label" style="display: none;">
             {{> components/products/price-label
@@ -48,20 +48,6 @@
         {{#and price.price_range.min.without_tax price.price_range.max.without_tax}}
             <abbr title="{{lang 'products.including_tax'}}">{{lang 'products.price_with_tax' tax_label=price.price_range.min.tax_label}}</abbr>
         {{/and}}
-        {{#if schema_org}}
-            <meta itemprop="availability" itemtype="https://schema.org/ItemAvailability"
-                    content="https://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
-            <meta itemprop="itemCondition" itemtype="https://schema.org/OfferItemCondition" content="https://schema.org/{{product.condition}}Condition">
-            <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
-            <meta itemprop="url" content="{{product.url}}">
-            <div itemprop="priceSpecification" itemscope itemtype="https://schema.org/PriceSpecification">
-                <meta itemprop="minPrice" content="{{price_range.min.with_tax.value}}"  />
-                <meta itemprop="price" content="{{price_range.min.with_tax.value}}">
-                <meta itemprop="maxPrice" content="{{price_range.max.with_tax.value}}"  />
-                <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
-                <meta itemprop="valueAddedTaxIncluded" content="true">
-            </div>
-        {{/if}}
     </div>
 {{/and}}
 {{#and price.retail_price_range.min.without_tax price.retail_price_range.max.without_tax}}
@@ -102,7 +88,7 @@
             {{price.non_sale_price_without_tax.formatted}}
         </span>
     </div>
-    <div class="price-section price-section--withoutTax{{#and price_range.min.with_tax price_range.max.with_tax}} price-section--minor{{/and}}" {{#if schema_org}}itemprop="offers" itemscope itemtype="https://schema.org/Offer"{{/if}}>
+    <div class="price-section price-section--withoutTax{{#and price_range.min.with_tax price_range.max.with_tax}} price-section--minor{{/and}}">
         <span class="price-label">{{theme_settings.pdp-price-label}}</span>
         <span class="price-now-label" style="display: none;">
             {{> components/products/price-label
@@ -114,20 +100,6 @@
         {{#and price.price_range.min.with_tax price.price_range.max.with_tax}}
             <abbr title="{{lang 'products.excluding_tax'}}">{{lang 'products.price_without_tax' tax_label=price.price_range.min.tax_label}}</abbr>
         {{/and}}
-        {{#if schema_org}}
-            <meta itemprop="availability" itemtype="https://schema.org/ItemAvailability"
-                    content="https://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
-            <meta itemprop="itemCondition" itemtype="https://schema.org/OfferItemCondition" content="https://schema.org/{{product.condition}}Condition">
-            <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
-            <meta itemprop="url" content="{{product.url}}">
-            <div itemprop="priceSpecification" itemscope itemtype="https://schema.org/PriceSpecification">
-                <meta itemprop="minPrice" content="{{price.price_range.min.without_tax.value}}"  />
-                <meta itemprop="price" content="{{price.price_range.min.without_tax.value}}">
-                <meta itemprop="maxPrice" content="{{price.price_range.max.without_tax.value}}"  />
-                <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
-                <meta itemprop="valueAddedTaxIncluded" content="false">
-            </div>
-        {{/if}}
     </div>
 {{/and}}
 

--- a/templates/components/products/price.html
+++ b/templates/components/products/price.html
@@ -5,7 +5,7 @@ paths generate the same HTML structure with some differences in whether that ele
 If you are making a change here or in price-range.html, you probably want to make that change in both files. --}}
 
 {{#and price.price_range (if theme_settings.price_ranges '==' true)}}
-    {{> components/products/price-range price=price schema_org=schema_org}}
+    {{> components/products/price-range price=price}}
 {{else}}
     {{#if price.with_tax}}
         <div class="price-section price-section--withTax rrp-price--withTax" {{#unless price.rrp_with_tax}}style="display: none;"{{/unless}}>
@@ -30,7 +30,7 @@ If you are making a change here or in price-range.html, you probably want to mak
                 {{price.non_sale_price_with_tax.formatted}}
             </span>
         </div>
-        <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="https://schema.org/Offer"{{/if}}>
+        <div class="price-section price-section--withTax">
             <span class="price-label" {{#if price.non_sale_price_with_tax}}style="display: none;"{{/if}}>
                 {{theme_settings.pdp-price-label}}
             </span>
@@ -41,18 +41,6 @@ If you are making a change here or in price-range.html, you probably want to mak
                 }}
             </span>
             <span data-product-price-with-tax class="price price--withTax">{{price.with_tax.formatted}}</span>
-            {{#if schema_org}}
-                <meta itemprop="availability" itemtype="https://schema.org/ItemAvailability"
-                	content="https://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
-                <meta itemprop="itemCondition" itemtype="https://schema.org/OfferItemCondition" content="https://schema.org/{{product.condition}}Condition">
-                <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
-                <meta itemprop="url" content="{{product.url}}">
-                <div itemprop="priceSpecification" itemscope itemtype="https://schema.org/PriceSpecification">
-                    <meta itemprop="price" content="{{price.with_tax.value}}">
-                    <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
-                    <meta itemprop="valueAddedTaxIncluded" content="true">
-                </div>
-            {{/if}}
             {{#if price.without_tax}}
                 <abbr title="{{lang 'products.including_tax'}}">{{lang 'products.price_with_tax' tax_label=price.tax_label}}</abbr>
             {{/if}}
@@ -81,7 +69,7 @@ If you are making a change here or in price-range.html, you probably want to mak
                 {{price.non_sale_price_without_tax.formatted}}
             </span>
         </div>
-        <div class="price-section price-section--withoutTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="https://schema.org/Offer"{{/if}}>
+        <div class="price-section price-section--withoutTax">
             <span class="price-label" {{#if price.non_sale_price_without_tax}}style="display: none;"{{/if}}>
                 {{theme_settings.pdp-price-label}}
             </span>
@@ -92,18 +80,6 @@ If you are making a change here or in price-range.html, you probably want to mak
                 }}
             </span>
             <span data-product-price-without-tax class="price price--withoutTax{{#if price.with_tax}} price-section--minor{{/if}}">{{price.without_tax.formatted}}</span>
-            {{#if schema_org}}
-                <meta itemprop="availability" itemtype="https://schema.org/ItemAvailability"
-                    content="https://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
-                <meta itemprop="itemCondition" itemtype="https://schema.org/OfferItemCondition" content="https://schema.org/{{product.condition}}Condition">
-                <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
-                <meta itemprop="url" content="{{product.url}}">
-                <div itemprop="priceSpecification" itemscope itemtype="https://schema.org/PriceSpecification">
-                    <meta itemprop="price" content="{{price.without_tax.value}}">
-                    <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
-                    <meta itemprop="valueAddedTaxIncluded" content="false">
-                </div>
-            {{/if}}
             {{#if price.with_tax}}
                 <abbr title="{{lang 'products.excluding_tax'}}">{{lang 'products.price_without_tax' tax_label=price.tax_label}}</abbr>
             {{/if}}

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -26,7 +26,7 @@
                 {{!-- Remove the surrounding a-element if there is no main image. --}}
                 {{#if product.main_image}}
                     <a href="{{getImageSrcset product.main_image (cdn theme_settings.default_image_product) 1x=theme_settings.zoom_size}}"
-                        target="_blank"{{#if schema}} itemprop="image"{{/if}}>
+                        target="_blank">
                 {{/if}}
                 {{> components/common/responsive-img
                     image=product.main_image
@@ -73,10 +73,10 @@
 
     <section class="productView-details product-data">
         <div class="productView-product">
-            <h1 class="productView-title" {{#if schema}}itemprop="name"{{/if}}>{{product.title}}</h1>
+            <h1 class="productView-title">{{product.title}}</h1>
             {{#if product.brand}}
-                <h2 class="productView-brand"{{#if schema}} itemprop="brand" itemscope itemtype="https://schema.org/Brand"{{/if}}>
-                    <a href="{{product.brand.url}}"{{#if schema}} itemprop="url"{{/if}}><span{{#if schema}} itemprop="name"{{/if}}>{{product.brand.name}}</span></a>
+                <h2 class="productView-brand">
+                    <a href="{{product.brand.url}}"><span>{{product.brand.name}}</span></a>
                 </h2>
             {{/if}}
             {{#if product.call_for_price}}
@@ -86,22 +86,15 @@
             {{/if}}
             <div class="productView-price">
                 {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
-                    {{> components/products/price price=product.price schema_org=schema}}
+                    {{> components/products/price price=product.price}}
                 {{else}}
                     {{> components/common/login-for-pricing}}
                 {{/or}}
             </div>
             {{{region name="product_below_price"}}}
-            <div class="productView-rating"{{#if product.num_reviews '>' 0}}{{#if schema}} itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating"{{/if}}{{/if}}>
+            <div class="productView-rating">
                 {{#if settings.show_product_rating}}
-                    {{#if product.num_reviews '>' 0}}
-                        {{#if schema}}
-                            <meta itemprop="ratingValue" content="{{product.rating}}">
-                            <meta itemprop="ratingCount" content="{{product.num_reviews}}">
-                            <meta itemprop="reviewCount" content="{{product.num_reviews}}">
-                        {{/if}}
-                    {{/if}}
-                        {{> components/products/ratings rating=product.rating}}
+                    {{> components/products/ratings rating=product.rating}}
                     {{#if product.num_reviews '>' 0}}
                         <a href="{{product.url}}{{#if is_ajax}}#product-reviews{{/if}}" id="productReview_link">
                             {{lang 'products.reviews.link_to_review' total=product.num_reviews}}
@@ -124,13 +117,9 @@
             {{product.detail_messages}}
             <dl class="productView-info">
                 <dt class="productView-info-name sku-label"{{#unless product.sku}} style="display: none;"{{/unless}}>{{lang 'products.sku'}}</dt>
-                <dd class="productView-info-value" data-product-sku{{#if schema}} itemprop="sku"{{/if}}>{{product.sku}}</dd>
+                <dd class="productView-info-value" data-product-sku>{{product.sku}}</dd>
                 <dt class="productView-info-name upc-label"{{#unless product.upc}} style="display: none;"{{/unless}}>{{lang 'products.upc'}}</dt>
                 <dd class="productView-info-value" data-product-upc>{{product.upc}}</dd>
-                {{#if schema}}
-                    {{#if product.mpn}}<meta itemprop="mpn" content="{{product.mpn}}" />{{/if}}
-                    {{#if product.gtin}}<meta itemprop="gtin" content="{{product.gtin}}" />{{/if}}
-                {{/if}}
                 {{#if product.condition}}
                     <dt class="productView-info-name">{{lang 'products.condition'}}</dt>
                     <dd class="productView-info-value">{{product.condition}}</dd>
@@ -252,7 +241,7 @@
         {{> components/common/share url=product.url}}
     </section>
 
-    <article class="productView-description"{{#if schema}} itemprop="description"{{/if}}>
+    <article class="productView-description">
         {{#if theme_settings.show_product_details_tabs}}
             {{> components/products/description-tabs}}
         {{else}}

--- a/templates/components/products/quick-view.html
+++ b/templates/components/products/quick-view.html
@@ -1,5 +1,5 @@
 <div class="modal-body quickView">
-    {{> components/products/product-view schema=false}}
+    {{> components/products/product-view}}
 
     {{#all settings.show_product_reviews theme_settings.show_product_reviews (if theme_settings.show_product_details_tabs '!==' true)}}
         {{> components/products/reviews reviews=product.reviews product=product urls=urls}}

--- a/templates/components/products/reviews.html
+++ b/templates/components/products/reviews.html
@@ -17,15 +17,14 @@
         <ul class="productReviews-list" id="productReviews-list">
             {{#each reviews.list}}
             <li class="productReview">
-                <article itemprop="review" itemscope itemtype="https://schema.org/Review">
+                <article>
                     <header>
-                        <span class="productReview-rating rating--small" itemprop="reviewRating" itemscope itemtype="https://schema.org/Rating">
+                        <span class="productReview-rating rating--small">
                             {{> components/products/ratings rating=rating}}
-                            <span class="productReview-ratingNumber" itemprop="ratingValue">{{ rating }}</span>
+                            <span class="productReview-ratingNumber">{{ rating }}</span>
                         </span>
-                        <h5 itemprop="name" class="productReview-title">{{{ sanitize title }}}</h5>
+                        <h5 class="productReview-title">{{{ sanitize title }}}</h5>
                         {{#if name}}
-                            <meta itemprop="author" content="{{name}}">
                             <p class="productReview-author">
                                 {{{lang 'products.reviews.post_on_by' date=date name=(sanitize name) }}}
                             </p>
@@ -35,7 +34,7 @@
                             </p>
                         {{/if}}
                     </header>
-                    <p itemprop="reviewBody" class="productReview-body">{{{ sanitize text }}}</p>
+                    <p class="productReview-body">{{{ sanitize text }}}</p>
                 </article>
             </li>
             {{/each}}

--- a/templates/components/products/schema.html
+++ b/templates/components/products/schema.html
@@ -1,0 +1,61 @@
+<script type="application/ld+json">
+    {
+        "@context": "https://schema.org/",
+        "@type": "Product",
+        "name": {{{JSONstringify product.title}}},
+        {{#if product.sku}}"sku": "{{product.sku}}",{{/if}}
+        {{#if product.mpn}}"mpn": "{{product.mpn}}",{{/if}}
+        {{#if product.gtin}}"gtin{{length product.gtin}}": "{{product.gtin}}",{{/if}}
+        "url" : "{{product.url}}",
+        {{#if product.brand}}
+        "brand": {
+            "@type": "Brand",
+            "url": "{{product.brand.url}}",
+            "name": {{{JSONstringify product.brand.name}}}
+        },
+        {{/if}}
+        "description": "{{encodeURI (sanitize product.description)}}",
+        "image": "{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}",
+        {{#and settings.show_product_reviews product.reviews.list.length}}
+        "aggregateRating": {
+            "@type": "AggregateRating",
+            "ratingValue": "{{product.rating}}",
+            "reviewCount": "{{product.num_reviews}}"
+        },
+        "review": [
+        {{#each product.reviews.list}}
+            {
+                "@type": "Review",
+                "author": {
+                    "@type": "Person",
+                    "name": {{{JSONstringify name}}}
+                },
+                "datePublished": "{{date}}",
+                "reviewBody": {{{JSONstringify text}}},
+                "name": {{{JSONstringify title}}},
+                "reviewRating": {
+                    "@type": "Rating",
+                    "bestRating": "5",
+                    "ratingValue": "{{rating}}",
+                    "worstRating": "1"
+                }
+            }{{#unless @last}},{{/unless}}
+        {{/each}}
+        ],
+        {{/and}}
+        "offers": {
+            "@type": "Offer",
+            "priceCurrency": "{{currency_selector.active_currency_code}}",
+            {{#if product.price.price_range}}
+            "minPrice": "{{#if product.price.price_range.min.with_tax}}{{product.price.price_range.min.with_tax.value}}{{else}}{{product.price.price_range.min.without_tax.value}}{{/if}}",
+            "maxPrice": "{{#if product.price.price_range.max.with_tax}}{{product.price.price_range.max.with_tax.value}}{{else}}{{product.price.price_range.max.without_tax.value}}{{/if}}",
+            {{else}}
+            "price": "{{#if product.price.with_tax}}{{product.price.with_tax.value}}{{else}}{{product.price.without_tax.value}}{{/if}}",
+            {{/if}}
+            "itemCondition" : "https://schema.org/{{#if product.condition}}{{product.condition}}{{else}}New{{/if}}Condition",
+            "availability" : "https://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}",
+            "url" : "{{product.url}}",
+            "priceValidUntil": "{{moment (moment add='31536000000') 'YYYY-MM-DD' }}"
+        }
+    }
+    </script>

--- a/templates/components/products/schema.html
+++ b/templates/components/products/schema.html
@@ -58,4 +58,4 @@
             "priceValidUntil": "{{moment (moment add='31536000000') 'YYYY-MM-DD' }}"
         }
     }
-    </script>
+</script>

--- a/templates/pages/amp/product-options.html
+++ b/templates/pages/amp/product-options.html
@@ -1,4 +1,4 @@
 {{#partial "page"}}
-    {{> components/amp/products/product-options schema=true}}
+    {{> components/amp/products/product-options}}
 {{/partial}}
 {{> layout/amp-iframe}}

--- a/templates/pages/amp/product.html
+++ b/templates/pages/amp/product.html
@@ -23,9 +23,70 @@ product:
 {{/partial}}
 {{#partial "page"}}
     {{> components/amp/common/header }}
-    <div itemscope itemtype="https://schema.org/Product">
-        {{> components/amp/products/product-view schema=true}}
+    <div>
+        {{> components/amp/products/product-view}}
     </div>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org/",
+        "@type": "Product",
+        "name": {{{JSONstringify product.title}}},
+        {{#if product.sku}}"sku": "{{product.sku}}",{{/if}}
+        {{#if product.mpn}}"mpn": "{{product.mpn}}",{{/if}}
+        {{#if product.gtin}}"gtin{{length product.gtin}}": "{{product.gtin}}",{{/if}}
+        "url" : "{{product.url}}",
+        {{#if product.brand}}
+        "brand": {
+            "@type": "Brand",
+            "url": "{{product.brand.url}}",
+            "name": {{{JSONstringify product.brand.name}}}
+        },
+        {{/if}}
+        "description": "{{encodeURI (sanitize product.description)}}",
+        "image": "{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}",
+        {{#and settings.show_product_reviews product.reviews.list.length}}
+        "aggregateRating": {
+            "@type": "AggregateRating",
+            "ratingValue": "{{product.rating}}",
+            "reviewCount": "{{product.num_reviews}}"
+        },
+        "review": [
+        {{#each product.reviews.list}}
+            {
+                "@type": "Review",
+                "author": {
+                    "@type": "Person",
+                    "name": {{{JSONstringify name}}}
+                },
+                "datePublished": "{{date}}",
+                "reviewBody": {{{JSONstringify text}}},
+                "name": {{{JSONstringify title}}},
+                "reviewRating": {
+                    "@type": "Rating",
+                    "bestRating": "5",
+                    "ratingValue": "{{rating}}",
+                    "worstRating": "1"
+                }
+            }{{#unless @last}},{{/unless}}
+        {{/each}}
+        ],
+        {{/and}}
+        "offers": {
+            "@type": "Offer",
+            "priceCurrency": "{{currency_selector.active_currency_code}}",
+            {{#if product.price.price_range}}
+            "minPrice": "{{#if product.price.price_range.min.with_tax}}{{product.price.price_range.min.with_tax.value}}{{else}}{{product.price.price_range.min.without_tax.value}}{{/if}}",
+            "maxPrice": "{{#if product.price.price_range.max.with_tax}}{{product.price.price_range.max.with_tax.value}}{{else}}{{product.price.price_range.max.without_tax.value}}{{/if}}",
+            {{else}}
+            "price": "{{#if product.price.with_tax}}{{product.price.with_tax.value}}{{else}}{{product.price.without_tax.value}}{{/if}}",
+            {{/if}}
+            "itemCondition" : "https://schema.org/{{#if product.condition}}{{product.condition}}{{else}}New{{/if}}Condition",
+            "availability" : "https://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}",
+            "url" : "{{product.url}}",
+            "priceValidUntil": "{{moment (moment add='31536000000') 'YYYY-MM-DD' }}"
+        }
+    }
+    </script>
     {{#if settings.amp_analytics_id}}
         <amp-analytics type="googleanalytics">
             <script type="application/json">

--- a/templates/pages/amp/product.html
+++ b/templates/pages/amp/product.html
@@ -26,67 +26,7 @@ product:
     <div>
         {{> components/amp/products/product-view}}
     </div>
-    <script type="application/ld+json">
-    {
-        "@context": "https://schema.org/",
-        "@type": "Product",
-        "name": {{{JSONstringify product.title}}},
-        {{#if product.sku}}"sku": "{{product.sku}}",{{/if}}
-        {{#if product.mpn}}"mpn": "{{product.mpn}}",{{/if}}
-        {{#if product.gtin}}"gtin{{length product.gtin}}": "{{product.gtin}}",{{/if}}
-        "url" : "{{product.url}}",
-        {{#if product.brand}}
-        "brand": {
-            "@type": "Brand",
-            "url": "{{product.brand.url}}",
-            "name": {{{JSONstringify product.brand.name}}}
-        },
-        {{/if}}
-        "description": "{{encodeURI (sanitize product.description)}}",
-        "image": "{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}",
-        {{#and settings.show_product_reviews product.reviews.list.length}}
-        "aggregateRating": {
-            "@type": "AggregateRating",
-            "ratingValue": "{{product.rating}}",
-            "reviewCount": "{{product.num_reviews}}"
-        },
-        "review": [
-        {{#each product.reviews.list}}
-            {
-                "@type": "Review",
-                "author": {
-                    "@type": "Person",
-                    "name": {{{JSONstringify name}}}
-                },
-                "datePublished": "{{date}}",
-                "reviewBody": {{{JSONstringify text}}},
-                "name": {{{JSONstringify title}}},
-                "reviewRating": {
-                    "@type": "Rating",
-                    "bestRating": "5",
-                    "ratingValue": "{{rating}}",
-                    "worstRating": "1"
-                }
-            }{{#unless @last}},{{/unless}}
-        {{/each}}
-        ],
-        {{/and}}
-        "offers": {
-            "@type": "Offer",
-            "priceCurrency": "{{currency_selector.active_currency_code}}",
-            {{#if product.price.price_range}}
-            "minPrice": "{{#if product.price.price_range.min.with_tax}}{{product.price.price_range.min.with_tax.value}}{{else}}{{product.price.price_range.min.without_tax.value}}{{/if}}",
-            "maxPrice": "{{#if product.price.price_range.max.with_tax}}{{product.price.price_range.max.with_tax.value}}{{else}}{{product.price.price_range.max.without_tax.value}}{{/if}}",
-            {{else}}
-            "price": "{{#if product.price.with_tax}}{{product.price.with_tax.value}}{{else}}{{product.price.without_tax.value}}{{/if}}",
-            {{/if}}
-            "itemCondition" : "https://schema.org/{{#if product.condition}}{{product.condition}}{{else}}New{{/if}}Condition",
-            "availability" : "https://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}",
-            "url" : "{{product.url}}",
-            "priceValidUntil": "{{moment (moment add='31536000000') 'YYYY-MM-DD' }}"
-        }
-    }
-    </script>
+    {{> components/products/schema}}
     {{#if settings.amp_analytics_id}}
         <amp-analytics type="googleanalytics">
             <script type="application/json">

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -35,66 +35,6 @@ product:
         {{> components/products/tabs}}
     </div>
 
-    <script type="application/ld+json">
-    {
-        "@context": "https://schema.org/",
-        "@type": "Product",
-        "name": {{{JSONstringify product.title}}},
-        {{#if product.sku}}"sku": "{{product.sku}}",{{/if}}
-        {{#if product.mpn}}"mpn": "{{product.mpn}}",{{/if}}
-        {{#if product.gtin}}"gtin{{length product.gtin}}": "{{product.gtin}}",{{/if}}
-        "url" : "{{product.url}}",
-        {{#if product.brand}}
-        "brand": {
-            "@type": "Brand",
-            "url": "{{product.brand.url}}",
-            "name": {{{JSONstringify product.brand.name}}}
-        },
-        {{/if}}
-        "description": "{{encodeURI (sanitize product.description)}}",
-        "image": "{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}",
-        {{#and settings.show_product_reviews product.reviews.list.length}}
-        "aggregateRating": {
-            "@type": "AggregateRating",
-            "ratingValue": "{{product.rating}}",
-            "reviewCount": "{{product.num_reviews}}"
-        },
-        "review": [
-        {{#each product.reviews.list}}
-            {
-                "@type": "Review",
-                "author": {
-                    "@type": "Person",
-                    "name": {{{JSONstringify name}}}
-                },
-                "datePublished": "{{date}}",
-                "reviewBody": {{{JSONstringify text}}},
-                "name": {{{JSONstringify title}}},
-                "reviewRating": {
-                    "@type": "Rating",
-                    "bestRating": "5",
-                    "ratingValue": "{{rating}}",
-                    "worstRating": "1"
-                }
-            }{{#unless @last}},{{/unless}}
-        {{/each}}
-        ],
-        {{/and}}
-        "offers": {
-            "@type": "Offer",
-            "priceCurrency": "{{currency_selector.active_currency_code}}",
-            {{#if product.price.price_range}}
-            "minPrice": "{{#if product.price.price_range.min.with_tax}}{{product.price.price_range.min.with_tax.value}}{{else}}{{product.price.price_range.min.without_tax.value}}{{/if}}",
-            "maxPrice": "{{#if product.price.price_range.max.with_tax}}{{product.price.price_range.max.with_tax.value}}{{else}}{{product.price.price_range.max.without_tax.value}}{{/if}}",
-            {{else}}
-            "price": "{{#if product.price.with_tax}}{{product.price.with_tax.value}}{{else}}{{product.price.without_tax.value}}{{/if}}",
-            {{/if}}
-            "itemCondition" : "https://schema.org/{{#if product.condition}}{{product.condition}}{{else}}New{{/if}}Condition",
-            "availability" : "https://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}",
-            "url" : "{{product.url}}",
-            "priceValidUntil": "{{moment (moment add='31536000000') 'YYYY-MM-DD' }}"
-        }
-    }
-    </script>
+    {{> components/products/schema}}
 {{/partial}}
 {{> layout/base}}

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -19,8 +19,8 @@ product:
         {{> components/common/alert/alert-info message}}
     {{/each}}
 
-    <div itemscope itemtype="https://schema.org/Product">
-        {{> components/products/product-view schema=true  }}
+    <div>
+        {{> components/products/product-view}}
 
         {{{region name="product_below_content"}}}
 
@@ -34,5 +34,67 @@ product:
 
         {{> components/products/tabs}}
     </div>
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org/",
+        "@type": "Product",
+        "name": {{{JSONstringify product.title}}},
+        {{#if product.sku}}"sku": "{{product.sku}}",{{/if}}
+        {{#if product.mpn}}"mpn": "{{product.mpn}}",{{/if}}
+        {{#if product.gtin}}"gtin{{length product.gtin}}": "{{product.gtin}}",{{/if}}
+        "url" : "{{product.url}}",
+        {{#if product.brand}}
+        "brand": {
+            "@type": "Brand",
+            "url": "{{product.brand.url}}",
+            "name": {{{JSONstringify product.brand.name}}}
+        },
+        {{/if}}
+        "description": "{{encodeURI (sanitize product.description)}}",
+        "image": "{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}",
+        {{#and settings.show_product_reviews product.reviews.list.length}}
+        "aggregateRating": {
+            "@type": "AggregateRating",
+            "ratingValue": "{{product.rating}}",
+            "reviewCount": "{{product.num_reviews}}"
+        },
+        "review": [
+        {{#each product.reviews.list}}
+            {
+                "@type": "Review",
+                "author": {
+                    "@type": "Person",
+                    "name": {{{JSONstringify name}}}
+                },
+                "datePublished": "{{date}}",
+                "reviewBody": {{{JSONstringify text}}},
+                "name": {{{JSONstringify title}}},
+                "reviewRating": {
+                    "@type": "Rating",
+                    "bestRating": "5",
+                    "ratingValue": "{{rating}}",
+                    "worstRating": "1"
+                }
+            }{{#unless @last}},{{/unless}}
+        {{/each}}
+        ],
+        {{/and}}
+        "offers": {
+            "@type": "Offer",
+            "priceCurrency": "{{currency_selector.active_currency_code}}",
+            {{#if product.price.price_range}}
+            "minPrice": "{{#if product.price.price_range.min.with_tax}}{{product.price.price_range.min.with_tax.value}}{{else}}{{product.price.price_range.min.without_tax.value}}{{/if}}",
+            "maxPrice": "{{#if product.price.price_range.max.with_tax}}{{product.price.price_range.max.with_tax.value}}{{else}}{{product.price.price_range.max.without_tax.value}}{{/if}}",
+            {{else}}
+            "price": "{{#if product.price.with_tax}}{{product.price.with_tax.value}}{{else}}{{product.price.without_tax.value}}{{/if}}",
+            {{/if}}
+            "itemCondition" : "https://schema.org/{{#if product.condition}}{{product.condition}}{{else}}New{{/if}}Condition",
+            "availability" : "https://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}",
+            "url" : "{{product.url}}",
+            "priceValidUntil": "{{moment (moment add='31536000000') 'YYYY-MM-DD' }}"
+        }
+    }
+    </script>
 {{/partial}}
 {{> layout/base}}


### PR DESCRIPTION
#### What?

The LD+JSON approach to schema.org data has been widely used for years now. It offers a much clearer, more concise way of providing the data necessary for Rich Results to search engines, such as Google. 

This change cleans up some of the bugs with the existing microdata, such as the description starting with "Description 1 Review", the author being invalid in product reviews, and a missing "priceValidUntil" field. It also adds the number to the gtin field, making it more specific (IE. "gtin12" instead of just "gtin").

More importantly, it separates the microdata from the product content, allowing for users to edit their site's code without having to worry about breaking the delicate data structure. 

Lastly, it makes editing the actual structured data very easy. For example, if a merchant wanted to list out their variants as separate offers using gql data in the existing Cornerstone setup, they would need to pass this data through to the price component, then go back up, loop through the gql, making it very difficult. With the new setup, they would simply loop through the gql response in this single LD+JSON tag!

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

No specific requests here, but it does solve the following issue:
- https://github.com/bigcommerce/cornerstone/issues/2135

#### Screenshots (if appropriate)

##### Before edits:
![Screen Shot 2021-11-01 at 6 26 40 PM](https://user-images.githubusercontent.com/47044676/139750280-9fa72db3-dccb-46a3-8613-889e25fd4256.png)

##### After edits:
![Screen Shot 2021-11-01 at 6 33 22 PM](https://user-images.githubusercontent.com/47044676/139750839-9ce23f3d-65bc-4c5a-9eef-3891aad49a22.png)

#### Notes

I am willing to accept a different solution to passing the description through. This way apparently works fine for Google, and does not break, but it does look a bit ugly. 
