### PR TITLE
fix(storefront): BCTHEME-1185 fixed escaping on created store account confirm message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump webpack-bundle-analyzer [#2229]https://github.com/bigcommerce/cornerstone/pull/2229
 - Make screen reader say all errors then each error while tabbing. [#2230]https://github.com/bigcommerce/cornerstone/pull/2230
 - Clarify customer order pagination. [#2241]https://github.com/bigcommerce/cornerstone/pull/2241
+- Fixed escaping on created store account confirm message. [#2248]https://github.com/bigcommerce/cornerstone/pull/2248
 
 ## 6.5.0 (06-24-2022)
 - Category icons do not appear in Search Form [#2221]https://github.com/bigcommerce/cornerstone/pull/2221

--- a/templates/pages/auth/account-created.html
+++ b/templates/pages/auth/account-created.html
@@ -2,7 +2,7 @@
     <section class="page">
         <div class="page-content page-content--textCenter">
             <h1 class="page-heading">{{lang 'create_account.created.heading'}}</h1>
-            <p>{{{lang 'create_account.created.intro' store_name=settings.store_name email=customer.email}}}</p>
+            <p>{{lang 'create_account.created.intro' store_name=settings.store_name email=customer.email}}</p>
             <a class="button button--primary" href="{{create_account.continue_url}}">{{lang 'create_account.created.continue'}}</a>
         </div>
     </section>


### PR DESCRIPTION
#### What?

This PR fixed escaping on created store account confirm message

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

[BCTHEME-1185](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1185)
