### PR TITLE
fix(storefront): BCTHEME-1092 Make screen reader say all errors then …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Draft
 - Bump webpack-bundle-analyzer [#2229]https://github.com/bigcommerce/cornerstone/pull/2229
+- Make screen reader say all errors then each error while tabbing. [#2230]https://github.com/bigcommerce/cornerstone/pull/2230
 
 ## 6.5.0 (06-24-2022)
 - Category icons do not appear in Search Form [#2221]https://github.com/bigcommerce/cornerstone/pull/2221

--- a/assets/js/theme/auth.js
+++ b/assets/js/theme/auth.js
@@ -111,7 +111,7 @@ export default class Auth extends PageManager {
         const validationModel = validation($createAccountForm, this.context);
         const createAccountValidator = nod({
             submit: `${this.formCreateSelector} input[type='submit']`,
-            tap: announceInputErrorMessage,
+            delay: 0,
         });
         const $stateElement = $('[data-field-type="State"]');
         const emailSelector = `${this.formCreateSelector} [data-field-type='EmailAddress']`;
@@ -170,15 +170,20 @@ export default class Auth extends PageManager {
             );
         }
 
-        $createAccountForm.on('submit', event => {
-            createAccountValidator.performCheck();
-
-            if (createAccountValidator.areAll('valid')) {
-                return;
-            }
-
-            event.preventDefault();
+        $createAccountForm.on('submit', (event) => {
+            this.submitAction(event, createAccountValidator);
         });
+    }
+
+    submitAction(event, validator) {
+        validator.performCheck();
+
+        if (validator.areAll('valid')) {
+            return;
+        }
+        event.preventDefault();
+        const earliestError = $('span.form-inlineMessage:first').prev('input');
+        earliestError.focus();
     }
 
     /**

--- a/templates/components/common/forms/checkbox.html
+++ b/templates/components/common/forms/checkbox.html
@@ -13,6 +13,8 @@
                    data-input
                    data-label="{{label}}"
                    class="form-checkbox"
+                   aria-labelledby="{{id}}"
+                   aria-live="polite"
                    {{#if checked}}checked{{/if}}
                    {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
             >

--- a/templates/components/common/forms/date.html
+++ b/templates/components/common/forms/date.html
@@ -13,6 +13,8 @@
                     data-label="month"
                     data-input
                     aria-required="{{required}}"
+                    aria-labelledby="{{id}}"
+                    aria-live="polite"
                     {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
             >
             {{> components/common/forms/date-options month isRequired=required}}
@@ -25,6 +27,8 @@
                     data-label="day"
                     data-input
                     aria-required="{{required}}"
+                    aria-labelledby="{{id}}"
+                    aria-live="polite"
                     {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
             >
             {{> components/common/forms/date-options day isRequired=required}}
@@ -37,6 +41,8 @@
                     data-label="year"
                     data-input
                     aria-required="{{required}}"
+                    aria-labelledby="{{id}}"
+                    aria-live="polite"
                     {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
             >
             {{> components/common/forms/date-options year isRequired=required}}

--- a/templates/components/common/forms/multiline.html
+++ b/templates/components/common/forms/multiline.html
@@ -9,6 +9,8 @@
               data-label="{{label}}"
               rows="{{rows}}"
               aria-required="{{required}}"
+              aria-labelledby="{{id}}"
+              aria-live="polite"
               data-input
               class="form-input"
               {{#if private_id}}data-field-type="{{private_id}}"{{/if}}

--- a/templates/components/common/forms/number.html
+++ b/templates/components/common/forms/number.html
@@ -14,6 +14,8 @@
            id="{{id}}_input"
            name="{{name}}"
            aria-required="{{required}}"
+           aria-labelledby="{{id}}"
+           aria-live="polite"
            {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
     >
 </div>

--- a/templates/components/common/forms/password.html
+++ b/templates/components/common/forms/password.html
@@ -12,6 +12,8 @@
            value="{{value}}"
            autocomplete="off"
            aria-required="{{required}}"
+           aria-labelledby="{{id}}"
+           aria-live="polite"
            {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
     >
 </div>

--- a/templates/components/common/forms/radio.html
+++ b/templates/components/common/forms/radio.html
@@ -15,6 +15,8 @@
                 data-label="{{label}}"
                 data-input
                 aria-required="{{required}}"
+                aria-labelledby="{{id}}"
+                aria-live="polite"
                 {{#if checked}}checked{{/if}}
                 {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
             >

--- a/templates/components/common/forms/select.html
+++ b/templates/components/common/forms/select.html
@@ -8,6 +8,8 @@
             data-label="{{label}}"
             data-input
             aria-required="{{required}}"
+            aria-labelledby="{{id}}"
+            aria-live="polite"
             name="{{name}}"
             {{#if private_id}} data-field-type="{{private_id}}" {{/if}}
     >

--- a/templates/components/common/forms/selectortext.html
+++ b/templates/components/common/forms/selectortext.html
@@ -9,6 +9,8 @@
                value="{{value}}"
                class="form-input"
                aria-required="{{required}}"
+               aria-labelledby="{{id}}"
+               aria-live="polite"
                data-label="{{label}}"
                data-input
         />
@@ -22,6 +24,8 @@
     <select name="{{name}}"
             class="form-select"
             aria-required="{{required}}"
+            aria-labelledby="{{id}}"
+            aria-live="polite"
             id="{{id}}_select"
             data-label="{{label}}"
             data-input

--- a/templates/components/common/forms/text.html
+++ b/templates/components/common/forms/text.html
@@ -9,6 +9,8 @@
            data-label="{{label}}"
            data-input
            aria-required="{{required}}"
+           aria-labelledby="{{id}}"
+           aria-live="polite"
            {{#if value}} value="{{value}}"{{/if}}
            {{#if maxlength}}maxlength="{{maxlength}}"{{/if}}
            {{#if placeholder}} placeholder="{{placeholder}}"{{/if}}


### PR DESCRIPTION
…each error while tabbing

Watching - https://github.com/bigcommerce/cornerstone/pull/2235 - before moving forward

#### What?

Currently screen readers do not read out the errors until after the second submission, this seems to be do to the error not being defined within 'announceInputErrorMessage' assets/js/theme/common/utils/form-utils.js:132 

So the role alert is not attached as expected. Once attached (after the second submission), the alert is too intrusive. The alerts interrupt each other causing the reading to not be audible.  

Also, once the user is tabbing through each input, it should remind them of the specific error for that input field. 

announceInputErrorMessage Does not seem to be firing as expected on any of the forms and should likely be replaced with different solution, but we will just replace it for the account signup for now; and remove it further from other forms on separate tickets. 

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [BCTHEME-1092](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1092)

#### Screenshots (if appropriate)

Before:

https://user-images.githubusercontent.com/5630999/176069042-13fea788-9ce6-4539-9bc1-a23a86649a05.mp4

https://user-images.githubusercontent.com/5630999/176070511-bbabfb7b-17b9-4b0b-8998-56035d7d013d.mp4

After:

https://user-images.githubusercontent.com/5630999/176071029-ed65e5be-7de4-4104-9f62-3b1e66b8da32.mp4


