### PR TITLE
Bump jQuery to 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add global region below the navigation in the header [#2231](https://github.com/bigcommerce/cornerstone/pull/2231)
 - Fixed escaping on created store account confirm message. [#2248]https://github.com/bigcommerce/cornerstone/pull/2248
 - Pass theme settings from blog page to blog post template. [#2253]https://github.com/bigcommerce/cornerstone/pull/2253
+- Bump jQuery to 3.6.1. [#2250](https://github.com/bigcommerce/cornerstone/issues/2250)
 
 ## 6.5.0 (06-24-2022)
 - Category icons do not appear in Search Form [#2221]https://github.com/bigcommerce/cornerstone/pull/2221

--- a/package-lock.json
+++ b/package-lock.json
@@ -11431,9 +11431,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
+      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw=="
     },
     "js-beautify": {
       "version": "1.13.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "focus-within-polyfill": "^5.1.0",
     "formdata-polyfill": "^3.0.20",
     "foundation-sites": "^5.5.3",
-    "jquery": "^3.5.1",
+    "jquery": "^3.6.1",
     "jstree": "^3.3.12",
     "lazysizes": "5.2.2",
     "lodash": "^4.17.21",


### PR DESCRIPTION
#### What?

- Fixes to focus
- A performance boost for $.trim

#### Tickets / Documentation

https://blog.jquery.com/2021/03/02/jquery-3-6-0-released/
https://blog.jquery.com/2022/08/26/jquery-3-6-1-maintenance-release/
https://github.com/jquery/jquery/pull/5068


#### Screenshots (if appropriate)

![Screen Shot 2022-08-30 at 8 01 02 AM](https://user-images.githubusercontent.com/5056945/187472660-7d9569cd-df73-4a44-88d9-4916c7bf7ebd.png)
