### PR TITLE
fix(storefront): BCTHEME-1093 Make screen reader say all errors on me…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cannot Vault 16-digit Diners Club cards - creditcards module version is out of date [#2239](https://github.com/bigcommerce/cornerstone/issues/2239)
 - Incorrect translation key for Diners Club card type. [#2237](https://github.com/bigcommerce/cornerstone/issues/2237).
 - Make screen reader say error messages when editing customer account. [#2233](https://github.com/bigcommerce/cornerstone/pull/2233)
+- On customer message page, screen reader should say each error [#2234]https://github.com/bigcommerce/cornerstone/pull/2234
 - Bump webpack-bundle-analyzer [#2229]https://github.com/bigcommerce/cornerstone/pull/2229
 - Make screen reader say all errors then each error while tabbing. [#2230]https://github.com/bigcommerce/cornerstone/pull/2230
 

--- a/assets/js/theme/account.js
+++ b/assets/js/theme/account.js
@@ -404,7 +404,7 @@ export default class Account extends PageManager {
     registerInboxValidation($inboxForm) {
         const inboxValidator = nod({
             submit: 'form[data-inbox-form] input[type="submit"]',
-            tap: announceInputErrorMessage,
+            delay: 0,
         });
 
         inboxValidator.add([
@@ -445,6 +445,8 @@ export default class Account extends PageManager {
             }
 
             event.preventDefault();
+            const earliestError = $('span.form-inlineMessage:first').prev('input');
+            earliestError.focus();
         });
     }
 }

--- a/templates/components/account/messages-form.html
+++ b/templates/components/account/messages-form.html
@@ -15,20 +15,20 @@
                 {{/each}}
             </select>
         </div>
-        <div class="form-field">
+        <div class="form-field" id="message_subject_field_id">
             <label class="form-label" for="message_subject">
                 {{lang 'forms.inbox.subject' }}
                 <small>{{lang 'common.required' }}</small>
             </label>
-            <input type="text" class="form-input" name="message_subject" id="message_subject">
+            <input aria-labelledby="message_subject_field_id" aria-live="polite" type="text" class="form-input" name="message_subject" id="message_subject">
         </div>
-        <div class="form-field">
+        <div class="form-field" id="message_content_field_id">
             <label class="form-label" for="message_content">
                 {{lang 'forms.inbox.message' }}
                 <small>{{lang 'common.required' }}</small>
             </label>
 
-            <textarea class="form-input" name="message_content" id="message_content" rows="7" ></textarea>
+            <textarea aria-labelledby="message_content_field_id" aria-live="polite" class="form-input" name="message_content" id="message_content" rows="7" ></textarea>
         </div>
         <div class="form-actions">
             <input class="button button--primary" type="submit" value="{{lang 'forms.inbox.submit_value' }}">


### PR DESCRIPTION
…ssage page

Watching - https://github.com/bigcommerce/cornerstone/pull/2235 - before moving forward

#### What?

When submitting the message form, each error should be read by the screen reader and again if tabbing back to the field. 

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- https://bigcommercecloud.atlassian.net/browse/BCTHEME-1093 

#### Screenshots (if appropriate)

Before - notice the messages are read too quickly at 0:09-0:11

https://user-images.githubusercontent.com/5630999/178400435-1e416eb8-304a-41b9-9173-a0c47aca28cd.mp4

After

https://user-images.githubusercontent.com/5630999/178400461-577bfd98-8eda-46c0-ab00-bf5d73c1328f.mp4

https://user-images.githubusercontent.com/5630999/178400464-8269dab3-a1f0-49c3-a2c2-a4967ade8ff4.mp4

