### PR TITLE
feat(checkout): CHECKOUT-7557 display fees on cart page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ACH payment method section to My Account -> Payment Methods page [#2362](https://github.com/bigcommerce/cornerstone/pull/2362)
 - Remove data_tag_enabled check from everywhere [#2369][https://github.com/bigcommerce/cornerstone/pull/2369]
 - Fix add product to cart on iphone x (iphone version 11) [#2370][https://github.com/bigcommerce/cornerstone/pull/2370]
+- Display fees on cart page [#2360](https://github.com/bigcommerce/cornerstone/pull/2376)
 
 ## 6.11.0 (05-24-2023)
 - Reverted fix for sold-out badge appearance [#2354](https://github.com/bigcommerce/cornerstone/pull/2354)

--- a/templates/components/cart/totals.html
+++ b/templates/components/cart/totals.html
@@ -21,6 +21,18 @@
             </div>
         </li>
     {{/if}}
+    {{#if cart.fees}}
+        {{#each cart.fees}}
+            <li class="cart-total">
+                <div class="cart-total-label">
+                    <strong>{{display_name}}:</strong>
+                </div>
+                <div class="cart-total-value">
+                    <span>{{cost.formatted}}</span>
+                </div>
+            </li>
+        {{/each}}
+    {{/if}}
     {{#if cart.shipping_handling.show_estimator}}
         <li class="cart-total">
             <div class="cart-total-label">


### PR DESCRIPTION
#### What?

change cart page template to display fees on cart page

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [CHECKOUT-7557](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-7557)
- 
#### Screenshots

after change
<img width="1450" alt="Screenshot 2023-07-06 at 11 55 15 am" src="https://github.com/bigcommerce/cornerstone/assets/94653751/7b2b2ca1-cc78-4419-a7c3-c93b512c5aa4">


[CHECKOUT-7557]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-7557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ping @bigcommerce/team-checkout 