### PR TITLE
fix(storefront): BCTHEME-1461 A bug with the display of the product quantity on the PDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- A bug with the display of the product quantity on the PDP [#2340](https://github.com/bigcommerce/cornerstone/pull/2340)
+- Extended initialization interface of the storefront-account-payments lib, added theme styles [#2335][https://github.com/bigcommerce/cornerstone/pull/2335]
+- Added showAlertModal to the storefront-account-payments app initialization [#2338][https://github.com/bigcommerce/cornerstone/pull/2338]
 
 ## 6.9.0 (03-03-2023)
 - Fix sold-out badge appearance [#2315](https://github.com/bigcommerce/cornerstone/pull/2315)
@@ -14,8 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extended BigCommerce.accountPayments app initialization interface [#2317](https://github.com/bigcommerce/cornerstone/pull/2317)
 - Gift certificate CSS properties are applied to page after previewing Gift certificate on storefront [#2330](https://github.com/bigcommerce/cornerstone/pull/2330)
 - Translation Gap: Submit Return Request button [#2331](https://github.com/bigcommerce/cornerstone/pull/2331)
-- Extended initialization interface of the storefront-account-payments lib, added theme styles [#2335][https://github.com/bigcommerce/cornerstone/pull/2335]
-- Added showAlertModal to the storefront-account-payments app initialization [#2338][https://github.com/bigcommerce/cornerstone/pull/2338]
 
 ## 6.8.0 (01-26-2023)
 - Add remote_api_scripts into cart/preview template to let GA3 snippet to fire the Product Added event, when clicking Add to cart button on Product detail page and rendering the response in popup. [#2281](https://github.com/bigcommerce/cornerstone/pull/2281)

--- a/templates/components/products/add-to-cart.html
+++ b/templates/components/products/add-to-cart.html
@@ -1,5 +1,5 @@
 <div id="add-to-cart-wrapper" class="add-to-cart-wrapper" {{#unless product.can_purchase}}style="display: none"{{/unless}}>
-    {{#if theme_settings.show_product_quantity_box}}
+    {{#if product.show_quantity_input}}
         {{inject 'productQuantityErrorMessage'  (lang 'products.quantity_error_message')}}
         <div class="form-field form-field--increments">
             <label class="form-label form-label--alternate"


### PR DESCRIPTION
#### What?

This PR fixes a bug with the display of the product quantity on the PDP

#### Tickets / Documentation

[- BCTHEME-1461](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1461)

#### Screenshots (if appropriate)
Before:
<img width="1311" alt="Screenshot 2023-03-22 at 12 26 30" src="https://user-images.githubusercontent.com/83779098/226875289-a9b7c150-19b0-451c-8e99-81edd788ad3a.png">

After:
<img width="1269" alt="Screenshot 2023-03-22 at 12 25 39" src="https://user-images.githubusercontent.com/83779098/226875333-cb4b6689-c54c-4809-90ea-c85f78d3f7b0.png">
