### PR TITLE
Improve German plural strings

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -10,7 +10,8 @@
         "info": "Info",
         "categories": "Kategorien",
         "call_us": "Rufen Sie uns an unter {phone_number}",
-        "powered_by": "Bereitgestellt von"
+        "powered_by": "Bereitgestellt von",
+        "test": "Hello, Berlin!"
     },
     "home": {
         "heading": "Startseite"
@@ -40,7 +41,7 @@
         "nav_aria_label": "Warenkorb mit 0 Artikeln",
         "continue_shopping": "Klicken Sie hier, um mit dem Einkauf fortzufahren",
         "login_to_checkout": "Anmelden, um zur Kasse zu gehen",
-        "items": "{NUM, plural, =0{(0 Artikel)} one {(# Artikel)} other {(# Artikel)}}",
+        "items": "{NUM, plural, =0{(Kein Artikel)} one {(Ein Artikel)} other {(# Artikel)}}",
         "checkout": {
             "address": {
                 "multiple": "Bezahlvorgang mit mehreren Adressen abschließen",
@@ -126,8 +127,8 @@
             "preview": "Vorschau"
         },
         "added_to_cart": {
-            "what_next": "Ok, {num_products, plural, one {1 Artikel wurde} other {# Artikel wurden}} in Ihren Warenkorb gelegt. Wie möchten Sie fortfahren?",
-            "your_cart_contains": "Ihr Warenkorb enthält {num_products, plural, one {1 Artikel} other {# Artikel}}",
+            "what_next": "Ok, {num_products, plural, one {ein Artikel wurde} other {# Artikel wurden}} in Ihren Warenkorb gelegt. Wie möchten Sie fortfahren?",
+            "your_cart_contains": "Ihr Warenkorb enthält {num_products, plural, one {einen Artikel} other {# Artikel}}",
             "proceed_to_checkout": "Weiter zur Kasse",
             "order_subtotal": "Zwischensumme der Bestellung",
             "continue_shopping": "Weiter einkaufen",
@@ -215,9 +216,9 @@
     },
     "compare": {
         "button": "Produkte vergleichen",
-        "header": "Vergleich von {products, plural, one {# Produkt} other {# Produkten}}",
+        "header": "Vergleich von {products, plural, one {einem Produkt} other {# Produkten}}",
         "remove": "Entfernen",
-        "no_remove": "Für einen gültigen Vergleich sind mindestens 2 Produkte erforderlich.",
+        "no_remove": "Für einen gültigen Vergleich sind mindestens zwei Produkte erforderlich.",
         "add_to_cart": "Zum Warenkorb hinzufügen",
         "no_compare": "Bitte wählen Sie mindestens zwei Produkte aus, um Sie zu vergleichen."
     },
@@ -339,7 +340,7 @@
             "last_update": "Letztes Update",
             "list": {
                 "order_number": "Bestellung #{number}",
-                "product_details": "{num_products, plural, one {1 produkt} other {# Produkte}} mit einem Gesamtbetrag von {cost}"
+                "product_details": "{num_products, plural, one {Ein Produkt} other {# Produkte}} mit einem Gesamtbetrag von {cost}"
             },
             "details": {
                 "heading": "Bestellung #{number}",
@@ -379,8 +380,8 @@
                 "heading": "Bestellung #{number} Downloads",
                 "download_files_below": "Untenstehend können Sie die Dateien herunterladen für:",
                 "expired_content": "Datei ist abgelaufen",
-                "days_remaining": "{number, plural, one {1 Tag} other {# Tage}}",
-                "downloads_remaining": "{number, plural, one {1 Download} other {# Downloads}} verbleibend",
+                "days_remaining": "{number, plural, one {Ein Tag} other {# Tage}}",
+                "downloads_remaining": "{number, plural, one {Ein Download} other {# Downloads}} verbleibend",
                 "days_or_downloads": "oder {number} Downloads",
                 "remaining": "verbleiben"
             }
@@ -486,7 +487,7 @@
             "edit": "Wunschliste bearbeiten",
             "view_heading": "Wunschliste: {name}",
             "share_intro": "Diese Wunschliste mit Freunden teilen:",
-            "num_products": "{num_products, plural, one {1 Produkt} other {# Produkte}}",
+            "num_products": "{num_products, plural, one {Ein Produkt} other {# Produkte}}",
             "create": "Wunschliste erstellen",
             "save": "Wunschliste speichern",
             "delete_alert": "Möchten Sie Ihre Wunschliste(n) wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
@@ -599,7 +600,7 @@
                 "amount": "Betrag",
                 "theme": "Geschenkgutschein-Design",
                 "custom_range": "(Der Wert muss zwischen {min} und {max} liegen.)",
-                "agree": "Ich verstehe, dass Geschenkgutscheine nach {days, plural, one {1 Tag} other {# Tagen}} ablaufen",
+                "agree": "Ich verstehe, dass Geschenkgutscheine nach {days, plural, one {einem Tag} other {# Tagen}} ablaufen",
                 "agree2": "Ich erkläre mich damit einverstanden, dass Geschenkgutscheine nicht erstattungsfähig sind",
                 "preview": "Vorschau",
                 "preview_error": "Beim Laden der Vorschau ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.",
@@ -712,7 +713,7 @@
         "quantity_decrease": "Menge von {name} verringern",
         "quantity_increase": "Menge von {name} erhöhen",
         "quantity_error_message": "Die Anzahl sollte nur Zahlen enthalten",
-        "purchase_units": "{quantity, plural, =0{0 Einheiten} one {# Einheit} other {# Einheiten}}",
+        "purchase_units": "{quantity, plural, =0{0 Einheiten} one {Eine Einheit} other {# Einheiten}}",
         "max_purchase_quantity": "Höchstkaufwert:",
         "min_purchase_quantity": "Mindestkaufwert:",
         "related_products": "Verwandte Produkte",
@@ -726,7 +727,7 @@
             "hide": "Bewertungen ausblenden",
             "new": "Bewertung schreiben",
             "show": "Bewertungen anzeigen",
-            "header": "{total, plural, =0{0 Bewertungen} one {# Bewertung} other {# Bewertungen}}",
+            "header": "{total, plural, =0{Keine Bewertungen} one {# Bewertung} other {# Bewertungen}}",
             "link_to_review": "({total, plural, =0{Noch keine Bewertungen} one {# Bewertung} other {# Bewertungen}})",
             "post_on_by": "Verfasst von { name } am { date }",
             "rating_label": "Bewertung",
@@ -858,8 +859,8 @@
         "results": {
             "form_label": "Schlagwort suchen:",
             "form_button_text": "Suchen",
-            "count": "{ count, plural, one {# Ergebnis} other {# Ergebnisse} } für „{ search_query }“",
-            "quick_count": "{ count, plural, one {# Produktergebnis} other {# Produktergebnisse} } für „{ search_query }“",
+            "count": "{ count, plural, one {Kein Ergebnis} other {# Ergebnisse} } für „{ search_query }“",
+            "quick_count": "{ count, plural, one {Kein Produktergebnis} other {# Produktergebnisse} } für „{ search_query }“",
             "quick_count_live": "Produktergebnisse für",
             "product_count": "Produkte ({count})",
             "content_count": "Neuigkeiten und Informationen ({count})"
@@ -867,7 +868,7 @@
         "faceted": {
             "selected": {
                 "title": "Eingrenzen auf",
-                "rating-label": "Bewertet mit {rating, plural, one {# Stern} other {# Sterne}} oder höher",
+                "rating-label": "Bewertet mit {rating, plural, one {einem Stern} other {# Sterne}} oder höher",
                 "no-filters": "Kein Filter angewendet",
                 "clear-all": "Alles löschen"
             },


### PR DESCRIPTION
#### What?

In German, when referring to a single item, we use "ein" ("one") instead of using the number 1 before the term.

Example: "ein Produkt" instead of "1 Produkt"

This PR will change all translations to a more natural way of writing those strings in German.
