### PR TITLE
fix(storefront): BCTHEME-1110 Product Pick List "none" is not selected by default without images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Draft
 
+## Unreleased (unreleased)
+- Fixed "None" not being selected by default on unrequired Pick Lists without images [#2215](https://github.com/bigcommerce/cornerstone/pull/2215)
+
 ## 6.4.1 (05-16-2022)
 - Incorrect handling of unsuccessful item removing from cart on the Cart page. [#2211](https://github.com/bigcommerce/cornerstone/issues/2211)
 

--- a/templates/components/products/options/product-list.html
+++ b/templates/components/products/options/product-list.html
@@ -15,7 +15,7 @@
                            name="attribute[{{id}}]"
                            value=""
                            id="attribute_productlist_{{id}}_none"
-                           checked="{{#if defaultValue '==' ''}}checked{{/if}}">
+                           {{#unless defaultValue}}checked{{/unless}}>
                     <label class="form-label" for="attribute_productlist_{{id}}_none">{{lang 'products.none'}}</label>
                 </li>
             {{/unless}}
@@ -54,7 +54,7 @@
                name="attribute[{{id}}]"
                value="0"
                id="attribute_productlist_0_{{id}}"
-               {{#if defaultValue '==' 0}}checked{{/if}}>
+               {{#unless defaultValue}}checked{{/unless}}>
         <label class="form-label" for="attribute_productlist_0_{{id}}">{{lang 'products.none'}}</label>
         {{/unless}}
         {{#each values}}
@@ -64,7 +64,10 @@
                 name="attribute[{{../id}}]"
                 value="{{id}}"
                 id="attribute_productlist_{{../id}}_{{id}}"
-                {{#if selected}}checked{{/if}}
+                {{#if selected}}
+                    checked
+                    data-default
+                {{/if}}
                 {{#if ../required}}required{{/if}}>
             <label data-product-attribute-value="{{id}}" class="form-label" for="attribute_productlist_{{../id}}_{{id}}">{{label}}</label>
         {{/each}}


### PR DESCRIPTION
#### What?
When using a Product Pick List _without images_, the **None** option will not be selected by default if the option is unrequired.
![image](https://user-images.githubusercontent.com/19815878/169668143-868138da-9409-4f99-8a05-90eb68137a43.png)


#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [BCTHEME-1110](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1110)

#### Screenshots (if appropriate)

Proof of fix:
![image](https://user-images.githubusercontent.com/19815878/169668184-c36c14a5-318b-43a1-bca2-21054ff9d1d3.png)

