### PR TITLE
Add global region at the bottom of the navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump webpack-bundle-analyzer [#2229]https://github.com/bigcommerce/cornerstone/pull/2229
 - Make screen reader say all errors then each error while tabbing. [#2230]https://github.com/bigcommerce/cornerstone/pull/2230
 - Clarify customer order pagination. [#2241]https://github.com/bigcommerce/cornerstone/pull/2241
+- Add global region below the navigation in the header [#2231](https://github.com/bigcommerce/cornerstone/pull/2231)
 
 ## 6.5.0 (06-24-2022)
 - Category icons do not appear in Search Form [#2221]https://github.com/bigcommerce/cornerstone/pull/2221

--- a/templates/components/common/header.html
+++ b/templates/components/common/header.html
@@ -28,6 +28,7 @@
     <div class="navPages-container" id="menu" data-menu>
         {{> components/common/navigation-menu}}
     </div>
+    {{{region name="header_navigation_bottom--global"}}}
 </header>
 {{{region name="header_bottom--global"}}}
 {{{region name="header_bottom"}}}


### PR DESCRIPTION
#### What?

Currently, it's not possible to add a widget to a global region within the header. The only available region is `header_bottom--global`. This is in the header template so is on all pages but is actually outside of the <header> element so may be styled differently resulting it feeling like it's below the header, not at the bottom of the header.

As an app developer, I would like to request at least one global region be added inside the header.

Happy for this to be a discussion on the best way to do this and it's appropriate to add further global regions too, e.g. top of this file as an alternative to banners.

#### Requirements

TBC

- [x] CHANGELOG.md entry added (required for code changes only)

