### PR TITLE
feat(strf-10366) Bump stencil utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- bump stencil utils to 6.14.0  [#x](https://github.com/bigcommerce/cornerstone/pull/x)
 
 ## 6.8.0 (01-26-2023)
 - Add remote_api_scripts into cart/preview template to let GA3 snippet to fire the Product Added event, when clicking Add to cart button on Product detail page and rendering the response in popup. [#2281](https://github.com/bigcommerce/cornerstone/pull/2281)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1065,9 +1065,9 @@
       "dev": true
     },
     "@bigcommerce/stencil-utils": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-6.13.0.tgz",
-      "integrity": "sha512-cG4iIjAXesr8QbSb+H5CAqBKoJ183i6vea7HnjrmqQZkVEdR4f5m3KUGcS5aolkIyHfTChS1Rt8LXJ2chKGCIg==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-6.14.0.tgz",
+      "integrity": "sha512-h59jyqhkJsZHqymDn/jeWDSFWqTfEnnntfIQr/VF+F2uOh+2mwpwUBhwrUg2oa4kLEJC17ONB6nuhi0zb2xNlg==",
       "requires": {
         "eventemitter3": "^4.0.4",
         "whatwg-fetch": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "BigCommerce",
   "license": "MIT",
   "dependencies": {
-    "@bigcommerce/stencil-utils": "6.13.0",
+    "@bigcommerce/stencil-utils": "6.14.0",
     "core-js": "^3.9.0",
     "creditcards": "^4.2.0",
     "easyzoom": "^2.5.3",


### PR DESCRIPTION
#### What?

Bump stencil utils with update of bodl events version and webpack dependency

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [STRF-10366](https://bigcommercecloud.atlassian.net/browse/STRF-10366)

#### Screenshots (if appropriate)

<img width="1727" alt="Screenshot 2023-01-30 at 12 21 39" src="https://user-images.githubusercontent.com/68893868/215548668-41d8d8f1-e9f9-4b20-8190-7ce32c919cd3.png">
<img width="1319" alt="Screenshot 2023-01-30 at 12 21 46" src="https://user-images.githubusercontent.com/68893868/215548691-7fcef502-d0dd-469f-82a8-9a4866e121bf.png">



[STRF-10366]: https://bigcommercecloud.atlassian.net/browse/STRF-10366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ