### PR TITLE
fix(storefront): BCTHEME-1006 When price list price is set for currency, the cart does not respect product's price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- When price list price is set for currency, the cart does not respect product's price.[#2190](https://github.com/bigcommerce/cornerstone/issues/2190)
 
 ## 6.3.0 (03-11-2022)
 - Update blog component to use H1 tags on posts [#2179](https://github.com/bigcommerce/cornerstone/issues/2179)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -11,6 +11,7 @@ import forms from '../common/models/forms';
 import { normalizeFormData } from './utils/api';
 import { isBrowserIE, convertIntoArray } from './utils/ie-helpers';
 import bannerUtils from './utils/banner-utils';
+import currencySelector from '../global/currency-selector';
 
 export default class ProductDetails extends ProductDetailsBase {
     constructor($scope, context, productAttributesData = {}) {
@@ -399,6 +400,7 @@ export default class ProductDetails extends ProductDetailsBase {
 
         // Add item to cart
         utils.api.cart.itemAdd(normalizeFormData(new FormData(form)), (err, response) => {
+            currencySelector(response.data.cart_id);
             const errorMessage = err || response.data.error;
 
             $addToCartBtn

--- a/assets/js/theme/global/currency-selector.js
+++ b/assets/js/theme/global/currency-selector.js
@@ -1,7 +1,17 @@
 import swal from './sweet-alert';
 import utils from '@bigcommerce/stencil-utils';
 
+let currencySelectorCalled = false;
+
 export default function (cartId) {
+    if (!cartId) return;
+
+    if (!currencySelectorCalled) {
+        currencySelectorCalled = true;
+    } else {
+        return;
+    }
+
     function changeCurrency(url, currencyCode) {
         $.ajax({
             url,
@@ -21,9 +31,6 @@ export default function (cartId) {
 
     $('[data-cart-currency-switch-url]').on('click', event => {
         const currencySessionSwitcher = event.target.href;
-        if (!cartId) {
-            return;
-        }
         event.preventDefault();
         utils.api.cart.getCart({ cartId }, (err, response) => {
             if (err || response === undefined) {


### PR DESCRIPTION
#### What?

This PR fixes a bug that did not update the currency in the cart the first time changed currency.

#### Tickets / Documentation

- [BCTHEME-1006](https://jira.bigcommerce.com/browse/BCTHEME-1006)

#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/83779098/160631189-23c52ddf-10df-42b9-8654-ed42de2ab68d.mov

https://user-images.githubusercontent.com/83779098/160631163-1d71eef6-4c20-4789-845f-e8c7c1ea288d.mov