### PR TITLE
fix(storefront): BCTHEME-1184 form.serialize() ignores dropdown option elements that have the disabled attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Draft
 - Remove xlink attributes on svg [#2322](https://github.com/bigcommerce/cornerstone/pull/2322)
+- form.serialize() ignores dropdown option elements that have the disabled attribute [#2326](https://github.com/bigcommerce/cornerstone/pull/2326)
 
 ## 6.8.0 (01-26-2023)
 - Add remote_api_scripts into cart/preview template to let GA3 snippet to fire the Product Added event, when clicking Add to cart button on Product detail page and rendering the response in popup. [#2281](https://github.com/bigcommerce/cornerstone/pull/2281)

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -90,10 +90,17 @@ export default class ProductDetailsBase {
     updateProductAttributes(data) {
         const behavior = data.out_of_stock_behavior;
         const inStockIds = data.in_stock_attributes;
-        const outOfStockMessage = ` (${data.out_of_stock_message})`;
+        const outOfStockDefaultMessage = this.context.outOfStockDefaultMessage;
+        let outOfStockMessage = data.out_of_stock_message;
 
         if (behavior !== 'hide_option' && behavior !== 'label_option') {
             return;
+        }
+
+        if (outOfStockMessage) {
+            outOfStockMessage = ` (${outOfStockMessage})`;
+        } else {
+            outOfStockMessage = ` (${outOfStockDefaultMessage})`;
         }
 
         $('[data-product-attribute-value]', this.$scope).each((i, attribute) => {
@@ -407,7 +414,6 @@ export default class ProductDetailsBase {
                 $select[0].selectedIndex = 0;
             }
         } else {
-            $attribute.attr('disabled', 'disabled');
             $attribute.html($attribute.html().replace(outOfStockMessage, '') + outOfStockMessage);
         }
     }
@@ -416,7 +422,6 @@ export default class ProductDetailsBase {
         if (behavior === 'hide_option') {
             $attribute.toggleOption(true);
         } else {
-            $attribute.prop('disabled', false);
             $attribute.html($attribute.html().replace(outOfStockMessage, ''));
         }
     }

--- a/lang/da.json
+++ b/lang/da.json
@@ -766,6 +766,7 @@
         "shipping_free": "Gratis fragt",
         "shipping_calculated": "Beregnes ved kassen",
         "sold_out": "Udsolgt",
+        "out_of_stock_default_message": "Udsolgt",
         "pre_order": "Forudbestil nu",
         "choose_options": "Vælg valgmuligheder",
         "quick_view": "Hurtig visning",

--- a/lang/de.json
+++ b/lang/de.json
@@ -766,6 +766,7 @@
         "shipping_free": "Kostenloser Versand",
         "shipping_calculated": "Wird beim Bezahlvorgang berechnet",
         "sold_out": "Ausverkauft",
+        "out_of_stock_default_message": "Ausverkauft",
         "pre_order": "Jetzt vorbestellen",
         "choose_options": "Optionen auswählen",
         "quick_view": "Schnellansicht",

--- a/lang/en.json
+++ b/lang/en.json
@@ -767,6 +767,7 @@
         "shipping_free": "Free Shipping",
         "shipping_calculated": "Calculated at Checkout",
         "sold_out": "Sold Out",
+        "out_of_stock_default_message": "Sold Out",
         "pre_order": "Pre-Order Now",
         "choose_options": "Choose Options",
         "quick_view": "Quick view",

--- a/lang/es-419.json
+++ b/lang/es-419.json
@@ -766,6 +766,7 @@
         "shipping_free": "Envío gratuito",
         "shipping_calculated": "Calculado en el proceso de pago",
         "sold_out": "Agotado",
+        "out_of_stock_default_message": "Agotado",
         "pre_order": "Reserva ahora",
         "choose_options": "Elegir opciones",
         "quick_view": "Vista rápida",

--- a/lang/es-AR.json
+++ b/lang/es-AR.json
@@ -766,6 +766,7 @@
         "shipping_free": "Envío gratuito",
         "shipping_calculated": "Calculado en el proceso de pago",
         "sold_out": "Agotado",
+        "out_of_stock_default_message": "Agotado",
         "pre_order": "Reserva ahora",
         "choose_options": "Elegir opciones",
         "quick_view": "Vista rápida",

--- a/lang/es-CL.json
+++ b/lang/es-CL.json
@@ -766,6 +766,7 @@
         "shipping_free": "Envío gratuito",
         "shipping_calculated": "Calculado en el proceso de pago",
         "sold_out": "Agotado",
+        "out_of_stock_default_message": "Agotado",
         "pre_order": "Reserva ahora",
         "choose_options": "Elegir opciones",
         "quick_view": "Vista rápida",

--- a/lang/es-CO.json
+++ b/lang/es-CO.json
@@ -766,6 +766,7 @@
         "shipping_free": "Envío gratuito",
         "shipping_calculated": "Calculado en el proceso de pago",
         "sold_out": "Agotado",
+        "out_of_stock_default_message": "Agotado",
         "pre_order": "Reserva ahora",
         "choose_options": "Elegir opciones",
         "quick_view": "Vista rápida",

--- a/lang/es-LA.json
+++ b/lang/es-LA.json
@@ -766,6 +766,7 @@
         "shipping_free": "Envío gratuito",
         "shipping_calculated": "Calculado en el proceso de pago",
         "sold_out": "Agotado",
+        "out_of_stock_default_message": "Agotado",
         "pre_order": "Reserva ahora",
         "choose_options": "Elegir opciones",
         "quick_view": "Vista rápida",

--- a/lang/es-MX.json
+++ b/lang/es-MX.json
@@ -766,6 +766,7 @@
         "shipping_free": "Envío gratuito",
         "shipping_calculated": "Calculado en el proceso de pago",
         "sold_out": "Agotado",
+        "out_of_stock_default_message": "Agotado",
         "pre_order": "Reserva ahora",
         "choose_options": "Elegir opciones",
         "quick_view": "Vista rápida",

--- a/lang/es-PE.json
+++ b/lang/es-PE.json
@@ -766,6 +766,7 @@
         "shipping_free": "Envío gratuito",
         "shipping_calculated": "Calculado en el proceso de pago",
         "sold_out": "Agotado",
+        "out_of_stock_default_message": "Agotado",
         "pre_order": "Reserva ahora",
         "choose_options": "Elegir opciones",
         "quick_view": "Vista rápida",

--- a/lang/es.json
+++ b/lang/es.json
@@ -766,6 +766,7 @@
         "shipping_free": "Envío gratis",
         "shipping_calculated": "Se calcula durante el proceso de pago",
         "sold_out": "Agotado",
+        "out_of_stock_default_message": "Agotado",
         "pre_order": "Realizar pedido de preventa ahora",
         "choose_options": "Elegir opciones",
         "quick_view": "Vista rápida",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -766,6 +766,7 @@
         "shipping_free": "Livraison gratuite",
         "shipping_calculated": "Calculés au moment du paiement",
         "sold_out": "Épuisé",
+        "out_of_stock_default_message": "Épuisé",
         "pre_order": "Précommander maintenant",
         "choose_options": "Choisir les options",
         "quick_view": "Aperçu rapide",

--- a/lang/it.json
+++ b/lang/it.json
@@ -766,6 +766,7 @@
         "shipping_free": "Spedizione gratuita",
         "shipping_calculated": "Calcolato al momento del checkout",
         "sold_out": "Esaurito",
+        "out_of_stock_default_message": "Esaurito",
         "pre_order": "Pre-ordina ora",
         "choose_options": "Scegli opzioni",
         "quick_view": "Visualizzazione rapida",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -766,6 +766,7 @@
         "shipping_free": "Gratis verzending",
         "shipping_calculated": "Berekend tijdens het afrekenen",
         "sold_out": "Uitverkocht",
+        "out_of_stock_default_message": "Uitverkocht",
         "pre_order": "Nu vooruitbestellen",
         "choose_options": "Opties kiezen",
         "quick_view": "Snelle weergave",

--- a/lang/no.json
+++ b/lang/no.json
@@ -766,6 +766,7 @@
         "shipping_free": "Gratis frakt",
         "shipping_calculated": "Regnes ut i kassen",
         "sold_out": "Utsolgt",
+        "out_of_stock_default_message": "Utsolgt",
         "pre_order": "Forhåndsbestill nå",
         "choose_options": "Velg alternativer",
         "quick_view": "Hurtigvisning",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -766,6 +766,7 @@
         "shipping_free": "Frete grátis",
         "shipping_calculated": "Calculado na finalização da compra",
         "sold_out": "Sair",
+        "out_of_stock_default_message": "Sair",
         "pre_order": "Pré-encomendar agora",
         "choose_options": "Selecionar opções",
         "quick_view": "Exibição rápida",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -766,6 +766,7 @@
         "shipping_free": "Frete grátis",
         "shipping_calculated": "Calculado na finalização da compra",
         "sold_out": "Sair",
+        "out_of_stock_default_message": "Sair",
         "pre_order": "Pré-encomendar agora",
         "choose_options": "Selecionar opções",
         "quick_view": "Exibição rápida",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -766,6 +766,7 @@
         "shipping_free": "Gratis frakt",
         "shipping_calculated": "Beräknas vid kassan",
         "sold_out": "Utsåld",
+        "out_of_stock_default_message": "Utsåld",
         "pre_order": "Förbeställ nu",
         "choose_options": "Välj alternativ",
         "quick_view": "Snabbtitt",

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -1,3 +1,5 @@
+{{inject 'outOfStockDefaultMessage' (lang 'products.out_of_stock_default_message')}}
+
 <div class="productView"
     {{#if settings.data_tag_enabled}}
     data-event-type="product"


### PR DESCRIPTION
#### What?
This PR fixes form.serialize() when changing product options.
After discussing with @vdm-kr, it was decided to get rid of the disabled attribute for the unavailable product option in the dropdown, since the user cannot switch between such options.
For an unavailable option, a corresponding message will be added to the select options.

#### Tickets / Documentation
- [BCTHEME-1184](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1184)

#### Screenshots / Video
Bug:

https://user-images.githubusercontent.com/82589781/216034839-0c743930-1b67-47b1-ade0-7cf193f42905.mov

Fix:

https://user-images.githubusercontent.com/82589781/216038001-1a89155f-0ff1-40ff-9970-cd998278bb89.mov


[BCTHEME-1184]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ