### PR TITLE
fix(storefront): BCTHEME-709 "Out of Stock" banner is duplicated and overlaps "Add to cart" button on PDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- "Out of Stock" banner is duplicated and overlaps "Add to cart" button on PDP.[#2198](https://github.com/bigcommerce/cornerstone/issues/2198)
 
 ## 6.4.0 (05-11-2022)
 - Remove adminBar translations from da/no lang files [#2209](https://github.com/bigcommerce/cornerstone/issues/2209)

--- a/templates/components/amp/products/product-view.html
+++ b/templates/components/amp/products/product-view.html
@@ -26,8 +26,8 @@
             {{/each}}
         </amp-carousel>
     </section>
-    <div class="productView-action">
-        {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
+    {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
+        <div class="productView-action">
             <amp-iframe height="400" width="250"
                 layout="responsive"
                 sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-top-navigation allow-modals"
@@ -35,15 +35,8 @@
                 src="{{product.amp_options_url}}">
                 <div class="button button--primary button--wide" overflow tabindex="0" role="button">Choose Options</div>
             </amp-iframe>
-        {{/or}}
-        {{#if product.out_of_stock}}
-            {{#if product.out_of_stock_message}}
-                {{>components/amp/common/alert-error product.out_of_stock_message}}
-            {{else}}
-                {{>components/amp/common/alert-error (lang 'products.sold_out')}}
-            {{/if}}
-        {{/if}}
-    </div>
+        </div>
+    {{/or}}
 
     <amp-accordion class="productAccordion-wrapper">
         {{#if product.description}}

--- a/templates/components/products/add-to-cart.html
+++ b/templates/components/products/add-to-cart.html
@@ -35,7 +35,7 @@
         </div>
     {{/if}}
 
-    <div class="alertBox productAttributes-message" style="display:none">
+    <div class="alertBox alertBox--error productAttributes-message" style="display:none">
         <div class="alertBox-column alertBox-icon">
             <icon glyph="ic-success" class="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"></path></svg></icon>
         </div>

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -249,13 +249,6 @@
                     </label>
                 </div>
                 {{> components/products/add-to-cart}}
-                {{#if product.out_of_stock}}
-                    {{#if product.out_of_stock_message}}
-                        {{> components/common/alert/alert-error product.out_of_stock_message}}
-                    {{else}}
-                        {{> components/common/alert/alert-error (lang 'products.sold_out')}}
-                    {{/if}}
-                {{/if}}
             </form>
             {{#if settings.show_wishlist}}
                 {{> components/common/wishlist-dropdown}}


### PR DESCRIPTION
#### What?

This PR removes the duplicate "Out of Stock" banner.

#### Tickets / Documentation

- [BCTHEME-709](https://bigcommercecloud.atlassian.net/browse/BCTHEME-709)

#### Screenshots (if appropriate)

<img width="1680" alt="before 709" src="https://user-images.githubusercontent.com/83779098/162747805-ea025d9d-6a44-40ed-b95f-307bf63bd07f.png">
<img width="1680" alt="after  709" src="https://user-images.githubusercontent.com/83779098/168783743-71825668-5b38-4ca1-881e-ee7b8dbe8b11.png">
<img width="1680" alt="before  AMP  709" src="https://user-images.githubusercontent.com/83779098/168784456-28c354dc-4fda-4d8c-9f1b-b230480b5ee5.png">
<img width="1680" alt="after  AMP  709" src="https://user-images.githubusercontent.com/83779098/168783860-60e361de-dcfa-4357-97ce-79187ee685d2.png">

