### PR TITLE
fix(storefront): BCTHEME-1213 prevent immediate validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add logic to collect Product Details data and send it to the BC App stencil template through custom event [#2270](https://github.com/bigcommerce/cornerstone/pull/2270)
 - Allow quantity of "0" in cart to remove item [#2266](https://github.com/bigcommerce/cornerstone/pull/2266)
 - Fix the issue with getting product details data if the product details form is valid on page load [#2271](https://github.com/bigcommerce/cornerstone/pull/2271)
+- Delay validation on account signup, message form, and account edit page [#2274](https://github.com/bigcommerce/cornerstone/pull/2274)
 
 ## 6.6.1 (09-14-2022)
 

--- a/assets/js/theme/account.js
+++ b/assets/js/theme/account.js
@@ -318,7 +318,7 @@ export default class Account extends PageManager {
         const formEditSelector = 'form[data-edit-account-form]';
         const editValidator = nod({
             submit: '${formEditSelector} input[type="submit"]',
-            delay: 0,
+            delay: 900,
         });
         const emailSelector = `${formEditSelector} [data-field-type="EmailAddress"]`;
         const $emailElement = $(emailSelector);
@@ -396,15 +396,17 @@ export default class Account extends PageManager {
             }
 
             event.preventDefault();
-            const earliestError = $('span.form-inlineMessage:first').prev('input');
-            earliestError.focus();
+            setTimeout(() => {
+                const earliestError = $('span.form-inlineMessage:first').prev('input');
+                earliestError.focus();
+            }, 900);
         });
     }
 
     registerInboxValidation($inboxForm) {
         const inboxValidator = nod({
             submit: 'form[data-inbox-form] input[type="submit"]',
-            delay: 0,
+            delay: 900,
         });
 
         inboxValidator.add([
@@ -445,8 +447,11 @@ export default class Account extends PageManager {
             }
 
             event.preventDefault();
-            const earliestError = $('span.form-inlineMessage:first').prev('input');
-            earliestError.focus();
+
+            setTimeout(() => {
+                const earliestError = $('span.form-inlineMessage:first').prev('input');
+                earliestError.focus();
+            }, 900);
         });
     }
 }

--- a/assets/js/theme/auth.js
+++ b/assets/js/theme/auth.js
@@ -111,7 +111,7 @@ export default class Auth extends PageManager {
         const validationModel = validation($createAccountForm, this.context);
         const createAccountValidator = nod({
             submit: `${this.formCreateSelector} input[type='submit']`,
-            delay: 0,
+            delay: 900,
         });
         const $stateElement = $('[data-field-type="State"]');
         const emailSelector = `${this.formCreateSelector} [data-field-type='EmailAddress']`;
@@ -182,8 +182,10 @@ export default class Auth extends PageManager {
             return;
         }
         event.preventDefault();
-        const earliestError = $('span.form-inlineMessage:first').prev('input');
-        earliestError.focus();
+        setTimeout(() => {
+            const earliestError = $('span.form-inlineMessage:first').prev('input');
+            earliestError.focus();
+        }, 900);
     }
 
     /**


### PR DESCRIPTION
#### What?

The configuration `delay:0` was originally added so that the page would focus/scroll to the earliest error. A validation may be returned after the page starts to scroll/focus to the earliest error and interrupt the scroll/focus. See https://github.com/bigcommerce/cornerstone/pull/2230#issuecomment-1181596748 

However, some merchants have reported that the instant validation is undesired because the user is not given a chance to complete the text input before being validated. From an accessibility standpoint this can cause confusion for some users. The default delay is .7 seconds - https://github.com/casperin/nod#delay - but this still seems pretty fast to me considering the merchant report, so I've changed it to .9.

The timeout gives all the validations a chance to be returned before scrolling/earliest error selection, preventing interruption while scrolling. Using callbacks or an async library to achieve this does not seem feasible and would require modifying libraries, though I'm open to suggestions and feedback on this. 

BEFORE: The user input is validated just as they start to type

https://user-images.githubusercontent.com/5630999/197012700-4d6557a8-80a3-4d72-aed0-6b76d404d4e4.mp4

AFTER: The user has time to type the input before being validated

https://user-images.githubusercontent.com/5630999/197012794-d6ea55b9-9477-4669-8b2a-f445ba09e9a8.mp4

NOTE: Here we apply a version that sets the delay for nod, but does not use a timeout. Because of the way the earliest error is selected from the UI with jQuery, we are not guaranteed to scroll to earliest error because it's possible not all the validations have finished. Notice the earliest error element not focusing and the incomplete scrolling behavior. 

https://user-images.githubusercontent.com/5630999/197016099-65b3ec65-af4e-40c7-bc7d-bf642d0d8705.mp4


#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [BCTHEME-1213](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1213)

