### PR TITLE
fix(storefront): BCTHEME-1323 (sanitize product.description) in the theme results to ‘error length of description’ from Google indexing for lengthy product description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- (sanitize product.description) in the theme results to ‘error length of description’ from Google indexing for lengthy product description [#2363](https://github.com/bigcommerce/cornerstone/pull/2363)
 - If the gift is a variant, the button "Change" shows in cart, and other variant are visible [#2349](https://github.com/bigcommerce/cornerstone/pull/2349)
 - Removes the URL encoding from the 'description' in the product rich snippet schema [#2350](https://github.com/bigcommerce/cornerstone/pull/2350)
 - Running Lighthouse npm script fails in terminal [#2345](https://github.com/bigcommerce/cornerstone/pull/2345)

--- a/templates/components/products/schema.html
+++ b/templates/components/products/schema.html
@@ -14,7 +14,7 @@
             "name": {{{JSONstringify product.brand.name}}}
         },
         {{/if}}
-        "description": "{{sanitize product.description}}",
+        "description": {{{json (ellipsis (sanitize product.description) 4000) }}},
         "image": "{{getImage product.main_image 'zoom_size' (cdn theme_settings.default_image_product)}}",
         {{#and settings.show_product_reviews product.reviews.list.length}}
         "aggregateRating": {


### PR DESCRIPTION
**What?**

Google Search Console is reporting an error which state : 
`Invalid string length in field "description" (optional)`
This PR fixes an error.

**Tickets / Documentation**

- [BCTHEME-1323](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1323)

**Screen Recording** 
Before:

https://github.com/bigcommerce/cornerstone/assets/83779098/b84567d1-10c3-4afd-82a4-41b6b2a9b5d1

After:

https://github.com/bigcommerce/cornerstone/assets/83779098/2c6a0f48-cf53-4b61-939b-0515c8bbbcaf


[BCTHEME-1323]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ