### PR TITLE
fix(storefront): PSE-868 Pagebuilder menu items are in the wrong case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Top Global Region Image Widget overlaps the mobile menu [#2402](https://github.com/bigcommerce/cornerstone/pull/2402)
 - Changed default PayPal checkout button color [#2405](https://github.com/bigcommerce/cornerstone/pull/2405)
 - Changed default PayPal checkout button size [#2406](https://github.com/bigcommerce/cornerstone/pull/2406)
+- Change case of Page builder menu item text [#2407](https://github.com/bigcommerce/cornerstone/pull/2407)
 
 ## 6.12.0 (07-06-2023)
 - sync package lock file [#2373](https://github.com/bigcommerce/cornerstone/pull/2373)

--- a/schemaTranslations.json
+++ b/schemaTranslations.json
@@ -1296,7 +1296,7 @@
     "pl": "Granica pola aktywna"
   },
   "i18n.HeaderAndFooter": {
-    "default": "Header & Footer",
+    "default": "Header and footer",
     "fr": "En-tête et pied de page",
     "it": "Intestazione e piè di pagina",
     "zh": "页眉和页脚",
@@ -2214,7 +2214,7 @@
     "pl": "Mała"
   },
   "i18n.HomePage": {
-    "default": "Home Page",
+    "default": "Homepage",
     "fr": "Page d'accueil",
     "it": "Homepage",
     "zh": "主页",
@@ -3546,7 +3546,7 @@
     "pl": "Standard"
   },
   "i18n.ButtonsAndIcons": {
-    "default": "Buttons & Icons",
+    "default": "Buttons and icons",
     "fr": "Boutons et icônes",
     "it": "Pulsanti e icone",
     "zh": "按钮与图标",
@@ -3924,7 +3924,7 @@
     "pl": "Pole wyboru i ikona radia"
   },
   "i18n.CheckoutPage": {
-    "default": "Checkout Page",
+    "default": "Checkout page",
     "fr": "Page de paiement",
     "it": "Pagina di checkout",
     "zh": "结账台页面",
@@ -4734,7 +4734,7 @@
     "pl": "Kolor tekstu tostów"
   },
   "i18n.PaymentButtons": {
-    "default": "Payment Buttons",
+    "default": "Payment buttons",
     "fr": "Boutons de paiement",
     "it": "Pulsanti di pagamento",
     "zh": "付款按钮",
@@ -5508,7 +5508,7 @@
     "pl": "Brak"
   },
   "i18n.PaymentBanners": {
-    "default": "Payment Banners",
+    "default": "Payment banners",
     "fr": "Bannières de paiement",
     "it": "Banner di pagamento",
     "zh": "付款横幅",


### PR DESCRIPTION
#### What?

Updating page builder menu items text to be in the correct case. Also replacing "&" with "and".

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Screenshots (if appropriate)
Before:
<img width="335" alt="Screenshot 2023-12-06 at 11 41 06 AM" src="https://github.com/bigcommerce/cornerstone/assets/20911717/609c9c28-5260-448a-bfe6-a553a3178bf4">

After:
<img width="256" alt="Screenshot 2023-12-06 at 11 42 56 AM" src="https://github.com/bigcommerce/cornerstone/assets/20911717/ed94fcd4-31b3-4e3b-afcd-ddca75a75310">

