### PR TITLE
feat(orders): ORDERS-3932 Changes to allow pickup details to be displ…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove adminBar. [#2191](https://github.com/bigcommerce/cornerstone/issues/2191)
 - When price list price is set for currency, the cart does not respect product's price.[#2190](https://github.com/bigcommerce/cornerstone/issues/2190)
 - Stored Payment Methods form can be submitted without selecting a Country.[#2194](https://github.com/bigcommerce/cornerstone/issues/2194)
+- Show pickup details in storefront for BOPIS orders. [#2199](https://github.com/bigcommerce/cornerstone/pull/2199)
 
 ## 6.3.0 (03-11-2022)
 - Update blog component to use H1 tags on posts [#2179](https://github.com/bigcommerce/cornerstone/issues/2179)

--- a/lang/en.json
+++ b/lang/en.json
@@ -365,7 +365,13 @@
                 "actions": "Actions",
                 "reorder": "Reorder",
                 "return": "Return",
-                "print_invoice": "Print Invoice"
+                "pickup": "Pickup Details",
+                "pickup_method": "Pickup method",
+                "in_store_pickup": "In-store pickup",
+                "print_invoice": "Print Invoice",
+                "phone": "Phone",
+                "email": "Email",
+                "opening_hours": "Opening hours"
             },
             "downloads": {
                 "heading": "Order #{number} Downloads",

--- a/templates/pages/account/orders/details.html
+++ b/templates/pages/account/orders/details.html
@@ -63,6 +63,41 @@
                         <li>{{{ sanitize order.shipping_address.country}}}</li>
                     </ul>
                 </section>
+            {{/if}}
+            {{#if order.pickup_address}}
+            <section class="account-sidebar-block">
+                <h3 class="account-heading">{{lang 'account.orders.details.pickup'}}</h3>
+                {{#each order.pickup_address}}
+                <dl class="definitionList">
+                    <dt class="definitionList-key">{{lang 'account.orders.details.pickup_method'}}</dt>
+                    <dd class="definitionList-value">{{sanitize pickup_method_display_name}}</dd>
+                </dl>
+
+                <ul class="account-order-address">
+                    <li><b>{{{ sanitize location_name}}}</b></li>
+                    <li>{{{ sanitize location_line_1}}}</li>
+                    <li>{{{ sanitize location_line_2}}}</li>
+                    <li>{{{ sanitize location_city}}}, {{{ sanitize location_state}}}, {{{ sanitize location_zip}}}</li>
+                    <li>{{{ sanitize location_country_name}}}</li>
+                </ul>
+
+                <dl class="definitionList">
+                    {{#if location_phone}}
+                    <dt class="definitionList-key">{{lang 'account.orders.details.phone'}}</dt>
+                    <dd class="definitionList-value">{{{ sanitize location_phone}}}</dd>
+                    {{/if}}
+                    {{#if order.pickup_address.location_email}}
+                    <dt class="definitionList-key">{{lang 'account.orders.details.email'}}</dt>
+                    <dd class="definitionList-value">{{{ sanitize location_email}}}</dd>
+                    {{/if}}
+                </dl>
+
+                <ul class="account-order-address">
+                    <li><b>{{{ lang 'account.orders.details.opening_hours'}}}</b></li>
+                    <li>{{{ sanitize collection_time_description}}}</li>
+                </ul>
+                {{/each}}
+            </section>
             {{else}}
                 {{#if order.has_multiple_shipping_addresses}}
                     <section class="account-sidebar-block">


### PR DESCRIPTION
…ayed in storefront

#### What?

Added support for displaying shopper's  pickup data to be displayed in the Order Details page in Customer's Account Pages. 

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only) **PENDING

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [ORDERS-3932](https://jira.bigcommerce.com/browse/ORDERS-3932)
- [BCAPP PR](https://github.com/bigcommerce/bigcommerce/pull/45865)

#### Screenshots (if appropriate)

When a pick up order is placed, shopper can see pickup details in Accounts -> Order -> Order Details.

<img width="1355" alt="Screen Shot 2022-04-12 at 2 24 19 am" src="https://user-images.githubusercontent.com/92066753/162789408-8fee7552-2ccc-43bd-a7f7-f865fc25ac04.png">


