### PR TITLE
fix(storefront): BCTHEME-1473 reverting PR for BCTHEME-1171

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Reverted fix for sold-out badge appearance [#2354](https://github.com/bigcommerce/cornerstone/pull/2354)
 - If the gift is a variant, the button "Change" shows in cart, and other variant are visible [#2349](https://github.com/bigcommerce/cornerstone/pull/2349)
 - Removes the URL encoding from the 'description' in the product rich snippet schema [#2350](https://github.com/bigcommerce/cornerstone/pull/2350)
 - Running Lighthouse npm script fails in terminal [#2345](https://github.com/bigcommerce/cornerstone/pull/2345)

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -29,39 +29,19 @@
     {{/if}}>
     <figure class="card-figure">
         {{#if stock_level '===' 0}}
-            {{#if show_cart_action}}
-                {{#if theme_settings.pdp_sold_out_label '===' ''}}
-                    {{> components/products/product-badge
-                        badge-type='sold-out'
-                        badge_view=theme_settings.product_sold_out_badges
-                        badge_label=(lang "page_builder.pdp_sold_out_label")
-                    }}
-                {{else}}
-                    {{> components/products/product-badge
-                        badge-type='sold-out'
-                        badge_view=theme_settings.product_sold_out_badges
-                        badge_label=theme_settings.pdp_sold_out_label
-                    }}
-                {{/if}}
+            {{#if theme_settings.pdp_sold_out_label '===' ''}}
+                {{> components/products/product-badge
+                    badge-type='sold-out'
+                    badge_view=theme_settings.product_sold_out_badges
+                    badge_label=(lang "page_builder.pdp_sold_out_label")
+                }}
+            {{else}}
+                {{> components/products/product-badge
+                    badge-type='sold-out'
+                    badge_view=theme_settings.product_sold_out_badges
+                    badge_label=theme_settings.pdp_sold_out_label
+                }}
             {{/if}}
-        {{else if has_options '===' false}}
-            {{#and (if stock_level '===' null) show_cart_action}}
-                {{#and (unless add_to_cart_url) (unless pre_order)}}
-                    {{#if theme_settings.pdp_sold_out_label '===' ''}}
-                        {{> components/products/product-badge
-                            badge-type='sold-out'
-                            badge_view=theme_settings.product_sold_out_badges
-                            badge_label=(lang "page_builder.pdp_sold_out_label")
-                        }}
-                    {{else}}
-                        {{> components/products/product-badge
-                            badge-type='sold-out'
-                            badge_view=theme_settings.product_sold_out_badges
-                            badge_label=theme_settings.pdp_sold_out_label
-                        }}
-                    {{/if}}
-                {{/and}}
-            {{/and}}
         {{else}}
             {{#or price.sale_price_with_tax.value price.sale_price_without_tax.value}}
                 {{#if theme_settings.pdp_sale_badge_label '===' ''}}

--- a/templates/components/products/list-item.html
+++ b/templates/components/products/list-item.html
@@ -21,39 +21,19 @@
            {{/if}}
         >
         {{#if stock_level '===' 0}}
-            {{#if show_cart_action}}
-                {{#if theme_settings.pdp_sold_out_label '===' ''}}
-                    {{> components/products/product-badge
-                        badge-type='sold-out'
-                        badge_view=theme_settings.product_sold_out_badges
-                        badge_label=(lang "page_builder.pdp_sold_out_label")
-                    }}
-                {{else}}
-                    {{> components/products/product-badge
-                        badge-type='sold-out'
-                        badge_view=theme_settings.product_sold_out_badges
-                        badge_label=theme_settings.pdp_sold_out_label
-                    }}
-                {{/if}}
+            {{#if theme_settings.pdp_sold_out_label '===' ''}}
+                {{> components/products/product-badge
+                    badge-type='sold-out'
+                    badge_view=theme_settings.product_sold_out_badges
+                    badge_label=(lang "page_builder.pdp_sold_out_label")
+                }}
+            {{else}}
+                {{> components/products/product-badge
+                    badge-type='sold-out'
+                    badge_view=theme_settings.product_sold_out_badges
+                    badge_label=theme_settings.pdp_sold_out_label
+                }}
             {{/if}}
-        {{else if has_options '===' false}}
-            {{#and (if stock_level '===' null) show_cart_action}}
-                {{#and (unless add_to_cart_url) (unless pre_order)}}
-                    {{#if theme_settings.pdp_sold_out_label '===' ''}}
-                        {{> components/products/product-badge
-                            badge-type='sold-out'
-                            badge_view=theme_settings.product_sold_out_badges
-                            badge_label=(lang "page_builder.pdp_sold_out_label")
-                        }}
-                    {{else}}
-                        {{> components/products/product-badge
-                            badge-type='sold-out'
-                            badge_view=theme_settings.product_sold_out_badges
-                            badge_label=theme_settings.pdp_sold_out_label
-                        }}
-                    {{/if}}
-                {{/and}}
-            {{/and}}
         {{else}}
             {{#or price.sale_price_with_tax.value price.sale_price_without_tax.value}}
                 {{#if theme_settings.pdp_sale_badge_label '===' ''}}


### PR DESCRIPTION
#### What?

We revert this PR since it added 2 bugs - BCTHEME-1473, 1481. The issue related to the fact that currently we don’t have an appropriate flag that shows if a product can be purchasable or not on PLP (screenshot#1). For instance, we have `can_purchase` flag for this purpose in PDP. Previously `show_cart_action` has been used in PLP according to our docs (screenshot#2).

<img width="1237" alt="Screenshot 2023-04-26 at 12 26 54" src="https://user-images.githubusercontent.com/67792608/235929110-6446ccbf-f2f6-45c3-98fa-0a361ed6522b.png">

<img width="1206" alt="Screenshot 2023-04-24 at 14 55 38" src="https://user-images.githubusercontent.com/67792608/235929066-99a0dccd-b110-4801-b132-911c4cf5d7c2.png">

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [BCTHEME-1171](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1171)
- [BCTHEME-1473](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1473)
- [BCTHEME-1481](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1481)

#### Screenshots (if appropriate)



[BCTHEME-1171]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BCTHEME-1473]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BCTHEME-1481]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ