### PR TITLE
fix(storefront): BCTHEME-1378 fix add product to cart on iphone x (iphone version 11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump Stencil utils to 6.15.1 [#2365][https://github.com/bigcommerce/cornerstone/pull/2365]
 - Added ACH payment method section to My Account -> Payment Methods page [#2362](https://github.com/bigcommerce/cornerstone/pull/2362)
 - Remove data_tag_enabled check from everywhere [#2369][https://github.com/bigcommerce/cornerstone/pull/2369]
+- Fix add product to cart on iphone x (iphone version 11) [#2370][https://github.com/bigcommerce/cornerstone/pull/2370]
 
 ## 6.11.0 (05-24-2023)
 - Reverted fix for sold-out badge appearance [#2354](https://github.com/bigcommerce/cornerstone/pull/2354)

--- a/assets/js/polyfills.js
+++ b/assets/js/polyfills.js
@@ -1,9 +1,6 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
-import 'whatwg-fetch';
 import objectFitImages from 'object-fit-images';
-
-require('formdata-polyfill');
 
 document.addEventListener('DOMContentLoaded', () => {
     objectFitImages();

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -60,6 +60,23 @@
             {{!-- Exported in app.js --}}
             function onThemeBundleMain() {
                 window.stencilBootstrap("{{page_type}}", {{jsContext}}).load();
+
+                function browserSupportsFormData() {
+                    return typeof FormData !== 'undefined' 
+                        && !!FormData.prototype.keys;
+                }
+                function loadFormDataPolyfillScript(src) {
+                    var formDataPolyfillScript = document.createElement('script');
+                    formDataPolyfillScript.src = src;
+                    formDataPolyfillScript.onerror = function () {
+                        console.error('Failed to load formData polyfill script ' + src);
+                    };
+                    document.body.appendChild(formDataPolyfillScript);
+                }
+
+                if (!browserSupportsFormData()) {
+                    loadFormDataPolyfillScript('{{cdn 'assets/dist/theme-bundle.polyfill_form_data.js'}}');
+                }
             }
         </script>
         <script async defer src="{{cdn 'assets/dist/theme-bundle.main.js' resourceHint='preload' as='script'}}" onload="onThemeBundleMain()"></script>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -13,6 +13,7 @@ module.exports = {
         head_async: ['lazysizes'],
         font: './assets/js/theme/common/font.js',
         polyfills: './assets/js/polyfills.js',
+        polyfill_form_data: ['formdata-polyfill'],
     },
     module: {
         rules: [


### PR DESCRIPTION
#### What?

This pr is a fix for correct processing of invalid formData in iOS Safari 11.2. Two issues were covered here:
1. When formData is invalid but exists - polifill do not work, so additional checks were added to detect such browsers, like iOS 11.2 Safari
2. FormData polyfill should run after whatwg-fetch to correctly update fetch that should convert formData like object into blob. That is the reason why correctly collected formData object was unclear for server. So formData polyfill should run after whatwg-fetch declared in stencil-utils. It goes with main bundle so after main loaded formData polyfill can be added to the browser 

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [BCTHEME-1678](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1378)

#### Screenshots (if appropriate)

https://github.com/bigcommerce/cornerstone/assets/66325265/48600629-6a2a-41b4-8704-b1f0b04cd281





[BCTHEME-1678]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ