### PR TITLE
fix(storefront): BCTHEME-1077 clarify customer order pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On customer message page, screen reader should say each error [#2234]https://github.com/bigcommerce/cornerstone/pull/2234
 - Bump webpack-bundle-analyzer [#2229]https://github.com/bigcommerce/cornerstone/pull/2229
 - Make screen reader say all errors then each error while tabbing. [#2230]https://github.com/bigcommerce/cornerstone/pull/2230
+- Clarify customer order pagination. [#2241]https://github.com/bigcommerce/cornerstone/pull/2241
 
 ## 6.5.0 (06-24-2022)
 - Category icons do not appear in Search Form [#2221]https://github.com/bigcommerce/cornerstone/pull/2221

--- a/templates/components/common/small-paginator.html
+++ b/templates/components/common/small-paginator.html
@@ -14,9 +14,11 @@
         {{/if}}
 
         {{#if this.links.length}}
-            <li class="pagination-item">{{lang 'common.paginator.page_of' current=this.current total=this.links.length}}</li>
-        {{else}}
-            <li class="pagination-item">{{lang 'common.paginator.page_of' current=1 total=1}}</li>
+        {{#each this.links}}
+            <a class="pagination-link" href="{{this.link}}">
+                <li class="pagination-item">{{this.number}}</li>
+            </a>
+        {{/each}}
         {{/if}}
 
         {{#if next}}


### PR DESCRIPTION
#### What?

The pagination enumeration text at the bottom of the customer account orders page displays innacurately once there are 7 or more pages of orders. This is because the pagination.links does not always return the total list of pages which is expected, so we cannot rely on the length of that array as indicator for the total pages. Instead we will return a horizontal list of page numbers which are links to the corresponding page of orders. 

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [BCTHEME-1077](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1077?filter=-3)

#### Screenshots (if appropriate)

Before: Notice the unexpected page count behavior

https://user-images.githubusercontent.com/5630999/181863853-8dfc2673-189f-41d8-8849-b16abd58f167.mp4

After: More control and clarity for the user

https://user-images.githubusercontent.com/5630999/181863874-48d6db87-d003-4410-946e-ac8ad94a3922.mp4


