### PR TITLE
fix(storefront): BCTHEME-912 Admin Bar displays regardless of setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Admin Bar displays regardless of setting. [#2144](https://github.com/bigcommerce/cornerstone/pull/2144)
 - Cannot see currency dropdown in storefront. [#2141](https://github.com/bigcommerce/cornerstone/pull/2141)
 
 ## 6.1.2 (11-05-2021)

--- a/assets/js/theme/global.js
+++ b/assets/js/theme/global.js
@@ -19,7 +19,7 @@ import svgInjector from './global/svg-injector';
 export default class Global extends PageManager {
     onReady() {
         const {
-            channelId, cartId, productId, categoryId, secureBaseUrl, maintenanceModeSettings, adminBarLanguage, showAdminBar,
+            channelId, cartId, productId, categoryId, secureBaseUrl, maintenanceModeSettings, adminBarLanguage,
         } = this.context;
         cartPreview(secureBaseUrl, cartId);
         quickSearch();
@@ -30,9 +30,7 @@ export default class Global extends PageManager {
         menu();
         mobileMenuToggle();
         privacyCookieNotification();
-        if (showAdminBar) {
-            adminBar(secureBaseUrl, channelId, maintenanceModeSettings, JSON.parse(adminBarLanguage), productId, categoryId);
-        }
+        adminBar(secureBaseUrl, channelId, maintenanceModeSettings, JSON.parse(adminBarLanguage), productId, categoryId);
         loadingProgressBar();
         svgInjector();
     }

--- a/config.json
+++ b/config.json
@@ -348,7 +348,6 @@
       "paypal"
     ],
     "lazyload_mode": "lazyload+lqip",
-    "show-admin-bar": true,
     "checkout-paymentbuttons-paypal-color": "black",
     "checkout-paymentbuttons-paypal-shape": "rect",
     "checkout-paymentbuttons-paypal-size": "large",

--- a/schema.json
+++ b/schema.json
@@ -516,15 +516,6 @@
         "type": "color",
         "label": "i18n.FieldBorderActive",
         "id": "input-border-color-active"
-      },
-      {
-        "type": "heading",
-        "content": "i18n.AdminBar"
-      },
-      {
-        "type": "checkbox",
-        "label": "i18n.ShowAdminBar",
-        "id": "show-admin-bar"
       }
     ]
   },

--- a/schemaTranslations.json
+++ b/schemaTranslations.json
@@ -510,12 +510,6 @@
     "uk": "Кордон поля активний",
     "zh": "字段边框启用"
   },
-  "i18n.AdminBar": {
-    "default": "Admin Bar"
-  },
-  "i18n.ShowAdminBar": {
-    "default": "Show persistent admin bar when viewing storefront from your control panel"
-  },
   "i18n.HeaderAndFooter": {
     "default": "Header & Footer",
     "fr": "En-tête & pied de page",

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -44,7 +44,6 @@
 
         {{~inject 'zoomSize' theme_settings.zoom_size}}
         {{~inject 'productSize' theme_settings.product_size}}
-        {{~inject 'showAdminBar' theme_settings.show-admin-bar}}
         {{~inject 'genericError' (lang 'common.generic_error')}}
         {{~inject 'maintenanceModeSettings' settings.maintenance}}
         {{~inject 'adminBarLanguage' (langJson 'admin')}}


### PR DESCRIPTION
#### What?

This PR removes setting Admin Bar from Cornerston because that setting will actually not do anything currently and is not controlled by the Theme anymore.

#### Tickets / Documentation

- [BCTHEME-912](https://jira.bigcommerce.com/browse/BCTHEME-912)

#### Screenshots (if appropriate)

![with AdminBar](https://user-images.githubusercontent.com/83779098/141778125-0b1e1eb1-9604-41ae-9d17-dded2718497f.png)
<img width="581" alt="without AdminBar" src="https://user-images.githubusercontent.com/83779098/141778127-d0a5779c-a147-4435-b9d1-5213994dfd15.png">

