### PR TITLE
Bump Stencil Utils to 6.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added manual captcha to Contact Us form for additional spam protection. [#2290](https://github.com/bigcommerce/cornerstone/pull/2290)
 - Fixed PDP not respecting "quantity box" display settings. [#2291](https://github.com/bigcommerce/cornerstone/pull/2291)
 - Added integrarion of storefront-account-payments lib [#2288][https://github.com/bigcommerce/cornerstone/pull/2288]
+- Bump Stencil utils to 6.13.0 [#2300][https://github.com/bigcommerce/cornerstone/pull/2300]
 
 ## 6.7.0 (11-03-2022)
 - Fixed escaping on created store account confirm message. [#2265]https://github.com/bigcommerce/cornerstone/pull/2265

--- a/package-lock.json
+++ b/package-lock.json
@@ -1065,9 +1065,9 @@
       "dev": true
     },
     "@bigcommerce/stencil-utils": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-6.12.1.tgz",
-      "integrity": "sha512-Kk9eW72feq2uCknOaqBxu0GQOOVya4Kzoy1r8N2P9D7AHUMASwAXJp4C+3u52GXUteiH5JcAB1DGoDE2msH2aA==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-6.13.0.tgz",
+      "integrity": "sha512-cG4iIjAXesr8QbSb+H5CAqBKoJ183i6vea7HnjrmqQZkVEdR4f5m3KUGcS5aolkIyHfTChS1Rt8LXJ2chKGCIg==",
       "requires": {
         "eventemitter3": "^4.0.4",
         "whatwg-fetch": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "BigCommerce",
   "license": "MIT",
   "dependencies": {
-    "@bigcommerce/stencil-utils": "6.12.1",
+    "@bigcommerce/stencil-utils": "6.13.0",
     "core-js": "^3.9.0",
     "creditcards": "^4.2.0",
     "easyzoom": "^2.5.3",


### PR DESCRIPTION
#### What?

Bumping stencil utils with BODL features and added /graphql-render endpoint

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [Stencil Utils Release items](https://github.com/bigcommerce/stencil-utils/releases/tag/6.13.0)
