### PR TITLE
Resolve stale assets in dist folder not being discarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove xlink attributes on svg [#2322](https://github.com/bigcommerce/cornerstone/pull/2322)
 - form.serialize() ignores dropdown option elements that have the disabled attribute [#2326](https://github.com/bigcommerce/cornerstone/pull/2326)
 - Extended BigCommerce.accountPayments app initialization interface [#2317](https://github.com/bigcommerce/cornerstone/pull/2317)
+- Resolve stale assets in dist folder not being discarded [#2329](https://github.com/bigcommerce/cornerstone/pull/2329)
 
 ## 6.8.0 (01-26-2023)
 - Add remote_api_scripts into cart/preview template to let GA3 snippet to fire the Product Added event, when clicking Add to cart button on Product detail page and rendering the response in popup. [#2281](https://github.com/bigcommerce/cornerstone/pull/2281)

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -58,7 +58,6 @@ module.exports = {
     },
     plugins: [
         new CleanWebpackPlugin({
-            cleanOnceBeforeBuildPatterns: ['assets/dist'],
             verbose: false,
             watch: false,
         }),


### PR DESCRIPTION
#### What?

Since the 6.8.0 release (more specifically https://github.com/bigcommerce/cornerstone/pull/2311), we were getting the TR-302 / 2500+ files, which meant pushing updates halted.

This PR removes the unnecessary `cleanOnceBeforeBuildPatterns` option from webpack.common.js which prevents stale assets from being discarded when bundling/pushing a theme. All files in `output.path` will be removed on each build, which is the default behavior.

#### Tickets / Documentation

https://github.com/bigcommerce/cornerstone/issues/2319
https://github.com/johnagan/clean-webpack-plugin/issues/106