### PR TITLE
fix(storefront)L: BCTHEME-1366 Customer order summary with both physical and digital items shows shipping as null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed non-working functionality from schema.json [#2301][https://github.com/bigcommerce/cornerstone/pull/2301]
 - Refactored `hide_price_from_guests` logic around `show_cart_action` use [#2304](https://github.com/bigcommerce/cornerstone/pull/2304)
 - Removed all Google AMP template files [#2308](https://github.com/bigcommerce/cornerstone/pull/2308)
+- Customer order summary with both physical and digital items shows shipping as null [#2309](https://github.com/bigcommerce/cornerstone/pull/2309)
 
 ## 6.7.0 (11-03-2022)
 - Fixed escaping on created store account confirm message. [#2265]https://github.com/bigcommerce/cornerstone/pull/2265

--- a/templates/components/account/order-contents.html
+++ b/templates/components/account/order-contents.html
@@ -4,9 +4,11 @@
     {{#each order.items}}
         {{#if shipping_rows.length}}
             {{#each shipping_rows}}
-                <li class="account-listShipping">
-                    <h5 class="account-listShipping-title">{{lang 'account.orders.details.ship_to_multi' street=address city=city state=state zip=zip country=country}}</h5>
-                </li>
+                {{#if is_shipping}}
+                    <li class="account-listShipping">
+                        <h5 class="account-listShipping-title">{{lang 'account.orders.details.ship_to_multi' street=address city=city state=state zip=zip country=country}}</h5>
+                    </li>
+                {{/if}}
             {{/each}}
         {{/if}}
     <li class="account-listItem">


### PR DESCRIPTION
#### What?
This PR fixes displaying shipping details in order details.

#### Tickets / Documentation
- [BCTHEME-1366](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1366)

#### Screenshots
<img width="1440" alt="1366_shipping_bug" src="https://user-images.githubusercontent.com/82589781/213433388-ac2792b9-ab4d-45cb-8362-84480999bc2d.png">
<img width="1432" alt="1366_shipping_bugfix" src="https://user-images.githubusercontent.com/82589781/213433417-d59bddf3-32bd-447a-99d5-258c6f74b8ec.png">


[BCTHEME-1366]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ