### PR TITLE
fix(storefront): BCTHEME-1094 Make screen reader say all errors on ac…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unable to navigate to home page from search results page after clicking Back button on browser. [#2238](https://github.com/bigcommerce/cornerstone/issues/2238)
 - Cannot Vault 16-digit Diners Club cards - creditcards module version is out of date [#2239](https://github.com/bigcommerce/cornerstone/issues/2239)
 - Incorrect translation key for Diners Club card type. [#2237](https://github.com/bigcommerce/cornerstone/issues/2237).
+- Make screen reader say error messages when editing customer account. [#2233](https://github.com/bigcommerce/cornerstone/pull/2233)
 - Bump webpack-bundle-analyzer [#2229]https://github.com/bigcommerce/cornerstone/pull/2229
 
 ## 6.5.0 (06-24-2022)

--- a/assets/js/theme/account.js
+++ b/assets/js/theme/account.js
@@ -318,7 +318,7 @@ export default class Account extends PageManager {
         const formEditSelector = 'form[data-edit-account-form]';
         const editValidator = nod({
             submit: '${formEditSelector} input[type="submit"]',
-            tap: announceInputErrorMessage,
+            delay: 0,
         });
         const emailSelector = `${formEditSelector} [data-field-type="EmailAddress"]`;
         const $emailElement = $(emailSelector);
@@ -396,6 +396,8 @@ export default class Account extends PageManager {
             }
 
             event.preventDefault();
+            const earliestError = $('span.form-inlineMessage:first').prev('input');
+            earliestError.focus();
         });
     }
 

--- a/templates/components/account/edit-account.html
+++ b/templates/components/account/edit-account.html
@@ -5,31 +5,31 @@
     {{inject 'currentPassword' (lang 'forms.validate.account.edit.password')}}
     <fieldset class="form-fieldset">
         <div class="form-row form-row--half">
-            <div class="form-field">
+            <div class="form-field" id="account_firstname_id">
                 <label class="form-label" for="account_firstname">
                     {{lang 'account.settings.first_name' }}
                     <small>{{lang 'common.required' }}</small>
                 </label>
-                <input type="text" class="form-input" name="account_firstname" id="account_firstname" value="{{forms.edit_account.first_name}}">
+                <input aria-labelledby="account_firstname_id" aria-live="polite" type="text" class="form-input" name="account_firstname" id="account_firstname" value="{{forms.edit_account.first_name}}">
             </div>
-            <div class="form-field">
+            <div class="form-field" id="account_lastname_id">
                 <label class="form-label" for="account_lastname">
                     {{lang 'account.settings.last_name' }}
                     <small>{{lang 'common.required' }}</small>
                 </label>
-                <input type="text" class="form-input" name="account_lastname" id="account_lastname" value="{{forms.edit_account.last_name}}">
+                <input aria-labelledby="account_lastname_id" aria-live="polite" type="text" class="form-input" name="account_lastname" id="account_lastname" value="{{forms.edit_account.last_name}}">
             </div>
-            <div class="form-field">
+            <div class="form-field" id="account_companyname_id">
                 <label class="form-label" for="account_companyname">
                     {{lang 'account.settings.company' }}
                 </label>
-                <input type="text" class="form-input" name="account_companyname" id="account_companyname" value="{{forms.edit_account.company_name}}">
+                <input aria-labelledby="account_companyname_id" aria-live="polite" type="text" class="form-input" name="account_companyname" id="account_companyname" value="{{forms.edit_account.company_name}}">
             </div>
-            <div class="form-field">
+            <div class="form-field" id="account_phone_id">
                 <label class="form-label" for="account_phone">
                     {{lang 'account.settings.phone' }}
                 </label>
-                <input type="text" class="form-input" name="account_phone" id="account_phone" value="{{forms.edit_account.phone}}">
+                <input aria-labelledby="account_phone_id" aria-live="polite" type="text" class="form-input" name="account_phone" id="account_phone" value="{{forms.edit_account.phone}}">
             </div>
             {{#each forms.edit_account.fields}}
                 {{{dynamicComponent 'components/common/forms'}}}

--- a/templates/components/common/forms/password.html
+++ b/templates/components/common/forms/password.html
@@ -12,6 +12,8 @@
            value="{{value}}"
            autocomplete="off"
            aria-required="{{required}}"
+           aria-labelledby="{{id}}"
+           aria-live="polite"
            {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
     >
 </div>


### PR DESCRIPTION
…count edit page

Watching - https://github.com/bigcommerce/cornerstone/pull/2235 - before moving forward

#### What?

Makes screen reader read error messages when submitting customer edit account page

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

https://bigcommercecloud.atlassian.net/browse/BCTHEME-1094 

#### Screenshots (if appropriate)

BEFORE

https://user-images.githubusercontent.com/5630999/178366694-194650fa-4cb4-464f-8ee8-7c2ed63c2451.mp4

AFTER

https://user-images.githubusercontent.com/5630999/178366719-4154b1a8-f7be-4fa2-a5d8-8f88624ec1b4.mp4


