### PR TITLE
fix(storefront): BCTHEME-1757 Anchor links on category pages are not working when product filtering is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Anchor links on category pages are not working when product filtering is enabled [#2415](https://github.com/bigcommerce/cornerstone/pull/2415)
 - Dispatch an event on productOptionsChanged [#2400](https://github.com/bigcommerce/cornerstone/pull/2400)
 - Check lang helpers usage and existence of key in translation file [#2403](https://github.com/bigcommerce/cornerstone/pull/2403)
 - Display fees on cart page [#2376](https://github.com/bigcommerce/cornerstone/pull/2376)

--- a/assets/js/theme/common/faceted-search.js
+++ b/assets/js/theme/common/faceted-search.js
@@ -431,15 +431,8 @@ class FacetedSearch {
     }
 
     onPopState() {
-        const currentUrl = window.location.href;
-        const searchParams = new URLSearchParams(currentUrl);
-        // If searchParams does not contain a page value then modify url query string to have page=1
-        if (!searchParams.has('page')) {
-            const linkUrl = $('.pagination-link').attr('href');
-            const re = /page=[0-9]+/i;
-            const updatedLinkUrl = linkUrl.replace(re, 'page=1');
-            window.history.replaceState({}, document.title, updatedLinkUrl);
-        }
+        if (document.location.hash !== '') return;
+
         $(window).trigger('statechange');
     }
 }


### PR DESCRIPTION
**What?**

This PR fixes a bug related to anchor links on category pages when product filtering is enabled.

**Tickets / Documentation**

- [BCTHEME-1757](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1757)

**Screenshots / Screen Recording**

<img width="1679" alt="Screenshot 2024-01-05 at 12 09 09" src="https://github.com/bigcommerce/cornerstone/assets/83779098/fe3de45f-1cee-4e7f-9f35-1016d429d13c">


**Before**

https://github.com/bigcommerce/cornerstone/assets/83779098/c17e3ef0-7726-46bf-85e4-447d9ec225a0

**After**

https://github.com/bigcommerce/cornerstone/assets/83779098/d206cadb-f7c9-421d-97f7-efb633c19131



[BCTHEME-1757]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ