### PR TITLE
feat(payments): PAYPAL-1781 Set Show PDP setting to true by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Set "Show quick payment buttons" setting to true by default [#2283]https://github.com/bigcommerce/cornerstone/pull/2283
 
 ## 6.7.0 (11-03-2022)
 - Fixed escaping on created store account confirm message. [#2265]https://github.com/bigcommerce/cornerstone/pull/2265

--- a/config.json
+++ b/config.json
@@ -84,7 +84,7 @@
     "show_accept_klarna": false,
     "show_product_details_tabs": true,
     "show_product_reviews": true,
-    "show_quick_payment_buttons": false,
+    "show_quick_payment_buttons": true,
     "show_custom_fields_tabs": false,
     "show_product_weight": true,
     "show_product_dimensions": false,


### PR DESCRIPTION
#### What?

`Show quick payment buttons` to True by default. 

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [PAYPAL-1781](https://bigcommercecloud.atlassian.net/browse/PAYPAL-1781)

#### Screenshots (if appropriate)

<img width="646" alt="Screenshot 2022-11-10 at 11 25 33" src="https://user-images.githubusercontent.com/54856617/201053573-643f8876-0457-4c86-b69f-a2bcf4b2291c.png">
