### PR TITLE
fix(storefront): BCTHEME-1710 Pre-Orded text in Polish looks cropped in the button on Product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change case of Page builder menu item text [#2407](https://github.com/bigcommerce/cornerstone/pull/2407)
 - Corrected typo with the word default previously deafault in config.json [#2410](https://github.com/bigcommerce/cornerstone/pull/2410)
 - Adding autocomplete to common input fields [2397](https://github.com/bigcommerce/cornerstone/pull/2397)
+- Pre-Orded text in Polish looks cropped in the button on Product page [2414](https://github.com/bigcommerce/cornerstone/pull/2414)
 
 ## 6.12.0 (07-06-2023)
 - sync package lock file [#2373](https://github.com/bigcommerce/cornerstone/pull/2373)

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -358,6 +358,24 @@
             width: 50%;
         }
 
+        &.pre-order-buttons {
+            @include breakpoint("small") {
+                min-width: 50%;
+                width: auto;
+            }
+
+            @include breakpoint("medium") {
+                margin-right: remCalc(11px);
+                min-width: auto;
+                padding: 0;
+                width: auto;
+            }
+
+            .button {
+                padding: remCalc(13px) remCalc(24px);
+            }
+        }
+
         .button {
             margin: 0;
             width: 100%;

--- a/templates/components/products/add-to-cart.html
+++ b/templates/components/products/add-to-cart.html
@@ -42,7 +42,7 @@
         <p class="alertBox-column alertBox-message"></p>
     </div>
     {{#or customer (unless settings.hide_price_from_guests)}}
-        <div class="add-to-cart-buttons">
+        <div class="add-to-cart-buttons {{#if product.pre_order}}pre-order-buttons{{/if}}">
             <div class="form-action">
                 <input
                         id="form-action-addToCart"


### PR DESCRIPTION
#### What?

This PR fixes pre-orded text in Polish.

#### Tickets / Documentation

- [BCTHEME-1710](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1710)

#### Screenshots / Videos (if appropriate)
**before**:

https://github.com/bigcommerce/cornerstone/assets/82589781/29f8ac33-1372-42d4-902e-ebe7da21eb1a

**after**:

https://github.com/bigcommerce/cornerstone/assets/82589781/4d2fad93-8028-47ba-8351-f6bc6b667a4f


[BCTHEME-1710]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ