### PR TITLE
fix(storefront): BCTHEME-1112 Translation Gap: Submit Return Request button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove xlink attributes on svg [#2322](https://github.com/bigcommerce/cornerstone/pull/2322)
 - form.serialize() ignores dropdown option elements that have the disabled attribute [#2326](https://github.com/bigcommerce/cornerstone/pull/2326)
 - Extended BigCommerce.accountPayments app initialization interface [#2317](https://github.com/bigcommerce/cornerstone/pull/2317)
+- Translation Gap: Submit Return Request button [#2331](https://github.com/bigcommerce/cornerstone/pull/2331)
 
 ## 6.8.0 (01-26-2023)
 - Add remote_api_scripts into cart/preview template to let GA3 snippet to fire the Product Added event, when clicking Add to cart button on Product detail page and rendering the response in popup. [#2281](https://github.com/bigcommerce/cornerstone/pull/2281)

--- a/lang/en.json
+++ b/lang/en.json
@@ -436,6 +436,7 @@
             "reason": "Return Reason",
             "action": "Return Action",
             "comments": "Your Comments",
+            "submit_request": "Submit Return Request",
             "list": {
                 "return_number": "Return #{id}",
                 "product_details": "Returning {num_products}"

--- a/templates/pages/account/add-return.html
+++ b/templates/pages/account/add-return.html
@@ -90,7 +90,7 @@
                         </fieldset>
                     </div>
                     <div class="form-actions">
-                        <input class="button button--primary" type="submit" value="Submit Return Request" />
+                        <input class="button button--primary" type="submit" value="{{lang 'account.returns.submit_request'}}" />
                     </div>
                 </form>
             {{else}}


### PR DESCRIPTION
#### What?
This PR fixes translation gap "Submit Return Request" button.

#### Tickets / Documentation
- [BCTHEME-1112](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1112)

#### Screenshots / Video
Bug:

<img width="1438" alt="1112_bug" src="https://user-images.githubusercontent.com/82589781/217311714-7f2ff0b7-0e3b-467b-ad11-5bcde672d68e.png">

Fix:

<img width="1445" alt="1112_fix" src="https://user-images.githubusercontent.com/82589781/217311771-cbccb99a-a737-4d81-a826-199fac4110f3.png">


[BCTHEME-1112]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ