### PR TITLE
Remove translations for adminBar component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Remove translations for adminBar component [#2196](https://github.com/bigcommerce/cornerstone/issues/2196)
 - Remove adminBar. [#2191](https://github.com/bigcommerce/cornerstone/issues/2191)
 - When price list price is set for currency, the cart does not respect product's price.[#2190](https://github.com/bigcommerce/cornerstone/issues/2190)
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Ausfall wegen Wartungsarbeiten"
     },
-    "admin": {
-        "maintenance_header": "Ihr Online-Shop ist wegen Wartungsarbeiten nicht verfügbar.",
-        "maintenance_tooltip": "Zurzeit können nur Administratoren den Shop einsehen. Gehen Sie im Bedienpanel zur Einstellungsseite, um den Wartungsmodus zu deaktivieren.",
-        "maintenance_showstore_link": "Klicken Sie hier, um zu sehen, was Ihre Besucher sehen.",
-        "prelaunch_header": "Ihr Onlineshop ist nicht öffentlich. Geben Sie Ihre Website mit einem Vorschau-Code frei:",
-        "page_builder_link": "Diese Seite im Page Builder gestalten"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Gehen Sie zu Folie [SLIDE_NUMBER] von [SLIDES_QUANTITY].",
         "active_dot_aria_label": "Aktiv",

--- a/lang/es-419.json
+++ b/lang/es-419.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Fuera de servicio por mantenimiento"
     },
-    "admin": {
-        "maintenance_header": "Tu tienda está inactiva por mantenimiento.",
-        "maintenance_tooltip": "Solo los administradores pueden ver la tienda actualmente. Vaya a la página de configuración en su panel de control para desactivar el modo de mantenimiento.",
-        "maintenance_showstore_link": "Haz clic aquí para visualizar lo que verán tus visitantes.",
-        "prelaunch_header": "Tu escaparate es privado. Comparte tu sitio con un código de vista previa:",
-        "page_builder_link": "Diseñar esta página en Page Builder"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Ir a la diapositiva [SLIDE_NUMBER] de [SLIDES_QUANTITY].",
         "active_dot_aria_label": "activo",

--- a/lang/es-AR.json
+++ b/lang/es-AR.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Fuera de servicio por mantenimiento"
     },
-    "admin": {
-        "maintenance_header": "Tu tienda está inactiva por mantenimiento.",
-        "maintenance_tooltip": "Solo los administradores pueden ver la tienda actualmente. Vaya a la página de configuración en su panel de control para desactivar el modo de mantenimiento.",
-        "maintenance_showstore_link": "Haz clic aquí para visualizar lo que verán tus visitantes.",
-        "prelaunch_header": "Tu escaparate es privado. Comparte tu sitio con un código de vista previa:",
-        "page_builder_link": "Diseñar esta página en Page Builder"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Ir a la diapositiva [SLIDE_NUMBER] de [SLIDES_QUANTITY].",
         "active_dot_aria_label": "activo",

--- a/lang/es-CL.json
+++ b/lang/es-CL.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Fuera de servicio por mantenimiento"
     },
-    "admin": {
-        "maintenance_header": "Tu tienda está inactiva por mantenimiento.",
-        "maintenance_tooltip": "Solo los administradores pueden ver la tienda actualmente. Vaya a la página de configuración en su panel de control para desactivar el modo de mantenimiento.",
-        "maintenance_showstore_link": "Haz clic aquí para visualizar lo que verán tus visitantes.",
-        "prelaunch_header": "Tu escaparate es privado. Comparte tu sitio con un código de vista previa:",
-        "page_builder_link": "Diseñar esta página en Page Builder"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Ir a la diapositiva [SLIDE_NUMBER] de [SLIDES_QUANTITY].",
         "active_dot_aria_label": "activo",

--- a/lang/es-CO.json
+++ b/lang/es-CO.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Fuera de servicio por mantenimiento"
     },
-    "admin": {
-        "maintenance_header": "Tu tienda está inactiva por mantenimiento.",
-        "maintenance_tooltip": "Solo los administradores pueden ver la tienda actualmente. Vaya a la página de configuración en su panel de control para desactivar el modo de mantenimiento.",
-        "maintenance_showstore_link": "Haz clic aquí para visualizar lo que verán tus visitantes.",
-        "prelaunch_header": "Tu escaparate es privado. Comparte tu sitio con un código de vista previa:",
-        "page_builder_link": "Diseñar esta página en Page Builder"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Ir a la diapositiva [SLIDE_NUMBER] de [SLIDES_QUANTITY].",
         "active_dot_aria_label": "activo",

--- a/lang/es-LA.json
+++ b/lang/es-LA.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Fuera de servicio por mantenimiento"
     },
-    "admin": {
-        "maintenance_header": "Tu tienda está inactiva por mantenimiento.",
-        "maintenance_tooltip": "Solo los administradores pueden ver la tienda actualmente. Vaya a la página de configuración en su panel de control para desactivar el modo de mantenimiento.",
-        "maintenance_showstore_link": "Haz clic aquí para visualizar lo que verán tus visitantes.",
-        "prelaunch_header": "Tu escaparate es privado. Comparte tu sitio con un código de vista previa:",
-        "page_builder_link": "Diseñar esta página en Page Builder"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Ir a la diapositiva [SLIDE_NUMBER] de [SLIDES_QUANTITY].",
         "active_dot_aria_label": "activo",

--- a/lang/es-MX.json
+++ b/lang/es-MX.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Fuera de servicio por mantenimiento"
     },
-    "admin": {
-        "maintenance_header": "Tu tienda está inactiva por mantenimiento.",
-        "maintenance_tooltip": "Solo los administradores pueden ver la tienda actualmente. Vaya a la página de configuración en su panel de control para desactivar el modo de mantenimiento.",
-        "maintenance_showstore_link": "Haz clic aquí para visualizar lo que verán tus visitantes.",
-        "prelaunch_header": "Tu escaparate es privado. Comparte tu sitio con un código de vista previa:",
-        "page_builder_link": "Diseñar esta página en Page Builder"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Ir a la diapositiva [SLIDE_NUMBER] de [SLIDES_QUANTITY].",
         "active_dot_aria_label": "activo",

--- a/lang/es-PE.json
+++ b/lang/es-PE.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Fuera de servicio por mantenimiento"
     },
-    "admin": {
-        "maintenance_header": "Tu tienda está inactiva por mantenimiento.",
-        "maintenance_tooltip": "Solo los administradores pueden ver la tienda actualmente. Vaya a la página de configuración en su panel de control para desactivar el modo de mantenimiento.",
-        "maintenance_showstore_link": "Haz clic aquí para visualizar lo que verán tus visitantes.",
-        "prelaunch_header": "Tu escaparate es privado. Comparte tu sitio con un código de vista previa:",
-        "page_builder_link": "Diseñar esta página en Page Builder"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Ir a la diapositiva [SLIDE_NUMBER] de [SLIDES_QUANTITY].",
         "active_dot_aria_label": "activo",

--- a/lang/es.json
+++ b/lang/es.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Fuera de servicio por mantenimiento"
     },
-    "admin": {
-        "maintenance_header": "Su tienda está cerrada por mantenimiento.",
-        "maintenance_tooltip": "Solo los administradores pueden ver esta tienda en este momento. Vaya a la página de configuración para desactivar el modo de mantenimiento.",
-        "maintenance_showstore_link": "Haga clic aquí para ver lo que verán sus visitantes.",
-        "prelaunch_header": "Su tienda en línea es privada. Comparta su sitio con un código de vista previa:",
-        "page_builder_link": "Diseñar esta página en Page Builder"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Ir a la diapositiva [SLIDE_NUMBER] de [SLIDES_QUANTITY]",
         "active_dot_aria_label": "Activo",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "En maintenance"
     },
-    "admin": {
-        "maintenance_header": "Votre boutique est indisponible pour cause de maintenance.",
-        "maintenance_tooltip": "Pour l'instant, seuls les administrateurs peuvent accéder à la boutique. Visitez la page des paramètres de votre panneau de configuration pour désactiver le mode de maintenance.",
-        "maintenance_showstore_link": "Cliquez ici pour découvrir ce que vos visiteurs voient.",
-        "prelaunch_header": "Votre vitrine est privée. Partagez votre site avec un code d'aperçu :",
-        "page_builder_link": "Concevoir cette page dans Page Builder"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Aller à la diapositive [SLIDE_NUMBER] sur [SLIDES_QUANTITY]",
         "active_dot_aria_label": "Actif",

--- a/lang/it.json
+++ b/lang/it.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Inattivo per manutenzione"
     },
-    "admin": {
-        "maintenance_header": "Il tuo store è inattivo per manutenzione.",
-        "maintenance_tooltip": "Al momento solo gli amministratori possono visualizzare il negozio. Visita la pagina delle impostazioni del pannello di controllo per disattivare la modalità manutenzione.",
-        "maintenance_showstore_link": "Clicca qui per vedere cosa vedranno i tuoi visitatori.",
-        "prelaunch_header": "La tua vetrina è privata. Condividi il tuo sito con il codice di anteprima:",
-        "page_builder_link": "Progetta questa pagina con Page Builder"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Vai alla slide [SLIDE_NUMBER] di [SLIDES_QUANTITY]",
         "active_dot_aria_label": "attivo",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Offline voor onderhoud"
     },
-    "admin": {
-        "maintenance_header": "Uw winkel is offline voor onderhoud.",
-        "maintenance_tooltip": "Alleen beheerders kunnen de winkel op dit moment bekijken. Ga naar de instellingenpagina van het configuratiescherm om de onderhoudsmodus uit te schakelen.",
-        "maintenance_showstore_link": "Klik hier om te zien wat uw bezoekers zien.",
-        "prelaunch_header": "Uw winkelontwerp is privé. Deel uw site met voorbeeldcode:",
-        "page_builder_link": "Deze pagina in Page Builder ontwerpen"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Ga naar dia [SLIDE_NUMBER] van [SLIDES_QUANTITY]",
         "active_dot_aria_label": "actief",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Fora do ar para manutenção"
     },
-    "admin": {
-        "maintenance_header": "A sua loja está fora do ar para manutenção.",
-        "maintenance_tooltip": "Somente os administradores podem ver a loja no momento. Acesse a página de configurações do painel de controle para desativar o modo de manutenção.",
-        "maintenance_showstore_link": "Clique aqui para ver o que seus visitantes verão.",
-        "prelaunch_header": "Sua vitrine é privada. Compartilhe seu site com o código de prévia:",
-        "page_builder_link": "Fazer o design desta página no Page Builder"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Ir para o slide [SLIDE_NUMBER] de [SLIDES_QUANTITY]",
         "active_dot_aria_label": "Ativo",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Fora do ar para manutenção"
     },
-    "admin": {
-        "maintenance_header": "A sua loja está fora do ar para manutenção.",
-        "maintenance_tooltip": "Somente os administradores podem ver a loja no momento. Acesse a página de configurações do painel de controle para desativar o modo de manutenção.",
-        "maintenance_showstore_link": "Clique aqui para ver o que seus visitantes verão.",
-        "prelaunch_header": "Sua vitrine é privada. Compartilhe seu site com o código de prévia:",
-        "page_builder_link": "Fazer o design desta página no Page Builder"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Ir para o slide [SLIDE_NUMBER] de [SLIDES_QUANTITY]",
         "active_dot_aria_label": "Ativo",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Nere för underhåll"
     },
-    "admin": {
-        "maintenance_header": "Din butik ligger nere för underhåll.",
-        "maintenance_tooltip": "För närvarande kan endast administratörer visa butiken. Gå till sidan med inställningar i kontrollpanelen för att stänga av underhållsläget.",
-        "maintenance_showstore_link": "Klicka här för att se vad dina besökare kommer att se.",
-        "prelaunch_header": "Din butik är privat. Dela din webbplats med förhandsgranskningskod:",
-        "page_builder_link": "Designa den här sidan i Page Builder"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Gå till bild [SLIDE_NUMBER] av [SLIDES_QUANTITY]",
         "active_dot_aria_label": "Aktiv",


### PR DESCRIPTION
#### What?

#2191 left behind some translations that are triggering warnings.

```
Warning: file: /Users/matt/Work/master/creativesafetysupply.com/lang/en.json doesn't have admin.maintenance_header, which is present in /Users/matt/Work/master/creativesafetysupply.com/lang/de.json
Warning: file: /Users/matt/Work/master/creativesafetysupply.com/lang/en.json doesn't have admin.maintenance_tooltip, which is present in /Users/matt/Work/master/creativesafetysupply.com/lang/de.json
Warning: file: /Users/matt/Work/master/creativesafetysupply.com/lang/en.json doesn't have admin.maintenance_showstore_link, which is present in /Users/matt/Work/master/creativesafetysupply.com/lang/de.json
Warning: file: /Users/matt/Work/master/creativesafetysupply.com/lang/en.json doesn't have admin.prelaunch_header, which is present in /Users/matt/Work/master/creativesafetysupply.com/lang/de.json
Warning: file: /Users/matt/Work/master/creativesafetysupply.com/lang/en.json doesn't have admin.page_builder_link, which is present in /Users/matt/Work/master/creativesafetysupply.com/lang/de.json
```

#### Screenshots

**BEFORE**
<img width="1550" alt="01 before" src="https://user-images.githubusercontent.com/5056945/162554106-77de0ed7-ada8-4d14-9399-b28ca5e5815c.png">

**AFTER**
<img width="1550" alt="02 after" src="https://user-images.githubusercontent.com/5056945/162554105-f52e774e-c318-4f5b-80b5-b7c365f32fa9.png">