### PR TITLE
fix(storefront): STRF-10066 Fix broken add to cart button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump jQuery to 3.6.1. [#2250](https://github.com/bigcommerce/cornerstone/issues/2250)
 - Fix "incorrect value type" for anonymous reviews in Google Search Console [#2255]https://github.com/bigcommerce/cornerstone/pull/2255
 - Reduce lodash usage [#2256]https://github.com/bigcommerce/cornerstone/pull/2256
+- Bump stencil utils to 6.12.1: fix broken add to cart button [#2259]https://github.com/bigcommerce/cornerstone/pull/2259
 
 ## 6.5.0 (06-24-2022)
 - Category icons do not appear in Search Form [#2221]https://github.com/bigcommerce/cornerstone/pull/2221

--- a/package-lock.json
+++ b/package-lock.json
@@ -1065,9 +1065,9 @@
       "dev": true
     },
     "@bigcommerce/stencil-utils": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-6.12.0.tgz",
-      "integrity": "sha512-pOoKdYHG+7ORlSkAhCzIOFmvf/OVw4ApDCLP5f41oSj0bM7MRowIFz72ytNpe3gBE7Imvcc3WjYHlfgu+EGNyg==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-6.12.1.tgz",
+      "integrity": "sha512-Kk9eW72feq2uCknOaqBxu0GQOOVya4Kzoy1r8N2P9D7AHUMASwAXJp4C+3u52GXUteiH5JcAB1DGoDE2msH2aA==",
       "requires": {
         "eventemitter3": "^4.0.4",
         "whatwg-fetch": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "BigCommerce",
   "license": "MIT",
   "dependencies": {
-    "@bigcommerce/stencil-utils": "^6.12.0",
+    "@bigcommerce/stencil-utils": "6.12.1",
     "core-js": "^3.9.0",
     "creditcards": "^4.2.0",
     "easyzoom": "^2.5.3",


### PR DESCRIPTION
#### What?

Bump stencil utils with fixed to broken add to cart and remove from cart ajax calls

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [STRF-10066](https://bigcommercecloud.atlassian.net/browse/STRF-10066)

#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/68893868/189340865-283ee913-0b83-4f0b-9fa7-89fbe2d1b448.mov


