### PR TITLE
feat-payment): PAYPAL-1682 hide PDP wallet buttons container when the product is not purchasable or out of stock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Draft
 - Migrate Cornerstone to new "Hide Price From Guests" functionality [#2262](https://github.com/bigcommerce/cornerstone/pull/2262)
 - Add Accelerated buttons container into 'add to cart' popup on product details page [#2264](https://github.com/bigcommerce/cornerstone/pull/2264)
+- Made PDP wallet buttons container hidden in cases when the product is not purchasable or out of stock [#2267](https://github.com/bigcommerce/cornerstone/pull/2267)
 
 ## 6.6.1 (09-14-2022)
 

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -187,6 +187,7 @@ export default class ProductDetailsBase {
                 $input: $('[name=qty\\[\\]]', $scope),
             },
             $bulkPricing: $('.productView-info-bulkPricing', $scope),
+            $walletButtons: $('[data-add-to-cart-wallet-buttons]', $scope),
         };
     }
 
@@ -345,9 +346,11 @@ export default class ProductDetailsBase {
         if (!data.purchasable || !data.instock) {
             viewModel.$addToCart.prop('disabled', true);
             viewModel.$increments.prop('disabled', true);
+            viewModel.$walletButtons.hide();
         } else {
             viewModel.$addToCart.prop('disabled', false);
             viewModel.$increments.prop('disabled', false);
+            viewModel.$walletButtons.show();
         }
     }
 

--- a/templates/components/products/add-to-cart.html
+++ b/templates/components/products/add-to-cart.html
@@ -54,7 +54,7 @@
                 <span class="product-status-message aria-description--hidden">{{lang 'products.adding_to_cart'}} {{lang 'category.add_cart_announcement'}}</span>
             </div>
             {{#if this.with_wallet_buttons}}
-                <div class="add-to-cart-wallet-buttons">
+                <div class="add-to-cart-wallet-buttons" data-add-to-cart-wallet-buttons>
                     {{> components/common/wallet-buttons}}
                 </div>
             {{/if}}


### PR DESCRIPTION
#### What?

Made PDP wallet buttons container hidden in cases when the product is not purchasable or out of stock

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [PAYPAL-1682](https://bigcommercecloud.atlassian.net/browse/PAYPAL-1682)

#### Screenshots (if appropriate)
<img width="1276" alt="Screenshot 2022-10-03 at 09 42 23" src="https://user-images.githubusercontent.com/25133454/193515764-4bbf8ce1-9a93-4039-9e58-7f6d777a9963.png">

<img width="1209" alt="Screenshot 2022-10-03 at 09 42 31" src="https://user-images.githubusercontent.com/25133454/193515783-c008afe7-5298-4b07-981b-588f763677d4.png">

