### PR TITLE
fix(storefront): BCTHEME-1014 Blog Pages Do Not Include Link Rel Next/Prev Tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Blog Pages Do Not Include Link Rel Next/Prev Tags. [#2214](https://github.com/bigcommerce/cornerstone/issues/2214).
 
 ## 6.4.1 (05-16-2022)
 - Incorrect handling of unsuccessful item removing from cart on the Cart page. [#2211](https://github.com/bigcommerce/cornerstone/issues/2211)

--- a/templates/pages/blog.html
+++ b/templates/pages/blog.html
@@ -5,6 +5,15 @@ blog:
         pages: 3
         summary: 200
 ---
+{{#partial "head"}}
+    {{#if pagination.blog.previous}}
+        <link rel="prev" href="{{pagination.blog.previous}}">
+    {{/if}}
+    {{#if pagination.blog.next}}
+        <link rel="next" href="{{pagination.blog.next}}">
+    {{/if}}
+{{/partial}}
+
 {{#partial "page"}}
 
 {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}


### PR DESCRIPTION
#### What?

This PR adds Link Rel Next/Prev Tags to the blog page. 

The links of the `<link>` tag are not hyperlinks, they cannot be clicked, and the `<link>` element itself contains only attributes that indicate a link to some external document. They play a big role in promoting websites or blogs.

**Tickets / Documentation**

- [BCTHEME-1014](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1014)
