### PR TITLE
Load other font weights and styles for the body-font

### DIFF
--- a/config.json
+++ b/config.json
@@ -103,7 +103,7 @@
     "default_image_brand": "img/BrandDefault.gif",
     "default_image_product": "img/ProductDefault.gif",
     "default_image_gift_certificate": "img/GiftCertificate.png",
-    "body-font": "Google_Karla_400",
+    "body-font": "Google_Karla_400,400i,700,700i",
     "headings-font": "Google_Montserrat_400",
     "fontSize-root": 14,
     "fontSize-h1": 28,


### PR DESCRIPTION
#### What?

Using a font name like `Google_Karla_400` for `body-font`, it would only load the 400 font weight. When using `Google_Karla_700` for another property, it would then load both the 400 and 700 fon weights. But since in CSS you could make something bold or italic, the font weight and/or style for this text might be missing, as it was not loaded automatically by using it in another property.

This PR will make sure that the most common font weights and font styles will be loaded for the body font.

#### Screenshots

The Karla font with `font-weight: 400` rendered in bold - looks squashed:
![Karla-Font](https://github.com/bigcommerce/cornerstone/assets/1793177/bb8c76ab-4e48-4e3e-9d9e-0e10e552390c)

The Karla font with `font-weight: 700` rendered in bold - looks perfect:
![Karla-Font-700](https://github.com/bigcommerce/cornerstone/assets/1793177/cd48b330-2b5b-47d0-8b04-856a451f2919)

