### PR TITLE
Remove adminBar translations from da/no lang files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Remove adminBar translations from da/no lang files [#2209](https://github.com/bigcommerce/cornerstone/issues/2209)
 - Translation updates April 2022 [#2204](https://github.com/bigcommerce/cornerstone/issues/2204)
 - Product image not shown in Pinterest preview if not signed in.[#2203](https://github.com/bigcommerce/cornerstone/issues/2203)
 - Remove nanobar (loading progress bar). [#2192](https://github.com/bigcommerce/cornerstone/issues/2192)

--- a/lang/da.json
+++ b/lang/da.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Nede pga. vedligeholdelse"
     },
-    "admin": {
-        "maintenance_header": "Din butik er nede på grund af vedligeholdelse.",
-        "maintenance_tooltip": "Kun administratorer kan se butikken i øjeblikket. Besøg dit kontrolpanels indstillingsside for at deaktivere vedligeholdelsestilstand.",
-        "maintenance_showstore_link": "Klik her for at se, hvad dine besøgende vil se.",
-        "prelaunch_header": "Din butiksfacade er privat. Del dit websted med forhåndsvisningskode:",
-        "page_builder_link": "Design denne side i Page Builder"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Gå til dias [SLIDE_NUMBER] af [SLIDES_QUANTITY]",
         "active_dot_aria_label": "Aktiv",

--- a/lang/no.json
+++ b/lang/no.json
@@ -899,13 +899,6 @@
     "maintenance": {
         "down": "Nede for vedlikehold"
     },
-    "admin": {
-        "maintenance_header": "Butikken din er nede på grunn av vedlikehold.",
-        "maintenance_tooltip": "Bare administratorer kan se butikken for øyeblikket. Gå til siden for kontrollpanelinnstillinger for å deaktivere vedlikeholdsmodus.",
-        "maintenance_showstore_link": "Klikk her for å se hva de besøkende får se.",
-        "prelaunch_header": "Butikkfronten din er privat. Del nettstedet ditt med forhåndsvisningskode:",
-        "page_builder_link": "Design denne siden i Page Builder"
-    },
     "carousel": {
         "arrow_and_dot_aria_label": "Gå til lysbilde [SLIDE_NUMBER] av [SLIDES_QUANTITY]",
         "active_dot_aria_label": "Aktiv",


### PR DESCRIPTION
https://github.com/bigcommerce/cornerstone/pull/2204 

`da.json` and `no.json` language files have an object for the admin bar component no longer present in Cornerstone, which created some warnings when starting a local dev server.

![Screen Shot 2022-05-04 at 10 04 48 AM](https://user-images.githubusercontent.com/5056945/166741087-22d8d67d-ba76-44b2-91a0-7d7ff48df532.png)

