### PR TITLE
fix(storefront): BCTHEME-1748 Check lang helpers usage and existence of key in translation file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Check lang helpers usage and existence of key in translation file [#2403](https://github.com/bigcommerce/cornerstone/pull/2403)
 - Display fees on cart page [#2376](https://github.com/bigcommerce/cornerstone/pull/2376)
 - Replace Twitter logo with X logo within social sharing and social link components [#2387](https://github.com/bigcommerce/cornerstone/pull/2387)
 - Added nvm config [#2389](https://github.com/bigcommerce/cornerstone/pull/2389)

--- a/lang/en-CA.json
+++ b/lang/en-CA.json
@@ -1,5 +1,0 @@
-{
-    "header": {
-        "welcome_back": "Good day, {name}"
-    }
-}

--- a/lang/fr-CA.json
+++ b/lang/fr-CA.json
@@ -1,5 +1,0 @@
-{
-    "header": {
-        "welcome_back": "Bonjour, {name}"
-    }
-}


### PR DESCRIPTION
#### What?

This PR fixes an issue with displaying warnings in the terminal.

#### Tickets / Documentation

- [BCTHEME-1748](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1748)

#### Screenshots / Screen Recording 

**Before**

https://github.com/bigcommerce/cornerstone/assets/83779098/a550d0e5-54a1-4e8b-9729-98df60777afb

**After**

<img width="1303" alt="Screenshot 2023-11-28 at 11 16 02" src="https://github.com/bigcommerce/cornerstone/assets/83779098/6ee5d370-92e9-4ebb-a3f3-4c996043b422">



[BCTHEME-1748]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ