### PR TITLE
fix(storefront): BCTHEME-1420 If the gift is a variant, the button Change shows in cart, and other variant are visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- If the gift is a variant, the button "Change" shows in cart, and other variant are visible [#2349](https://github.com/bigcommerce/cornerstone/pull/2349)
 - Running Lighthouse npm script fails in terminal [#2345](https://github.com/bigcommerce/cornerstone/pull/2345)
 - Removed accelerated checkout integration [#2341](https://github.com/bigcommerce/cornerstone/pull/2341)
 - Added css classes for ApplePay Button [[#2344]](https://github.com/bigcommerce/cornerstone/pull/2344)

--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -53,13 +53,15 @@
                             {{/each}}
                         </dl>
 
-                        <a href="#"
-                           data-item-edit="{{id}}"
-                           data-product-id="{{product_id}}"
-                           aria-label="{{lang 'products.change_product_options' name=name}}"
-                        >
-                            {{lang 'common.change'}}
-                        </a>
+                        {{#if can_modify}}
+                            <a href="#"
+                            data-item-edit="{{id}}"
+                            data-product-id="{{product_id}}"
+                            aria-label="{{lang 'products.change_product_options' name=name}}"
+                            >
+                                {{lang 'common.change'}}
+                            </a>
+                        {{/if}}
                     {{/if}}
 
                     {{#if type '==' 'GiftCertificate'}}


### PR DESCRIPTION
#### What?

This PR removes the "Change" button in the cart where other variations can be selected (but can't be saved). Selecting another variation doesn’t change the cart and the rule but confuses customers.

After setting up a promotion, the "Change" button is not needed, because it leads customers to misunderstand the promotion.

#### Tickets / Documentation

- [BCTHEME-1240](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1240)

#### Screen Recording

Before

https://user-images.githubusercontent.com/83779098/233063726-1a7ab73c-1a63-4a50-9376-157c0485b268.mov

After

https://user-images.githubusercontent.com/83779098/233063762-6c0c0064-b70c-4039-8663-9847ac8ace17.mov
