### PR TITLE
fix(storefront): BCTHEME-1072 Stored XSS within Wishlist creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Stored XSS within Wishlist creation. [#2193](https://github.com/bigcommerce/cornerstone/issues/2193)
 
 ## 6.3.0 (03-11-2022)
 - Update blog component to use H1 tags on posts [#2179](https://github.com/bigcommerce/cornerstone/issues/2179)

--- a/templates/components/account/add-wishlist.html
+++ b/templates/components/account/add-wishlist.html
@@ -20,7 +20,7 @@
                 {{lang 'forms.wishlist.name'}}
                 <small>{{lang 'common.required' }}</small>
             </label>
-            <input class="form-input" name="wishlistname" id="wishlistname" value="{{forms.wishlist.name}}">
+            <input class="form-input" name="wishlistname" id="wishlistname" value="{{{forms.wishlist.name}}}">
         </div>
         <div class="form-field">
             <input type="checkbox" class="form-checkbox" name="publicwishlist" id="publicwishlist" {{#if forms.wishlist.is_public}}checked{{/if}}>

--- a/templates/components/account/wishlist-list.html
+++ b/templates/components/account/wishlist-list.html
@@ -10,7 +10,7 @@
     <tbody class="table-tbody">
     {{#each customer.wishlists}}
         <tr>
-            <td><a href="{{view_url}}">{{{name}}}</a></td>
+            <td><a href="{{view_url}}">{{name}}</a></td>
             <td>{{num_items}}</td>
             <td>
                 {{#if is_public }}


### PR DESCRIPTION
#### What?

In the **add-wishlist.html** file, there should be `{{{}}}` because we should not escape, but should display the data as it is and send it as a form to the server.
In the **wish-list.html** file, there should be `{{}}` to prevent an XSS attack.

#### Tickets / Documentation

- [BCTHEME-1072](https://jira.bigcommerce.com/browse/BCTHEME-1072)

