### PR TITLE
Reduce lodash usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add global region below the navigation in the header [#2231](https://github.com/bigcommerce/cornerstone/pull/2231)
 - Fixed escaping on created store account confirm message. [#2248]https://github.com/bigcommerce/cornerstone/pull/2248
 - Pass theme settings from blog page to blog post template. [#2253]https://github.com/bigcommerce/cornerstone/pull/2253
+- Reduce lodash usage [#2256]https://github.com/bigcommerce/cornerstone/pull/2256
 
 ## 6.5.0 (06-24-2022)
 - Category icons do not appear in Search Form [#2221]https://github.com/bigcommerce/cornerstone/pull/2221

--- a/assets/js/theme/common/faceted-search.js
+++ b/assets/js/theme/common/faceted-search.js
@@ -156,7 +156,7 @@ class FacetedSearch {
         const id = $navList.attr('id');
 
         // Toggle depending on `collapsed` flag
-        if (_.includes(this.collapsedFacetItems, id)) {
+        if (this.collapsedFacetItems.includes(id)) {
             this.getMoreFacetResults($navList);
 
             return true;
@@ -266,7 +266,7 @@ class FacetedSearch {
         $navLists.each((index, navList) => {
             const $navList = $(navList);
             const id = $navList.attr('id');
-            const shouldCollapse = _.includes(this.collapsedFacetItems, id);
+            const shouldCollapse = this.collapsedFacetItems.includes(id);
 
             if (shouldCollapse) {
                 this.collapseFacetItems($navList);
@@ -283,7 +283,7 @@ class FacetedSearch {
             const $accordionToggle = $(accordionToggle);
             const collapsible = $accordionToggle.data('collapsibleInstance');
             const id = collapsible.targetId;
-            const shouldCollapse = _.includes(this.collapsedFacets, id);
+            const shouldCollapse = this.collapsedFacets.includes(id);
 
             if (shouldCollapse) {
                 this.collapseFacet($accordionToggle);

--- a/assets/js/theme/common/nod-functions/min-max-validate.js
+++ b/assets/js/theme/common/nod-functions/min-max-validate.js
@@ -1,11 +1,9 @@
-import _ from 'lodash';
-
 function minMaxValidate(minInputSelector, maxInputSelector) {
     function validate(cb) {
         const minValue = parseFloat($(minInputSelector).val());
         const maxValue = parseFloat($(maxInputSelector).val());
 
-        if (maxValue > minValue || _.isNaN(maxValue) || _.isNaN(minValue)) {
+        if (maxValue > minValue || Number.isNaN(maxValue) || Number.isNaN(minValue)) {
             return cb(true);
         }
 

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -1,6 +1,5 @@
 import Wishlist from '../wishlist';
 import { initRadioOptions } from './aria';
-import { isObject, isNumber } from 'lodash';
 
 const optionsTypesMap = {
     INPUT_FILE: 'input-file',
@@ -214,11 +213,11 @@ export default class ProductDetailsBase {
 
         this.showMessageBox(data.stock_message || data.purchasing_message);
 
-        if (isObject(data.price)) {
+        if (data.price instanceof Object) {
             this.updatePriceView(viewModel, data.price);
         }
 
-        if (isObject(data.weight)) {
+        if (data.weight instanceof Object) {
             viewModel.$weight.html(data.weight.formatted);
         }
 
@@ -246,7 +245,7 @@ export default class ProductDetailsBase {
         }
 
         // if stock view is on (CP settings)
-        if (viewModel.stock.$container.length && isNumber(data.stock)) {
+        if (viewModel.stock.$container.length && typeof data.stock === 'number') {
             // if the stock container is hidden, show
             viewModel.stock.$container.removeClass('u-hiddenVisually');
 

--- a/assets/js/theme/common/state-country.js
+++ b/assets/js/theme/common/state-country.js
@@ -86,7 +86,7 @@ function addOptions(statesArray, $selectElement, options) {
     container.push(`<option value="">${statesArray.prefix}</option>`);
 
     if (!_.isEmpty($selectElement)) {
-        _.each(statesArray.states, (stateObj) => {
+        statesArray.states.forEach((stateObj) => {
             if (options.useIdForStates) {
                 container.push(`<option value="${stateObj.id}">${stateObj.name}</option>`);
             } else {

--- a/assets/js/theme/common/utils/form-utils.js
+++ b/assets/js/theme/common/utils/form-utils.js
@@ -41,7 +41,7 @@ function classifyInput(input, formFieldClass) {
     if (tagName === 'input') {
         const inputType = $input.prop('type');
 
-        if (_.includes(['radio', 'checkbox', 'submit'], inputType)) {
+        if (['radio', 'checkbox', 'submit'].includes(inputType)) {
             // ie: .form-field--checkbox, .form-field--radio
             className = `${formFieldClass}--${_.camelCase(inputType)}`;
         } else {


### PR DESCRIPTION
#### What?

To help reduce the size of the bundle, I've removed the usage of `each`, `includes`, `isNaN`, `isNumber`, and `isObject`.

- assets/js/theme/common/faceted-search.js - `includes`
- assets/js/theme/common/product-details-base.js - `isObject` and `isNumber`
- assets/js/theme/common/state-country.js - `each`
- assets/js/theme/common/nod-functions/min-max-validate.js - `isNaN`
- assets/js/theme/common/utils/form-utils.js - `includes`

#### Links

https://github.com/bigcommerce/cornerstone/issues/2163#issuecomment-1021373765
https://youmightnotneed.com/lodash

#### Screenshots

**BEFORE**
<img width="1552" alt="Screen Shot 2022-09-05 at 7 55 25 PM" src="https://user-images.githubusercontent.com/5056945/188537457-2a8b5c10-4729-4573-b245-0bf185b8e272.png">


**AFTER**
<img width="1552" alt="Screen Shot 2022-09-05 at 7 54 40 PM" src="https://user-images.githubusercontent.com/5056945/188537436-84e72c1c-0fc1-4534-b712-14ad2180dfe0.png">
