### PR TITLE
feat(checkout): CHECKOUT-7176 Displaying the Hidden Cart Source Input Field on PDP page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display fees on cart page [#2376](https://github.com/bigcommerce/cornerstone/pull/2376)
 - Replace Twitter logo with X logo within social sharing and social link components [#2387](https://github.com/bigcommerce/cornerstone/pull/2387)
 - Added nvm config [#2389](https://github.com/bigcommerce/cornerstone/pull/2389)
+- Displaying the Hidden cart_order_source Input Field on PDP page [#2392](https://github.com/bigcommerce/cornerstone/pull/2392) 
 
 ## 6.12.0 (07-06-2023)
 - sync package lock file [#2373](https://github.com/bigcommerce/cornerstone/pull/2373)

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -234,6 +234,9 @@
                   data-cart-item-add>
                 <input type="hidden" name="action" value="add">
                 <input type="hidden" name="product_id" value="{{product.id}}"/>
+                {{#if product.cart_order_source}}
+                    <input type="hidden" name="cart_order_source" value="{{product.cart_order_source}}"/>
+                {{/if}}
                 <div data-product-option-change style="display:none;">
                     {{inject 'showSwatchNames' theme_settings.show_product_swatch_names}}
                     {{#each product.options}}


### PR DESCRIPTION
#### What?

Displaying the Hidden Cart Source Input Field on PDP page

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation [CHECKOUT-7176](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-7176)

The "Add to Cart" button on the PDP page initiates a call to the remote/v1/add endpoint for adding items to the cart. To facilitate the creation of a cart with the order source set to 'buyButton,' it will display the hidden cart source input field, enabling the posting of the cart source value to the endpoint.

Here are all the scenarios related to determining whether the order source needs to be set as "buy_button." This PR is specifically focused on addressing scenario 5.
  | Scenario | Redirect To | Is set order source buy button?
-- | -- | -- | --
1 | Not cart in the session | Checkout | Yes
2 | A cart in the session | Checkout | No
3 | Not cart in the session | Cart | No (to change Yes in another PR)
4 | A cart in the session | Cart | No
5 | Not cart in the session | PDP page → click add product | No (this PR will display cart_source and able to send to remote/add endpoint)
6 | A cart in the session | PDP page → click add product | No
7 | Secondary cart | PDP page → click wallet button | No

#### Screenshots
##### Add item to cart on PDP when there is no cart in the session - order source will set as buy button

https://github.com/bigcommerce/bigcommerce/assets/84553389/b8cdcdb3-b78e-482b-9b72-1828c5425e0e

##### Add item to cart on PDP when there is a cart in the session - order source will not set as buy button

https://github.com/bigcommerce/bigcommerce/assets/84553389/19495692-a114-4d0e-b99d-09d95108bd91


@bigcommerce/team-checkout 

[CHECKOUT-7176]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-7176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ