### PR TITLE
fix(storefront): Remove default whitespace from multiline input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Running Lighthouse npm script fails in terminal [#2345](https://github.com/bigcommerce/cornerstone/pull/2345)
 - Removed accelerated checkout integration [#2341](https://github.com/bigcommerce/cornerstone/pull/2341)
 - Added css classes for ApplePay Button [[#2344]](https://github.com/bigcommerce/cornerstone/pull/2344)
+- Remove default whitespace from multiline input [#2355](https://github.com/bigcommerce/cornerstone/pull/2355)
 
 ## 6.10.0 (03-23-2023)
 - A bug with the display of the product quantity on the PDP [#2340](https://github.com/bigcommerce/cornerstone/pull/2340)

--- a/templates/components/common/forms/multiline.html
+++ b/templates/components/common/forms/multiline.html
@@ -14,7 +14,5 @@
               data-input
               class="form-input"
               {{#if private_id}}data-field-type="{{private_id}}"{{/if}}
-    >
-        {{value}}
-    </textarea>
+    >{{value}}</textarea>
 </div>


### PR DESCRIPTION
#### What?

Extra spaces are added to the `<textarea>` input in the multiline form component: `components/common/forms/multiline.html`

You can see this in the "Write a Review" modal "Comments" input box on the [Cornerstone demo store](https://cornerstone-light-demo.mybigcommerce.com/all/canvas-laundry-cart/)

This looks like same issue fixed in: [fix(storefront): STRF-4497 Removed default whitespace in textarea product option.](https://github.com/bigcommerce/cornerstone/pull/1222), and it can be fixed the same way.

#### Requirements

#### Tickets / Documentation

Relevant PR's: https://github.com/bigcommerce/cornerstone/pull/1222

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/10084927/236332329-f371d435-071f-465e-81bc-ef6747a522ea.png)

