### PR TITLE
fix(storefront): BCTHEME-936 Cannot see currency dropdown in storefront

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Cannot see currency dropdown in storefront. [#2141](https://github.com/bigcommerce/cornerstone/pull/2141)
 
 ## 6.1.2 (11-05-2021)
 - Hide prices for aria-label and data-product-price attributes if set to "Hidden for guests". Hide currency selection for non-logged in users. [#2131](https://github.com/bigcommerce/cornerstone/pull/2131)

--- a/templates/components/common/navigation.html
+++ b/templates/components/common/navigation.html
@@ -1,7 +1,7 @@
 <nav class="navUser">
-    {{#if customer.id}}
+    {{#or customer (unless theme_settings.restrict_to_login)}}
         {{> components/common/currency-selector}}
-    {{/if}}
+    {{/or}}
 
     <ul class="navUser-section navUser-section--alt">
         {{#if customer.store_credit.value '>' 0}}


### PR DESCRIPTION
#### What?
This PR fixes the display of the currency dropdown.

#### Tickets / Documentation
- [BCTHEME-936](https://jira.bigcommerce.com/browse/BCTHEME-936)

#### Screenshots
<img width="1615" alt="936_hide_currency_restrict_to_login" src="https://user-images.githubusercontent.com/82589781/140918613-8334f00f-cf93-43a0-98b9-d9fe18cf4ae6.png">

<img width="1644" alt="936_currency_restrict_to_login" src="https://user-images.githubusercontent.com/82589781/140918631-a666783f-b9a8-4617-a781-555d0d9374e7.png">

<img width="1640" alt="936_currecncy_login" src="https://user-images.githubusercontent.com/82589781/140918646-b05094fb-b6e7-4490-a9bb-a00ba5a8a2b4.png">
