### PR TITLE
fix(storefront): Specify default API Host when initialising stencil

### DIFF
--- a/.github/workflow-examples/automatic_deployment_production.yml
+++ b/.github/workflow-examples/automatic_deployment_production.yml
@@ -47,7 +47,7 @@ jobs:
       env:
         URL: ${{ secrets.STENCIL_STORE_URL_PRODUCTION }}
         TOKEN: ${{ secrets.STENCIL_ACCESS_TOKEN_PRODUCTION }}
-      run: stencil init -u $URL -t $TOKEN -p 3000
+      run: stencil init -u $URL -t $TOKEN -p 3000 -h https://api.bigcommerce.com
 
     - name: Push theme live, automatically deleting oldest theme if necessary
       run: stencil push -a -d -c 1


### PR DESCRIPTION
#### What?

Automatic deployment workflow fails due to missing config files because without a specified API host this step fails silently waiting for interaction. 

See https://support.bigcommerce.com/s/question/0D74O000007xZEs/detail

#### Requirements

If you would like me to add a changelog entry, let me know and I'll update the PR. 