### PR TITLE
feat(bctheme): BCTHEME-1103  Add lang attribute to html tag in checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Add lang attribute to html tag to improve checkout accesibility [#2210]https://github.com/bigcommerce/cornerstone/pull/2210
 
 ## 6.4.0 (05-11-2022)
 - Remove adminBar translations from da/no lang files [#2209](https://github.com/bigcommerce/cornerstone/issues/2209)

--- a/templates/layout/empty.html
+++ b/templates/layout/empty.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ locale_name }}">
 <head>
     <title>{{ head.title }}</title>
     {{{ head.meta_tags }}}


### PR DESCRIPTION
#### What?

"The LANG tag (i.e. the lang="" attribute) is designed to signal screen readers pronunciation engines to switch to another language. For this reason [ tagging Web text as being in a particular language is required in WCAG 2.0 ]"(https://accessibility.psu.edu/foreignlanguages/langtaghtml/ )

#### Requirements

- ✅  CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [BCTHEME-1103](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1103)

#### Screenshots (if appropriate)

<img width="1369" alt="Screen Shot 2022-05-11 at 6 07 16 PM" src="https://user-images.githubusercontent.com/5630999/167961823-d8f1f71e-d08b-46e9-b1c6-3f79440680de.png">


<img width="1508" alt="Screen Shot 2022-05-11 at 5 30 02 PM" src="https://user-images.githubusercontent.com/5630999/167961617-73612603-634e-4c75-a61a-160c7b82ac1c.png">

