### PR TITLE
Use ISO 8601 DateTime format for datePublished in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added css classes for ApplePay Button [[#2344]](https://github.com/bigcommerce/cornerstone/pull/2344)
 - Added styling config for the Bolt smart payment button [[#2356]](https://github.com/bigcommerce/cornerstone/pull/2356)
 - Remove default whitespace from multiline input [#2355](https://github.com/bigcommerce/cornerstone/pull/2355)
+- Use ISO 8601 DateTime format for datePublished in schema [#2357](https://github.com/bigcommerce/cornerstone/pull/2357)
 
 ## 6.10.0 (03-23-2023)
 - A bug with the display of the product quantity on the PDP [#2340](https://github.com/bigcommerce/cornerstone/pull/2340)

--- a/templates/components/products/schema.html
+++ b/templates/components/products/schema.html
@@ -30,7 +30,7 @@
                     "@type": "Person",
                     "name": {{#if name}}{{{JSONstringify name}}}{{else}}{{{JSONstringify (lang 'products.reviews.anonymous_poster')}}}{{/if}}
                 },
-                "datePublished": "{{date}}",
+                "datePublished": "{{moment date "YYYY-MM-DD"}}",
                 "reviewBody": {{{JSONstringify text}}},
                 "name": {{{JSONstringify title}}},
                 "reviewRating": {


### PR DESCRIPTION
#### What?

Noticed this warning came up in the schema visualizer. Simple use of the `{{moment}}` helper resolves it.

> Schema.org datePublished value is not in a valid format or type
> The value needs to be a type or sub-type of:
>
> [DateTime](https://schema.org/DateTime) which needs to comply with the [ISO 8601 DateTime format](http://en.wikipedia.org/wiki/ISO_8601). e.g. '2020-10-24T23:30:05'
> [Date](https://schema.org/Date) which needs to comply with the [ISO 8601 Date format](http://en.wikipedia.org/wiki/ISO_8601). e.g. '2020-10-24'

https://schema.org/Date
https://schema.org/DateTime

#### Screenshots (if appropriate)

**BEFORE**
![Screenshot 2023-05-12 at 10 21 09 AM](https://github.com/bigcommerce/cornerstone/assets/5056945/82684bfc-e740-4aab-8902-d739710e4d52)

**AFTER**
![Screenshot 2023-05-12 at 10 24 18 AM](https://github.com/bigcommerce/cornerstone/assets/5056945/8d263ada-d9d1-4745-9ab4-bad5b2f893aa)