### PR TITLE
Update blog component to use H1 tags on posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Update blog component to use H1 tags on posts [#2179](https://github.com/bigcommerce/cornerstone/issues/2179)
 - Remove Compare Form. [#2162](https://github.com/bigcommerce/cornerstone/pull/2162)
 - Fixed password complexity error not displaying the complexity rules set in the store settings [#2117](https://github.com/bigcommerce/cornerstone/pull/2117)
 - Translation updates February 2022. [#2177](https://github.com/bigcommerce/cornerstone/pull/2177)

--- a/templates/components/blog/post.html
+++ b/templates/components/blog/post.html
@@ -15,9 +15,9 @@
 
     <div class="blog-post-body">
         <header class="blog-header">
-            <h2 class="blog-title">
+            <h{{#if is_blog_post}}1{{else}}2{{/if}} class="blog-title">
                 <a href="{{post.url}}">{{post.title}}</a>
-            </h2>
+            </h{{#if is_blog_post}}1{{else}}2{{/if}}>
             <p class="blog-date">{{#if post.author}}{{lang 'blog.posted_by' name=post.author}} on {{/if}}{{post.date_published}}</p>
         </header>
 

--- a/templates/pages/blog-post.html
+++ b/templates/pages/blog-post.html
@@ -2,7 +2,7 @@
 
 {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
 
-{{> components/blog/post post=blog.post show_tags=true}}
+{{> components/blog/post post=blog.post show_tags=true is_blog_post=true}}
 
 {{/partial}}
 {{> layout/base}}


### PR DESCRIPTION
#### What?

Blog posts should use an H1 tag for a page header.

#### Tickets / Documentation

https://github.com/bigcommerce/cornerstone/issues/2178