### PR TITLE
Bump GitHub Actions to use node 14

### DIFF
--- a/.github/workflow-examples/automatic_deployment_production.yml
+++ b/.github/workflow-examples/automatic_deployment_production.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [12.x]
+        node: [14.x]
 
     steps:
     - name: Checkout code

--- a/.github/workflow-examples/poll_for_changed_configuration.yml
+++ b/.github/workflow-examples/poll_for_changed_configuration.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [12.x]
+        node: [14.x]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [12.x]
+        node: [14.x]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
#### What?

Bump the GitHub Actions bundled with the theme to use node 14 to support latest CLI versions.
