### PR TITLE
fix(storefront): STRF-10416 - Remove URL Encoding from Description in the Product Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Removes the URL encoding from the 'description' in the product rich snippet schema [#2350](https://github.com/bigcommerce/cornerstone/pull/2350)
 - Running Lighthouse npm script fails in terminal [#2345](https://github.com/bigcommerce/cornerstone/pull/2345)
 - Removed accelerated checkout integration [#2341](https://github.com/bigcommerce/cornerstone/pull/2341)
 - Added css classes for ApplePay Button [[#2344]](https://github.com/bigcommerce/cornerstone/pull/2344)

--- a/templates/components/products/schema.html
+++ b/templates/components/products/schema.html
@@ -14,7 +14,7 @@
             "name": {{{JSONstringify product.brand.name}}}
         },
         {{/if}}
-        "description": "{{encodeURI (sanitize product.description)}}",
+        "description": "{{sanitize product.description}}",
         "image": "{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}",
         {{#and settings.show_product_reviews product.reviews.list.length}}
         "aggregateRating": {


### PR DESCRIPTION
#### What?
Updates the `description` in the schema.org product schema to remove url encoding. This schema is output into a "rich snippet" script on the PDP which is used by 3rd party platforms for accessing product details in a consistent way.

The url encoding was resulting in undesired encoded characters showing up in places the description was used, like when linking a product to pinterest.

For example, I setup a product with a description that resulted in this value being printed into the HTML of the page:
```
"description": "Who%20doesn&#x27;t%20like%20a%20sugar%20skull%3F%0ATesting%20if%20I%20can%20break%20the%20output%20by%20adding%20a%20quote%20-%26gt%3B%20%22%22and%20single%20quote%20-%26gt%3B%20&#x27;%0Aand%20closing%20curly%20brace%20-%26gt%3B%20%7D%0Aand%20opening%20curly%20brace%20-%26gt%3B%20%7B%0A%26nbsp%3B%0Atest%20script%20-%26gt%3B%20%7D%3Balert(%22print%20this!%22)%3B%0A%0ASayHello%0A%26nbsp%3B",
```

This caused things like the `%20` (instead of a space) to persist in the description pulled into pinterest when using the "share on pinterest" button that can be enabled on a PDP. With my changes the description instead looks like this:
```
"description": "Who doesn&#x27;t like a sugar skull?
Testing if I can break the output by adding a quote -&amp;gt; &quot;&quot;and single quote -&amp;gt; &#x27;
and closing curly brace -&amp;gt; }
and opening curly brace -&amp;gt; {
&amp;nbsp;
test script -&amp;gt; };alert(&quot;print this!&quot;);

SayHello
&amp;nbsp;",
```
Html encoded characters (like `&amp;` and `&#x27;`) are still used and do display properly on the pinterest side as seen in the images below.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation
https://bigcommercecloud.atlassian.net/browse/STRF-10416

#### Screenshots (if appropriate)
Here is an example of how the results in pinterest look with our current url encoding:
<img width="1071" alt="Screen Shot 2023-04-20 at 9 04 33 AM" src="https://user-images.githubusercontent.com/6527334/233391076-ee691a41-8dd6-4d0b-a187-1452f626408a.png">

Here is how it looks with the change in this PR:
<img width="1051" alt="Screen Shot 2023-04-19 at 6 59 27 PM" src="https://user-images.githubusercontent.com/6527334/233224184-adf79e71-b597-46b3-971d-acc5aa04992e.png">
