### PR TITLE
feat(payment): BOLT-576 Add Bolt SPB support to cornerstone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Running Lighthouse npm script fails in terminal [#2345](https://github.com/bigcommerce/cornerstone/pull/2345)
 - Removed accelerated checkout integration [#2341](https://github.com/bigcommerce/cornerstone/pull/2341)
 - Added css classes for ApplePay Button [[#2344]](https://github.com/bigcommerce/cornerstone/pull/2344)
+- Added styling config for the Bolt smart payment button [[#2356]](https://github.com/bigcommerce/cornerstone/pull/2356)
 
 ## 6.10.0 (03-23-2023)
 - A bug with the display of the product quantity on the PDP [#2340](https://github.com/bigcommerce/cornerstone/pull/2340)

--- a/config.json
+++ b/config.json
@@ -326,6 +326,7 @@
     "paymentbuttons-paypal-shape": "rect",
     "paymentbuttons-paypal-label": "checkout",
     "paymentbanners-homepage-color": "white",
+    "paymentbuttons-bolt-shape": "rect",
     "paymentbanners-homepage-ratio": "8x1",
     "paymentbanners-cartpage-text-color": "black",
     "paymentbanners-cartpage-logo-position": "left",

--- a/schema.json
+++ b/schema.json
@@ -2879,6 +2879,11 @@
             "value": "masterpass",
             "label": "i18n.MasterpassProviderSortingLabel",
             "enabledBy": "masterpass"
+          },
+          {
+            "value": "bolt",
+            "label": "i18n.BoltProviderSortingLabel",
+            "enabledBy": "bolt"
           }
         ]
       },
@@ -3173,6 +3178,28 @@
           {
             "value": "white",
             "label": "i18n.WhiteBlackText"
+          }
+        ]
+      },
+      {
+        "type": "heading",
+        "content": "i18n.SmartBoltButton",
+        "enable": "isBoltProvidersEnabled"
+      },
+      {
+        "type": "select",
+        "label": "i18n.ButtonShape",
+        "id": "paymentbuttons-bolt-shape",
+        "enable": "isBoltProvidersEnabled",
+        "force_reload": true,
+        "options": [
+          {
+            "value": "pill",
+            "label": "i18n.Pill"
+          },
+          {
+            "value": "rect",
+            "label": "i18n.Rectangle"
           }
         ]
       }

--- a/schemaTranslations.json
+++ b/schemaTranslations.json
@@ -4810,6 +4810,9 @@
     "no": "PayPal-knapp på betalingssiden",
     "ko": "PayPal 체크아웃"
   },
+  "i18n.SmartBoltButton": {
+    "default": "Bolt button"
+  },
   "i18n.ProductPageBanner": {
     "default": "Product page banner",
     "fr": "Bannière de la page produit",
@@ -5591,5 +5594,8 @@
     "da": "Masterpass",
     "no": "Masterpass",
     "ko": "Masterpass"
+  },
+  "i18n.BoltProviderSortingLabel": {
+    "default": "Bolt"
   }
 }


### PR DESCRIPTION
#### What?
Add ability to configure Bolt smart payment button on product details page

#### Requirements

#### Tickets / Documentation

• [BOLT-576](https://bigcommercecloud.atlassian.net/browse/BOLT-576)

#### Screenshots (if appropriate)

<img width="629" alt="Screenshot 2023-05-12 at 12 10 06" src="https://github.com/bigcommerce/cornerstone/assets/9430298/4ef47386-a3a0-4cbd-8053-67c2d3f24e5e">
<img width="1122" alt="Screenshot 2023-05-12 at 12 11 15" src="https://github.com/bigcommerce/cornerstone/assets/9430298/a7338665-cb26-42b9-b633-545406286b01">


[BOLT-576]: https://bigcommercecloud.atlassian.net/browse/BOLT-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ