### PR TITLE
Update key assets with preload headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add logic to collect Product Details data and send it to the BC App stencil template through custom event [#2270](https://github.com/bigcommerce/cornerstone/pull/2270)
 - Allow quantity of "0" in cart to remove item [#2266](https://github.com/bigcommerce/cornerstone/pull/2266)
 - Fix the issue with getting product details data if the product details form is valid on page load [#2271](https://github.com/bigcommerce/cornerstone/pull/2271)
+- - Update key render-blocking resources to be preloaded via HTTP headers/Early Hints [#2261](https://github.com/bigcommerce/cornerstone/pull/2261)
+
 
 ## 6.6.1 (09-14-2022)
 

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -24,12 +24,11 @@
             window.lazySizesConfig = window.lazySizesConfig || {};
             window.lazySizesConfig.loadMode = 1;
         </script>
-        <script async src="{{cdn 'assets/dist/theme-bundle.head_async.js'}}"></script>
+        <script async src="{{cdn 'assets/dist/theme-bundle.head_async.js' resourceHint='preload' as='script'}}"></script>
         
         {{getFontsCollection font-display='block'}}
         
-        <link rel="preload" href="{{cdn 'assets/dist/theme-bundle.font.js'}}" as="script">
-        <script async src="{{cdn 'assets/dist/theme-bundle.font.js'}}"></script>
+        <script async src="{{cdn 'assets/dist/theme-bundle.font.js' resourceHint='preload' as='script'}}"></script>
 
         {{{stylesheet '/assets/css/theme.css'}}}
 
@@ -48,9 +47,6 @@
         {{~inject 'carouselArrowAndDotAriaLabel' (lang 'carousel.arrow_and_dot_aria_label')}}
         {{~inject 'carouselActiveDotAriaLabel' (lang 'carousel.active_dot_aria_label')}}
         {{~inject 'carouselContentAnnounceMessage' (lang 'carousel.content_announce_message')}}
-
-        {{!-- Get this loading ASAP --}}
-        <link rel="preload" href="{{cdn 'assets/dist/theme-bundle.main.js'}}" as="script">
     </head>
     <body>
         <svg data-src="{{cdn 'img/icon-sprite.svg'}}" class="icons-svg-sprite"></svg>
@@ -66,7 +62,7 @@
                 window.stencilBootstrap("{{page_type}}", {{jsContext}}).load();
             }
         </script>
-        <script async defer src="{{cdn 'assets/dist/theme-bundle.main.js'}}" onload="onThemeBundleMain()"></script>
+        <script async defer src="{{cdn 'assets/dist/theme-bundle.main.js' resourceHint='preload' as='script'}}" onload="onThemeBundleMain()"></script>
 
         {{{footer.scripts}}}
     </body>


### PR DESCRIPTION
#### What?

Update the key render-blocking resources in `base.html` to be tagged as preloadable; this will result in [preload headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link) being sent for these resources.

Furthermore, when the Stencil storefront is behind Cloudflare, this will result in [HTTP 103 Early Hints](https://blog.cloudflare.com/early-hints/) being sent when appropriate, which can result in significant performance improvements for some clients.

Limiting this to only the most important, render-blocking resources for right now, as there is probably a point of diminishing returns or even nullifying the benefit if too many resources are tagged.

Outside of the theme, some Scripts in the Script Manager will also be preloaded.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [BCTHEME-1219](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1219)

#### Proof

Here's a WebPageTest result showing the effect of Early Hints (resources start downloading before HTML is delivered):

https://www.webpagetest.org/result/220912_BiDcW5_D8J/1/details/#waterfall_view_step1
