### PR TITLE
fix(checkout): CHECKOUT-7213 refresh cart page if no item in the cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added css classes for ApplePay Button [[#2344]](https://github.com/bigcommerce/cornerstone/pull/2344)
 - Added styling config for the Bolt smart payment button [[#2356]](https://github.com/bigcommerce/cornerstone/pull/2356)
 - Remove default whitespace from multiline input [#2355](https://github.com/bigcommerce/cornerstone/pull/2355)
+- Refresh page if no more item in the cart [#2360](https://github.com/bigcommerce/cornerstone/pull/2360)
 
 ## 6.10.0 (03-23-2023)
 - A bug with the display of the product quantity on the PDP [#2340](https://github.com/bigcommerce/cornerstone/pull/2340)

--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -214,10 +214,15 @@ export default class Cart extends PageManager {
             this.$cartAdditionalCheckoutBtns.html(response.additionalCheckoutButtons);
 
             $cartPageTitle.replaceWith(response.pageTitle);
-            this.bindEvents();
-            this.$overlay.hide();
 
             const quantity = $('[data-cart-quantity]', this.$cartContent).data('cartQuantity') || 0;
+
+            if (!quantity) {
+                return window.location.reload();
+            }
+
+            this.bindEvents();
+            this.$overlay.hide();
 
             $('body').trigger('cart-quantity-update', quantity);
 


### PR DESCRIPTION
#### What?

When a cart has both free gift products and standard products and all standard products are removed the cart page does not refresh to the “cart is empty” message and just shows a cart with no products in it.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [CHECKOUT-7213](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-7213)

#### Screenshots (if appropriate)

##### Before 
![image](https://github.com/bigcommerce/cornerstone/assets/84553389/30bf031d-412c-443a-bf35-4c780edd199c)

##### After
![image](https://github.com/bigcommerce/cornerstone/assets/84553389/728bc2a7-6fcd-4e55-835b-9ba708167e01)


cc @bigcommerce/checkout 


[CHECKOUT-7213]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-7213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ