### PR TITLE
feat(storefront): STRF-9829 Migrate Cornerstone to new "Hide Price From Guests" functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Migrate Cornerstone to new "Hide Price From Guests" functionality [#2262](https://github.com/bigcommerce/cornerstone/pull/2262)
 
 ## 6.6.1 (09-14-2022)
 

--- a/config.json
+++ b/config.json
@@ -312,7 +312,6 @@
     "color_hover_product_sold_out_badges": "#000000",
     "focusTooltip-textColor": "#ffffff",
     "focusTooltip-backgroundColor": "#313440",
-    "restrict_to_login": false,
     "swatch_option_size": "22x22",
     "social_icon_placement_top": false,
     "social_icon_placement_bottom": "bottom_none",

--- a/lang/en.json
+++ b/lang/en.json
@@ -39,6 +39,7 @@
     "cart": {
         "nav_aria_label": "Cart with 0 items",
         "continue_shopping": "Click here to continue shopping",
+        "login_to_checkout": "Login to proceed to checkout",
         "items": "{NUM, plural, =0{(0 items)} one {(# item)} other {(# items)}}",
         "checkout": {
             "address": {

--- a/schema.json
+++ b/schema.json
@@ -478,12 +478,6 @@
         "content": "i18n.PurchaseOptions"
       },
       {
-        "type": "checkbox",
-        "label": "i18n.HidePurchaseOptionsPriceAnd",
-        "force_reload": true,
-        "id": "restrict_to_login"
-      },
-      {
         "type": "heading",
         "content": "i18n.FormInputFields"
       },

--- a/schemaTranslations.json
+++ b/schemaTranslations.json
@@ -1157,24 +1157,6 @@
     "no": "Kjøpsalternativer",
     "ko": "구매 옵션"
   },
-  "i18n.HidePurchaseOptionsPriceAnd": {
-    "default": "Hide purchase options (price and add to cart button) for customers who aren't logged in",
-    "fr": "Masquer les options dachat prix et bouton Ajouter au panier pour les clients qui ne sont pas connectés",
-    "it": "Nascondi le opzioni di acquisto prezzo e pulsante di aggiunta al carrello per i clienti che non hanno effettuato laccesso",
-    "uk": "Сховати параметри покупки (ціна та кнопка додавання у кошик) для клієнтів, які не ввійшли в систему",
-    "zh": "当客户未登录时，隐藏购买选项（价格和添加购物车按钮）在",
-    "de": "Kaufoptionen Preis und Schaltfläche „Zum Warenkorb hinzufügen“ für Kunden ausblenden die nicht angemeldet sind",
-    "es": "Ocultar opciones de compra precio y botón Añadir al carrito para clientes que no han iniciado sesión",
-    "nl": "Verberg aankoopopties knoppen Prijs en Toevoegen aan winkelmandje voor klanten die niet zijn ingelogd",
-    "pt": "Ocultar opções de compra botão de preço e de adicionar ao carrinho para clientes não conectados",
-    "sv": "Dölj köpalternativ pris och knappen Lägg i kundvagn för kunder som inte är inloggade",
-    "es-MX": "Ocultar opciones de compra (precio y botón Añadir al carrito) para clientes que no han iniciado sesión",
-    "pt-BR": "Ocultar opções de compra botão de preço e de adicionar ao carrinho para clientes não conectados",
-    "es-419": "Ocultar opciones de compra botón de precio y añadir al carrito para los clientes que no han iniciado sesión",
-    "da": "Skjul købsmuligheder pris og læg i kurv-knap for kunder der ikke er logget ind",
-    "no": "Skjul kjøpsalternativer pris og legg i handlekurv-knapp for kunder som ikke er pålogget",
-    "ko": "로그인하지 않은 고객을 위한 구매 옵션 숨기기가격 및 장바구니에 담기 버튼"
-  },
   "i18n.FormInputFields": {
     "default": "Form Input fields",
     "fr": "Champs de saisie sur le formulaire",

--- a/templates/components/amp/products/card.html
+++ b/templates/components/amp/products/card.html
@@ -27,7 +27,7 @@
         </h3>
 
         <div class="card-text" data-test-info-type="price">
-            {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
+            {{#or customer (unless settings.hide_price_from_guests)}}
                 {{> components/products/price price=price customer=customer}}
             {{else}}
                 {{> components/common/login-for-pricing}}

--- a/templates/components/amp/products/product-view.html
+++ b/templates/components/amp/products/product-view.html
@@ -27,7 +27,7 @@
         </amp-carousel>
     </section>
     <div class="productView-action">
-        {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
+        {{#or customer (unless settings.hide_price_from_guests)}}
             <amp-iframe height="400" width="250"
                 layout="responsive"
                 sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-top-navigation allow-modals"

--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -85,7 +85,7 @@
                 </td>
                 <td class="cart-item-block cart-item-info">
                     <span class="cart-item-label">{{lang 'cart.checkout.price'}}</span>
-                    {{#or ../customer (if ../theme_settings.restrict_to_login '!==' true)}}
+                    {{#or ../customer (unless ../settings.hide_price_from_guests) (if type '==' 'GiftCertificate')}}
                         <span class="cart-item-value {{#if price_discounted}}price--discounted{{/if}}">{{price.formatted}}</span>
                         {{#if price_discounted}}
                             <span class="cart-item-value">{{price_discounted.formatted}}</span>
@@ -140,13 +140,13 @@
 
                 <td class="cart-item-block cart-item-info">
                     <span class="cart-item-label">{{lang 'cart.checkout.total'}}</span>
-                    {{#or ../customer (if ../theme_settings.restrict_to_login '!==' true)}}
+                    {{#or ../customer (unless ../settings.hide_price_from_guests) (if type '==' 'GiftCertificate')}}
                         <strong class="cart-item-value {{#if total_discounted}}price--discounted{{/if}}">{{total.formatted}}</strong>
                         {{#if total_discounted}}
                             <strong class="cart-item-value">{{total_discounted.formatted}}</strong>
                         {{/if}}
                     {{else}}
-                        {{> components/common/login-for-pricing}}
+                        --
                     {{/or}}
                     {{#or can_modify (if type '==' 'GiftCertificate')}}
                         <button class="cart-remove icon"

--- a/templates/components/cart/preview.html
+++ b/templates/components/cart/preview.html
@@ -31,7 +31,7 @@
                 {{lang 'cart.added_to_cart.order_subtotal'}}
 
                 <strong class="previewCartCheckout-price">
-                    {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
+                    {{#or customer (unless settings.hide_price_from_guests)}}
                         {{cart.sub_total.formatted}}
                     {{else}}
                         {{> components/common/login-for-pricing}}
@@ -75,7 +75,7 @@
                     </div>
 
                     <div class="productView-price">
-                        {{#or ../customer (if ../theme_settings.restrict_to_login '!==' true)}}
+                        {{#or ../customer (unless ../settings.hide_price_from_guests)}}
                             {{quantity}} &times; {{price.formatted}}
                         {{else}}
                             {{> components/common/login-for-pricing}}

--- a/templates/components/cart/totals.html
+++ b/templates/components/cart/totals.html
@@ -4,7 +4,7 @@
             <strong>{{lang 'cart.checkout.subtotal'}}:</strong>
         </div>
         <div class="cart-total-value">
-            {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
+            {{#or customer (unless settings.hide_price_from_guests)}}
                 <span>{{cart.sub_total.formatted}}</span>
             {{else}}
                 {{> components/common/login-for-pricing}}
@@ -99,7 +99,7 @@
             <strong>{{lang 'cart.checkout.grand_total'}}:</strong>
         </div>
         <div class="cart-total-value cart-total-grandTotal">
-            {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
+            {{#or customer (unless settings.hide_price_from_guests)}}
                 <span>{{cart.grand_total.formatted}}</span>
             {{else}}
                 {{> components/common/login-for-pricing}}

--- a/templates/components/common/cart-preview.html
+++ b/templates/components/common/cart-preview.html
@@ -33,7 +33,7 @@
                                 {{#if quantity '>' 1}}
                                     {{quantity}} &times;
                                 {{/if}}
-                                {{#or ../customer (if ../theme_settings.restrict_to_login '!==' true)}}
+                                {{#or ../customer (unless ../settings.hide_price_from_guests) (if type '==' 'GiftCertificate')}}
                                     <span{{#if price_discounted}} class="price--discounted"{{/if}}>{{price.formatted}}</span>
                                     {{#if price_discounted}}
                                         {{price_discounted.formatted}}

--- a/templates/components/common/navigation.html
+++ b/templates/components/common/navigation.html
@@ -1,5 +1,5 @@
 <nav class="navUser">
-    {{#or customer (unless theme_settings.restrict_to_login)}}
+    {{#or customer (unless settings.hide_price_from_guests)}}
         {{> components/common/currency-selector}}
     {{/or}}
 

--- a/templates/components/products/add-to-cart.html
+++ b/templates/components/products/add-to-cart.html
@@ -41,7 +41,7 @@
         </div>
         <p class="alertBox-column alertBox-message"></p>
     </div>
-    {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
+    {{#or customer (unless settings.hide_price_from_guests)}}
         <div class="add-to-cart-buttons">
             <div class="form-action">
                 <input

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -17,7 +17,7 @@
         {{/each}}"
         data-product-brand="{{brand.name}}"
         data-product-price="
-        {{#or customer (unless theme_settings.restrict_to_login)}}
+        {{#or customer (unless settings.hide_price_from_guests)}}
             {{#if price.with_tax}}
                 {{price.with_tax.value}}
             {{else}}
@@ -92,7 +92,7 @@
                         {{lang 'products.compare'}} <input type="checkbox" name="products[]" value="{{id}}" id="compare-{{id}}" data-compare-id="{{id}}">
                     </label>
                 {{/if}}
-                {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
+                {{#or customer (unless settings.hide_price_from_guests)}}
                     {{#if show_cart_action}}
                         {{#if has_options}}
                             <a href="{{url}}" data-event-type="product-click" class="button button--small card-figcaption-button" data-product-id="{{id}}">{{lang 'products.choose_options'}}</a>
@@ -133,7 +133,7 @@
         </h3>
 
         <div class="card-text" data-test-info-type="price">
-            {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
+            {{#or customer (unless settings.hide_price_from_guests)}}
                 {{> components/products/price price=price}}
             {{else}}
                 {{> components/common/login-for-pricing}}

--- a/templates/components/products/list-item.html
+++ b/templates/components/products/list-item.html
@@ -1,6 +1,6 @@
 {{#if settings.data_tag_enabled}}
     <article class="listItem" data-event-type="{{event}}" data-entity-id="{{id}}" data-position="{{position}}" data-name="{{name}}" data-product-category="{{#each category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}" data-product-brand="{{brand.name}}" data-product-price="
-    {{#or customer (unless theme_settings.restrict_to_login)}}
+    {{#or customer (unless settings.hide_price_from_guests)}}
         {{#if price.with_tax}}
             {{price.with_tax.value}}
         {{else}}
@@ -91,7 +91,7 @@
                 {{/if}}
             </div>
             <div class="listItem-actions">
-                {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
+                {{#or customer (unless settings.hide_price_from_guests)}}
                     {{#if price}}
                         <div class="listItem-price">{{> components/products/price price=price}}</div>
                     {{/if}}

--- a/templates/components/products/product-info.html
+++ b/templates/components/products/product-info.html
@@ -1,4 +1,4 @@
-{{#or customer (unless theme_settings.restrict_to_login)}}
+{{#or customer (unless settings.hide_price_from_guests)}}
 {{name}}, {{> components/products/product-aria-label}}
 {{else}}
 {{name}}

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -9,7 +9,7 @@
     {{/each}}"
     data-product-brand="{{product.brand.name}}"
     data-product-price="
-    {{#or customer (unless theme_settings.restrict_to_login)}}
+    {{#or customer (unless settings.hide_price_from_guests)}}
         {{#if product.price.with_tax}}
             {{product.price.with_tax.value}}
         {{else}}
@@ -106,7 +106,7 @@
                 </p>
             {{/if}}
             <div class="productView-price">
-                {{#or customer (if theme_settings.restrict_to_login '!==' true)}}
+                {{#or customer (unless settings.hide_price_from_guests)}}
                     {{> components/products/price price=product.price}}
                 {{else}}
                     {{> components/common/login-for-pricing}}

--- a/templates/pages/cart.html
+++ b/templates/pages/cart.html
@@ -28,37 +28,43 @@ cart: true
 
             {{{region name="cart_below_totals"}}}
 
-            {{#if cart.additional_checkout_buttons}}
-                <div data-cart-accelerated-checkout-buttons class="cart-acceleratedCheckoutButtons cart-content-padding-right"></div>
-            {{/if}}
+            {{#or customer (unless settings.hide_price_from_guests)}}
+                {{#if cart.additional_checkout_buttons}}
+                    <div data-cart-accelerated-checkout-buttons class="cart-acceleratedCheckoutButtons cart-content-padding-right"></div>
+                {{/if}}
 
-            {{#if cart.show_primary_checkout_button}}
-                <div class="cart-actions cart-content-padding-right">
-                    <a
-                            class="button button--primary"
-                            href="{{urls.checkout.single_address}}"
-                            title="{{lang 'cart.checkout.title'}}"
-                            data-primary-checkout-now-action
-                    >
-                        {{lang 'cart.checkout.button'}}
-                    </a>
-                    {{#if cart.show_multiple_address_shipping}}
-                        <a class="checkoutMultiple" href="{{urls.checkout.multiple_address}}">
-                            {{lang 'cart.preview.checkout_multiple'}}
+                {{#if cart.show_primary_checkout_button}}
+                    <div class="cart-actions cart-content-padding-right">
+                        <a
+                                class="button button--primary"
+                                href="{{urls.checkout.single_address}}"
+                                title="{{lang 'cart.checkout.title'}}"
+                                data-primary-checkout-now-action
+                        >
+                            {{lang 'cart.checkout.button'}}
                         </a>
-                    {{/if}}
-                </div>
+                        {{#if cart.show_multiple_address_shipping}}
+                            <a class="checkoutMultiple" href="{{urls.checkout.multiple_address}}">
+                                {{lang 'cart.preview.checkout_multiple'}}
+                            </a>
+                        {{/if}}
+                    </div>
+                {{else}}
+                    <div class="cart-actions cart-content-padding-right">
+                        <a class="button" href="{{urls.home}}" title="{{lang 'cart.continue_shopping'}}">{{lang 'cart.continue_shopping'}}</a>
+                    </div>
+                {{/if}}
+
+                {{#if cart.additional_checkout_buttons}}
+                    <div data-cart-additional-checkout-buttons class="cart-additionalCheckoutButtons cart-content-padding-right">
+                        {{> components/cart/additional-checkout-buttons}}
+                    </div>
+                {{/if}}
             {{else}}
                 <div class="cart-actions cart-content-padding-right">
-                    <a class="button" href="{{urls.home}}" title="{{lang 'cart.continue_shopping'}}">{{lang 'cart.continue_shopping'}}</a>
+                    <a class="button" href="{{urls.auth.login}}" title="{{lang 'cart.login_to_checkout'}}">{{lang 'cart.login_to_checkout'}}</a>
                 </div>
-            {{/if}}
-
-            {{#if cart.additional_checkout_buttons}}
-                <div data-cart-additional-checkout-buttons class="cart-additionalCheckoutButtons cart-content-padding-right">
-                    {{> components/cart/additional-checkout-buttons}}
-                </div>
-            {{/if}}
+            {{/or}}
 
         {{else}}
             <h3 tabindex="0">{{lang 'cart.checkout.empty_cart'}}</h3>

--- a/templates/pages/compare.html
+++ b/templates/pages/compare.html
@@ -37,7 +37,7 @@
                             <h3 class="card-title">
                                 <a href="{{url}}">{{ name }}</a>
                             </h3>
-                            {{#or ../customer (if ../theme_settings.restrict_to_login '!==' true)}}
+                            {{#or ../customer (unless ../settings.hide_price_from_guests)}}
                                 {{#if price_range}}
                                     {{> components/products/price-range}}
                                 {{else}}
@@ -55,7 +55,7 @@
                 <th class="compareTable-heading"></th>
                 {{#each comparisons}}
                     <td class="compareTable-action">
-                        {{#or ../customer (if ../theme_settings.restrict_to_login '!==' true)}}
+                        {{#or ../customer (unless ../settings.hide_price_from_guests)}}
                             {{#if show_cart_action}}
                                 {{#if has_options}}
                                     <a href="{{url}}" {{#if settings.data_tag_enabled}} data-event-type="product-click" {{/if}} class="button button--primary" data-product-id="{{id}}">{{lang 'products.choose_options'}}</a>


### PR DESCRIPTION
### Jira: [STRF-9829](https://bigcommercecloud.atlassian.net/browse/STRF-9829)

## What?

This PR will remove the "restrict_to_login" theme configuration and replace it with the server-side "hide_price_from_guests" setting. This functionality is hidden behind the `Feature_HidePriceFromGuestsSetting` feature flag, so we will need coordination when this will be released in a new Cornerstone update on the marketplace.

## Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

## Tickets / Documentation

Add links to any relevant tickets and documentation.

- [STRF-9829](https://bigcommercecloud.atlassian.net/browse/STRF-9829)

## Screenshots (if appropriate)

**Channel Storefront Setting:**
![image](https://user-images.githubusercontent.com/19815878/190013336-04e59e67-32fa-402a-81f6-330567c62a3a.png)

**Product Cards:**
![image](https://user-images.githubusercontent.com/19815878/190013441-52e4222f-af1f-496c-b48c-6d6102a7fbba.png)

**Product Page:**
![image](https://user-images.githubusercontent.com/19815878/190013493-e6abf5c6-6371-4939-b042-95e3468fd094.png)

**Cart Page (if user creates cart while logged in and then logs out):**
![image](https://user-images.githubusercontent.com/19815878/190013583-c934af8e-5b60-43c1-b2e4-ddb9c4405aa7.png)

ping @bigcommerce/themes-team 