### PR TITLE
feat(payments): PAYPAL-1480 adding button settings to the page builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix "incorrect value type" for anonymous reviews in Google Search Console [#2255]https://github.com/bigcommerce/cornerstone/pull/2255
 - Reduce lodash usage [#2256]https://github.com/bigcommerce/cornerstone/pull/2256
 - Bump stencil utils to 6.12.1: fix broken add to cart button [#2259]https://github.com/bigcommerce/cornerstone/pull/2259
+- Add smart buttons attributes for various payment providers in Page builder [#2212]https://github.com/bigcommerce/cornerstone/pull/2212
 
 ## 6.5.0 (06-24-2022)
 - Category icons do not appear in Search Form [#2221]https://github.com/bigcommerce/cornerstone/pull/2221

--- a/config.json
+++ b/config.json
@@ -84,6 +84,7 @@
     "show_accept_klarna": false,
     "show_product_details_tabs": true,
     "show_product_reviews": true,
+    "show_quick_payment_buttons": false,
     "show_custom_fields_tabs": false,
     "show_product_weight": true,
     "show_product_dimensions": false,
@@ -356,7 +357,13 @@
     "checkout-paymentbuttons-paypal-color": "black",
     "checkout-paymentbuttons-paypal-shape": "rect",
     "checkout-paymentbuttons-paypal-size": "large",
-    "checkout-paymentbuttons-paypal-label": "pay"
+    "checkout-paymentbuttons-paypal-label": "pay",
+    "paymentbuttons-number-of-buttons": 1,
+    "googlepay-button-color": "black",
+    "afterpay-button-color": "black-mint",
+    "amazon-button-color": "Gold",
+    "masterpass-button-color": "black",
+    "paymentbuttons-provider-sorting": []
   },
   "read_only_files": [
     "/assets/scss/components/citadel",

--- a/schema.json
+++ b/schema.json
@@ -906,25 +906,6 @@
         "id": "show_accept_googlepay"
       },
       {
-        "type": "select",
-        "label": "i18n.ApplePayColor",
-        "id": "applePay-button",
-        "options": [
-          {
-            "value": "black",
-            "label": "i18n.BlackWhiteText"
-          },
-          {
-            "value": "white",
-            "label": "i18n.WhiteBlackText"
-          },
-          {
-            "value": "white-border",
-            "label": "i18n.WhiteBlackTextWithBorder"
-          }
-        ]
-      },
-      {
         "type": "checkbox",
         "label": "i18n.ShowKlarna",
         "force_reload": true,
@@ -1494,6 +1475,12 @@
         "type": "color",
         "label": "i18n.WishlistDropdownBackground",
         "id": "dropdown--wishList-backgroundColor"
+      },
+      {
+        "type": "checkbox",
+        "label": "i18n.ShowQuickPaymentButtons",
+        "force_reload": true,
+        "id": "show_quick_payment_buttons"
       },
       {
         "type": "heading",
@@ -2836,6 +2823,79 @@
       },
       {
         "type": "heading",
+        "content": "i18n.QuickPaymentButtons"
+      },
+      {
+        "type": "select",
+        "label": "i18n.NumberOfButtonsAlwaysVisible",
+        "force_reload": true,
+        "id": "paymentbuttons-number-of-buttons",
+        "options": [
+          {
+            "value": 1,
+            "label": "1"
+          },
+          {
+            "value": 2,
+            "label": "2"
+          }
+        ]
+      },
+      {
+        "type": "sort",
+        "label": "i18n.ProviderSortingOrderLabel",
+        "id": "paymentbuttons-provider-sorting",
+        "force_reload": true,
+        "options": [
+          {
+            "value": "paypal",
+            "label": "i18n.PayPalProviderSortingLabel",
+            "enabledBy": "paypal"
+          },
+          {
+            "value": "paypal-credit",
+            "label": "i18n.PayPalCreditProviderSortingLabel",
+            "enabledBy": "paypal-credit"
+          },
+          {
+            "value": "paypal-venmo",
+            "label": "i18n.PayPalVenmoProviderSortingLabel",
+            "enabledBy": "paypal-venmo"
+          },
+          {
+            "value": "sepa",
+            "label": "i18n.PayPalSepaProviderSortingLabel",
+            "enabledBy": "sepa"
+          },
+          {
+            "value": "googlepay",
+            "label": "i18n.GooglepayProviderSortingLabel",
+            "enabledBy": "googlepay"
+          },
+          {
+            "value": "applepay",
+            "label": "i18n.ApplepayProviderSortingLabel",
+            "enabledBy": "applepay"
+          },
+          {
+            "value": "afterpay",
+            "label": "i18n.AfterpayProviderSortingLabel",
+            "enabledBy": "afterpay"
+          },
+          {
+            "value": "amazonpay",
+            "label": "i18n.AmazonProviderSortingLabel",
+            "enabledBy": "amazonpay"
+          },
+          {
+            "value": "masterpass",
+            "label": "i18n.MasterpassProviderSortingLabel",
+            "enabledBy": "masterpass"
+          }
+        ]
+      },
+      {
+        "type": "heading",
         "content": "i18n.PaypalAcceleratedCheckoutButton",
         "enable": "payPalAcceleratedCheckoutEnabled"
       },
@@ -2895,12 +2955,14 @@
       },
       {
         "type": "heading",
-        "content": "i18n.SmartPaypalButton"
+        "content": "i18n.SmartPaypalButton",
+        "enable": "payPalProvidersEnabled"
       },
       {
         "type": "select",
         "label": "i18n.ButtonColor",
         "id": "paymentbuttons-paypal-color",
+        "enable": "payPalProvidersEnabled",
         "force_reload": true,
         "options": [
           {
@@ -2929,6 +2991,7 @@
         "type": "select",
         "label": "i18n.ButtonShape",
         "id": "paymentbuttons-paypal-shape",
+        "enable": "payPalProvidersEnabled",
         "force_reload": true,
         "options": [
           {
@@ -2945,6 +3008,7 @@
         "type": "select",
         "label": "i18n.ButtonContent",
         "id": "paymentbuttons-paypal-label",
+        "enable": "payPalProvidersEnabled",
         "force_reload": true,
         "options": [
           {
@@ -2969,6 +3033,7 @@
         "type": "select",
         "label": "i18n.DisplayStyle",
         "id": "paymentbuttons-paypal-layout",
+        "enable": "payPalProvidersEnabled",
         "force_reload": true,
         "options": [
           {
@@ -2983,12 +3048,14 @@
       },
       {
         "type": "heading",
-        "content": "i18n.CheckoutPayPalButton"
+        "content": "i18n.CheckoutPayPalButton",
+        "enable": "payPalProvidersEnabled"
       },
       {
         "type": "select",
         "label": "i18n.ButtonColor",
         "id": "checkout-paymentbuttons-paypal-color",
+        "enable": "payPalProvidersEnabled",
         "force_reload": true,
         "options": [
           {
@@ -3017,6 +3084,7 @@
         "type": "select",
         "label": "i18n.ButtonShape",
         "id": "checkout-paymentbuttons-paypal-shape",
+        "enable": "payPalProvidersEnabled",
         "force_reload": true,
         "options": [
           {
@@ -3033,6 +3101,7 @@
         "type": "select",
         "label": "i18n.ButtonSize",
         "id": "checkout-paymentbuttons-paypal-size",
+        "enable": "payPalProvidersEnabled",
         "force_reload": true,
         "options": [
           {
@@ -3053,6 +3122,7 @@
         "type": "select",
         "label": "i18n.ButtonContent",
         "id": "checkout-paymentbuttons-paypal-label",
+        "enable": "payPalProvidersEnabled",
         "force_reload": true,
         "options": [
           {
@@ -3070,6 +3140,127 @@
           {
             "value": "paypal",
             "label": "i18n.PayPal"
+          }
+        ]
+      },
+      {
+        "type": "heading",
+        "content": "i18n.GooglePaySettings",
+        "enable": "googleProvidersEnabled"
+      },
+      {
+        "type": "select",
+        "label": "i18n.ButtonColor",
+        "id": "googlepay-button-color",
+        "enable": "googleProvidersEnabled",
+        "options": [
+          {
+            "value": "black",
+            "label": "i18n.BlackWhiteText"
+          },
+          {
+            "value": "white",
+            "label": "i18n.WhiteBlackText"
+          }
+        ]
+      },
+      {
+        "type": "heading",
+        "content": "i18n.ApplePaySettings",
+        "enable": "appleProvidersEnabled"
+      },
+      {
+        "type": "select",
+        "label": "i18n.ButtonColor",
+        "id": "applePay-button",
+        "enable": "appleProvidersEnabled",
+        "options": [
+          {
+            "value": "black",
+            "label": "i18n.BlackWhiteText"
+          },
+          {
+            "value": "white",
+            "label": "i18n.WhiteBlackText"
+          },
+          {
+            "value": "white-border",
+            "label": "i18n.WhiteBlackTextWithBorder"
+          }
+        ]
+      },
+      {
+        "type": "heading",
+        "content": "i18n.AfterPaySettings",
+        "enable": "afterpayProvidersEnabled"
+      },
+      {
+        "type": "select",
+        "label": "i18n.ButtonColor",
+        "id": "afterpay-button-color",
+        "enable": "afterpayProvidersEnabled",
+        "options": [
+          {
+            "value": "black-mint",
+            "label": "i18n.BlackOnMintText"
+          },
+          {
+            "value": "mint-black",
+            "label": "i18n.MintOnBlackText"
+          },
+          {
+            "value": "white",
+            "label": "i18n.BlackWhiteText"
+          },
+          {
+            "value": "black",
+            "label": "i18n.WhiteBlackText"
+          }
+        ]
+      },
+      {
+        "type": "heading",
+        "content": "i18n.AmazonSettings",
+        "enable": "amazonProvidersEnabled"
+      },
+      {
+        "type": "select",
+        "label": "i18n.ButtonColor",
+        "id": "amazon-button-color",
+        "enable": "amazonProvidersEnabled",
+        "options": [
+          {
+            "value": "Gold",
+            "label": "i18n.Gold"
+          },
+          {
+            "value": "LightGray",
+            "label": "i18n.LightGray"
+          },
+          {
+            "value": "DarkGray",
+            "label": "i18n.DarkGray"
+          }
+        ]
+      },
+      {
+        "type": "heading",
+        "content": "i18n.MasterpassSettings",
+        "enable": "masterpassProvidersEnabled"
+      },
+      {
+        "type": "select",
+        "label": "i18n.ButtonColor",
+        "id": "masterpass-button-color",
+        "enable": "masterpassProvidersEnabled",
+        "options": [
+          {
+            "value": "black",
+            "label": "i18n.BlackWhiteText"
+          },
+          {
+            "value": "white",
+            "label": "i18n.WhiteBlackText"
           }
         ]
       }

--- a/schemaTranslations.json
+++ b/schemaTranslations.json
@@ -2103,24 +2103,6 @@
     "no": "Vis Google Pay",
     "ko": "Google Pay 표시"
   },
-  "i18n.ApplePayColor": {
-    "default": "Apple Pay color",
-    "fr": "Couleur Apple Pay",
-    "it": "Colore Apple Pay",
-    "uk": "Колір Apple Pay",
-    "zh": "Apple 支付颜色",
-    "de": "Apple Pay-Farbe",
-    "es": "Color de Apple Pay",
-    "nl": "Kleur Apple Pay",
-    "pt": "Cor do Apple Pay",
-    "sv": "Apple Pay-färg",
-    "es-MX": "Color de Apple Pay",
-    "pt-BR": "Cor do Apple Pay",
-    "es-419": "Color de Apple Pay",
-    "da": "Apple Pay-farve",
-    "no": "Apple Pay-farge",
-    "ko": "Apple Pay 색상"
-  },
   "i18n.BlackWhiteText": {
     "default": "Black (white text)",
     "fr": "Noir text blanc",
@@ -5032,20 +5014,20 @@
     "zh": "进行结算"
   },
   "i18n.SmartPaypalButton": {
-    "default": "Smart Paypal Button",
-    "de": "Smart Paypal-Schaltfläche",
-    "es": "Botón inteligente de PayPal",
-    "fr": "Bouton Paypal intelligent",
-    "it": "Pulsante PayPal Smart",
-    "nl": "Slimme Paypal-knop",
-    "pt": "Botão Smart Paypal",
-    "sv": "Smart PayPal-knapp",
-    "es-MX": "Botón inteligente de PayPal",
-    "pt-BR": "Botão Smart Paypal",
-    "es-419": "Botón inteligente de Paypal",
-    "da": "Smart PayPal-knap",
-    "no": "Smart PayPal-knapp",
-    "ko": "스마트 PayPal 버튼"
+    "default": "PayPal Button",
+    "de": "PayPal-Schaltfläche",
+    "es": "Botón de PayPal",
+    "fr": "Bouton Paypal",
+    "it": "Pulsante PayPal",
+    "nl": "PayPal-knop",
+    "pt": "Botão do PayPal",
+    "sv": "PayPal-knapp",
+    "es-MX": "Botón de PayPal",
+    "pt-BR": "Botão do PayPal",
+    "es-419": "Botón de PayPal",
+    "da": "PayPal-knap",
+    "no": "PayPal-knapp",
+    "ko": "PayPal 버튼"
   },
   "i18n.PayPalCheckout": {
     "default": "PayPal Checkout",
@@ -5152,20 +5134,20 @@
     "ko": "버튼을 세로로 정렬"
   },
   "i18n.CheckoutPayPalButton": {
-    "default": "Checkout PayPal Button",
-    "de": "PayPal-Schaltfläche für Bezahlvorgang",
-    "es": "Botón de pago con PayPal",
-    "fr": "Bouton PayPal Checkout",
-    "it": "Pulsante PayPal Checkout",
-    "nl": "Knop Afrekenen met PayPal",
-    "pt": "Botão de finalização de compra com o PayPal",
-    "sv": "Checkout PayPal-knapp",
-    "es-MX": "Botón de pago con PayPal",
-    "pt-BR": "Botão de finalização de compra com o PayPal",
-    "es-419": "Botón de pago de PayPal",
-    "da": "PayPal-betalingsknap",
-    "no": "Betal med PayPal-knapp",
-    "ko": "체크아웃 PayPal 버튼"
+    "default": "PayPal Button on checkout page",
+    "de": "PayPal-Button auf der Checkout-Seite",
+    "es": "Botón de PayPal en la página de pago",
+    "fr": "Bouton PayPal sur la page de paiement",
+    "it": "Pulsante PayPal nella pagina di pagamento",
+    "nl": "PayPal-knop op afrekenpagina",
+    "pt": "Botão do PayPal na página de checkout",
+    "sv": "PayPal-knapp på kassasidan",
+    "es-MX": "Botón de PayPal en la página de pago",
+    "pt-BR": "Botão do PayPal na página de checkout",
+    "es-419": "Botón de PayPal en la página de pago",
+    "da": "PayPal-knap på betalingssiden",
+    "no": "PayPal-knapp på betalingssiden",
+    "ko": "결제 페이지의 PayPal 버튼"
   },
   "i18n.ProductPageBanner": {
     "default": "Product page banner",
@@ -5542,5 +5524,71 @@
     "da": "Størrelse på knapbeholder",
     "no": "Størrelse på knappbeholder",
     "ko": "버튼 컨테이너 크기"
+  },
+  "i18n.AfterPaySettings": {
+    "default": "After Pay Button"
+  },
+  "i18n.ApplePaySettings": {
+    "default": "Apple Pay Button"
+  },
+  "i18n.BlackOnMintText": {
+    "default": "Black on Mint"
+  },
+  "i18n.MintOnBlackText": {
+    "default": "Mint on Black"
+  },
+  "i18n.AmazonSettings": {
+    "default": "Amazon Button"
+  },
+  "i18n.LightGray": {
+    "default": "Light Gray"
+  },
+  "i18n.DarkGray": {
+    "default": "Dark Gray"
+  },
+  "i18n.GooglePaySettings": {
+    "default": "Google Pay Button"
+  },
+  "i18n.MasterpassSettings": {
+    "default": "Masterpass Button"
+  },
+  "i18n.ShowQuickPaymentButtons": {
+    "default": "Show quick payment buttons"
+  },
+  "i18n.QuickPaymentButtons": {
+    "default": "Quick payment buttons on product page"
+  },
+  "i18n.NumberOfButtonsAlwaysVisible": {
+    "default": "Number of buttons always visible"
+  },
+  "i18n.ProviderSortingOrderLabel": {
+    "default": "Sort Order"
+  },
+  "i18n.PayPalProviderSortingLabel": {
+    "default": "PayPal"
+  },
+  "i18n.PayPalCreditProviderSortingLabel": {
+    "default": "Pay Later"
+  },
+  "i18n.PayPalVenmoProviderSortingLabel": {
+    "default": "Venmo"
+  },
+  "i18n.PayPalSepaProviderSortingLabel": {
+    "default": "SEPA"
+  },
+  "i18n.GooglepayProviderSortingLabel": {
+    "default": "Google Pay"
+  },
+  "i18n.ApplepayProviderSortingLabel": {
+    "default": "Apple Pay"
+  },
+  "i18n.AfterpayProviderSortingLabel": {
+    "default": "After Pay"
+  },
+  "i18n.AmazonProviderSortingLabel": {
+    "default": "Amazon Pay"
+  },
+  "i18n.MasterpassProviderSortingLabel": {
+    "default": "Masterpass"
   }
 }


### PR DESCRIPTION
#### What?
1) Added for `Products` checkbox `Show quick payment buttons`
2) Changed some translations
3) Added configuration for quick payment button sorting
4) Added subsections to show conditionally for the following groups of providers:

- PayPal PayLater
- PayPal APMs
- Google Pay
- Apple Pay
- Amazon Pay
- AfterPay
- Masterpass

#### Requirements

- related PR https://github.com/bigcommerce/bigcommerce/pull/46248 should be merged first

#### Tickets / Documentation
In scope of the Epic: https://bigcommercecloud.atlassian.net/browse/PROJECT-4529 - Wallet Payment Buttons on the Product Detailed Page

https://bigcommercecloud.atlassian.net/browse/PAYPAL-1345

#### Screenshots
<img width="603" alt="Screenshot 2022-09-09 at 14 04 09" src="https://user-images.githubusercontent.com/54856617/189337246-f7368588-6d15-4412-ae59-5672656de8d6.png">

<img width="422" alt="Screenshot 2022-09-09 at 14 01 06" src="https://user-images.githubusercontent.com/54856617/189337275-4ca2e8d9-5f47-4a54-89d6-0a3290661425.png">

## sorting before:
<img width="581" alt="Screenshot 2022-09-09 at 14 02 42" src="https://user-images.githubusercontent.com/54856617/189337363-f4e9aad1-1369-4730-b891-f1b7301305cc.png">

## sorting after:
<img width="605" alt="Screenshot 2022-09-09 at 14 03 44" src="https://user-images.githubusercontent.com/54856617/189337432-5f733c0b-d098-49f0-a7af-af5f446c82fd.png">


@bigcommerce/themes-team @bigcommerce/kyiv-payments-team 