### PR TITLE
Update Node version to latest supported by Stencil CLI.

### DIFF
--- a/.github/workflow-examples/automatic_deployment_production.yml
+++ b/.github/workflow-examples/automatic_deployment_production.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [14.x]
+        node: [18.x]
 
     steps:
     - name: Checkout code

--- a/.github/workflow-examples/poll_for_changed_configuration.yml
+++ b/.github/workflow-examples/poll_for_changed_configuration.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [14.x]
+        node: [18.x]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [14.x]
+        node: [18.x]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
#### What?

Stencil CLI dropped Node 14 Support which is causing the github actions to fail. 
Update Node version to latest supported by Stencil CLI to fix the build and example workflows.

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [Stencil CLI Release Notes](https://github.com/bigcommerce/stencil-cli/releases/tag/7.0.0)
