### PR TITLE
feat(payment): PAYPAL-1474 added data attribute for 'Check out' buttons and add…

### DIFF
--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -535,14 +535,15 @@ $card-preview-zoom-bottom-offset:       6rem;
     }
 }
 
-.cart-additionalCheckoutButtons {
-    @extend %additionalCheckoutButtons;
+.cart-acceleratedCheckoutButtons {
+    align-items: end;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
 }
 
-.previewCart-additionalCheckoutButtons {
+.cart-additionalCheckoutButtons {
     @extend %additionalCheckoutButtons;
-    padding-bottom: spacing("single");
-    padding-right: spacing("single");
 }
 
 // Cart Preview
@@ -678,4 +679,14 @@ $card-preview-zoom-bottom-offset:       6rem;
 .previewCart-emptyBody {
     padding: spacing("double");
     text-align: center;
+}
+
+.previewCart-acceleratedCheckoutButtons {
+    width: 100%;
+}
+
+.previewCart-additionalCheckoutButtons {
+    @extend %additionalCheckoutButtons;
+    padding-bottom: spacing("single");
+    padding-right: spacing("single");
 }

--- a/templates/components/common/cart-preview.html
+++ b/templates/components/common/cart-preview.html
@@ -47,9 +47,16 @@
                 {{/each}}
             </ul>
             <div class="previewCartAction">
+                {{#if cart.additional_checkout_buttons}}
+                    <div data-cart-accelerated-checkout-buttons class="previewCart-acceleratedCheckoutButtons"></div>
+                {{/if}}
                 {{#if cart.show_primary_checkout_button}}
                     <div class="previewCartAction-checkout">
-                        <a href="{{urls.checkout.single_address}}" class="button button--small button--primary">
+                        <a
+                                href="{{urls.checkout.single_address}}"
+                                class="button button--small button--primary"
+                                data-primary-checkout-now-action
+                        >
                             {{lang 'cart.preview.checkout_now'}}
                         </a>
                     </div>

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -28,9 +28,20 @@ cart: true
 
             {{{region name="cart_below_totals"}}}
 
+            {{#if cart.additional_checkout_buttons}}
+                <div data-cart-accelerated-checkout-buttons class="cart-acceleratedCheckoutButtons cart-content-padding-right"></div>
+            {{/if}}
+
             {{#if cart.show_primary_checkout_button}}
                 <div class="cart-actions cart-content-padding-right">
-                    <a class="button button--primary" href="{{urls.checkout.single_address}}" title="{{lang 'cart.checkout.title'}}">{{lang 'cart.checkout.button'}}</a>
+                    <a
+                            class="button button--primary"
+                            href="{{urls.checkout.single_address}}"
+                            title="{{lang 'cart.checkout.title'}}"
+                            data-primary-checkout-now-action
+                    >
+                        {{lang 'cart.checkout.button'}}
+                    </a>
                     {{#if cart.show_multiple_address_shipping}}
                         <a class="checkoutMultiple" href="{{urls.checkout.multiple_address}}">
                             {{lang 'cart.preview.checkout_multiple'}}
@@ -43,9 +54,11 @@ cart: true
                 </div>
             {{/if}}
 
-            <div data-cart-additional-checkout-buttons class="cart-additionalCheckoutButtons cart-content-padding-right">
-                {{> components/cart/additional-checkout-buttons}}
-            </div>
+            {{#if cart.additional_checkout_buttons}}
+                <div data-cart-additional-checkout-buttons class="cart-additionalCheckoutButtons cart-content-padding-right">
+                    {{> components/cart/additional-checkout-buttons}}
+                </div>
+            {{/if}}
 
         {{else}}
             <h3 tabindex="0">{{lang 'cart.checkout.empty_cart'}}</h3>


### PR DESCRIPTION
…ed extra container to render Accelerated Checkout in

#### What?

Added some changes to make PayPal Inline Checkout button replace the primary 'Check out' button on cart page

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation
- [PAYPAL-1474](https://bigcommercecloud.atlassian.net/browse/PAYPAL-1474)

#### Screenshots
<img width="1137" alt="Screenshot 2022-09-06 at 12 24 01" src="https://user-images.githubusercontent.com/25133454/188623573-1f78df89-63a3-4d55-8384-8c55ffb4a9cc.png">
<img width="303" alt="Screenshot 2022-09-06 at 12 24 13" src="https://user-images.githubusercontent.com/25133454/188623594-315f664c-928e-4df0-a441-87521a9d1a92.png">

