### PR TITLE
fix(payment): PAYPAL-1720 made initial product details data update if the form is valid on page load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated PayPal Accelerated Checkout default button styles [#2268](https://github.com/bigcommerce/cornerstone/pull/2268)
 - Add logic to collect Product Details data and send it to the BC App stencil template through custom event [#2270](https://github.com/bigcommerce/cornerstone/pull/2270)
 - Allow quantity of "0" in cart to remove item [#2266](https://github.com/bigcommerce/cornerstone/pull/2266)
+- Fix the issue with getting product details data if the product details form is valid on page load [#2271](https://github.com/bigcommerce/cornerstone/pull/2271)
 
 ## 6.6.1 (09-14-2022)
 

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -28,7 +28,9 @@ export default class ProductDetails extends ProductDetailsBase {
 
         const $form = $('form[data-cart-item-add]', $scope);
 
-        if (!$form[0].checkValidity()) {
+        if ($form[0].checkValidity()) {
+            this.updateProductDetailsData();
+        } else {
             this.toggleWalletButtonsVisibility(false);
         }
 


### PR DESCRIPTION
#### What?

Made initial product details data update if the form is valid on page load. We have a case, when the form is valid by itself, but we don't have product details data to create 'Buy Now' cart for wallet buttons. This PR fixes the issue.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [PAYPAL-1720](https://bigcommercecloud.atlassian.net/browse/PAYPAL-1720)

#### Screenshots (if appropriate)
Before:
<img width="406" alt="Screenshot 2022-10-12 at 11 28 33" src="https://user-images.githubusercontent.com/25133454/195356089-8e470ac4-a978-4358-98a5-bd8e3e8defac.png">

After:
<img width="407" alt="Screenshot 2022-10-12 at 11 28 52" src="https://user-images.githubusercontent.com/25133454/195356088-a2623b64-9640-48a1-8ebe-8de421133ee5.png">

