### PR TITLE
fix(storefront): BCTHEME-1346 Gift certificate CSS properties are applied to page after previewing Gift certificate on storefront

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove xlink attributes on svg [#2322](https://github.com/bigcommerce/cornerstone/pull/2322)
 - form.serialize() ignores dropdown option elements that have the disabled attribute [#2326](https://github.com/bigcommerce/cornerstone/pull/2326)
 - Extended BigCommerce.accountPayments app initialization interface [#2317](https://github.com/bigcommerce/cornerstone/pull/2317)
+- Gift certificate CSS properties are applied to page after previewing Gift certificate on storefront [#2330](https://github.com/bigcommerce/cornerstone/pull/2330)
 
 ## 6.8.0 (01-26-2023)
 - Add remote_api_scripts into cart/preview template to let GA3 snippet to fire the Product Added event, when clicking Add to cart button on Product detail page and rendering the response in popup. [#2281](https://github.com/bigcommerce/cornerstone/pull/2281)

--- a/assets/js/theme/global/modal.js
+++ b/assets/js/theme/global/modal.js
@@ -223,6 +223,8 @@ export class Modal {
 
     onModalClose() {
         $('body').removeClass(bodyActiveClass);
+
+        this.clearContent();
     }
 
     onModalClosed() {


### PR DESCRIPTION
#### What?
This PR fixes styles that applies to page after previewing Gift certificate.

#### Tickets / Documentation
- [BCTHEME-1346](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1346)

#### Screenshots / Video
Bug:


https://user-images.githubusercontent.com/82589781/217244367-c89b4e38-7510-4fb2-b691-1292f3fa01cc.mov



Fix:


https://user-images.githubusercontent.com/82589781/217244416-e0b2d1ee-8a37-4563-99e0-9a4c425bb4dd.mov




[BCTHEME-1346]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ