### PR TITLE
fix(storefront): BCTHEME-965 Update stencil-utils package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Update stencil-utils package. [#2157](https://github.com/bigcommerce/cornerstone/pull/2157)
 
 ## 6.2.0 (12-13-2021)
 - Fix tooltip on close button of modal is shifted. [#2148](https://github.com/bigcommerce/cornerstone/pull/2148)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1065,9 +1065,9 @@
       "dev": true
     },
     "@bigcommerce/stencil-utils": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-6.8.1.tgz",
-      "integrity": "sha512-17+6itcocte+ma69ul90BghNVi5bOqF0AQb+u9s4XRxC9HyFFJG5nB7kd7CtInk8reVj8R8IYPbrFtgRQxJ4wQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-6.11.0.tgz",
+      "integrity": "sha512-ULhqJPrzZEap+ZoGbnx/VkXwEEcopspQ9kSFwZpBmBqgrp/QA7H6ElLeVHUUA9ImL2QF0OF80fxjRoWwYXHnOA==",
       "requires": {
         "eventemitter3": "^4.0.4",
         "whatwg-fetch": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "BigCommerce",
   "license": "MIT",
   "dependencies": {
-    "@bigcommerce/stencil-utils": "^6.8.1",
+    "@bigcommerce/stencil-utils": "^6.11.0",
     "core-js": "^3.9.0",
     "creditcards": "^3.0.1",
     "easyzoom": "^2.5.3",


### PR DESCRIPTION
#### What?
This PR updates stencil-utils package to v.6.11.0.

#### Tickets / Documentation
- [BCTHEME-965](https://jira.bigcommerce.com/browse/BCTHEME-965)