### PR TITLE
fix(storefront): BCTHEME-1072 Stored XSS within Wishlist creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Stored XSS within Wishlist creation.[#2289](https://github.com/bigcommerce/cornerstone/issues/2289)
 - Set "Show quick payment buttons" setting to true by default [#2283]https://github.com/bigcommerce/cornerstone/pull/2283
 - Fixed en-CA translation warning in terminal. [#2278][https://github.com/bigcommerce/cornerstone/pull/2278]
 

--- a/templates/components/account/wishlist-list.html
+++ b/templates/components/account/wishlist-list.html
@@ -10,7 +10,7 @@
     <tbody class="table-tbody">
     {{#each customer.wishlists}}
         <tr>
-            <td><a href="{{view_url}}">{{{name}}}</a></td>
+            <td><a href="{{view_url}}">{{name}}</a></td>
             <td>{{num_items}}</td>
             <td>
                 {{#if is_public }}


### PR DESCRIPTION
#### What?

In the **wish-list.html** file, there should be {{}} to prevent an XSS attack.

#### Tickets / Documentation

- [BCTHEME-1072](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1072)