### PR TITLE
fix(storefront): BCTHEME-1769 ADA Compliance - Expandable items should be read by screen reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change case of Page builder menu item text [#2407](https://github.com/bigcommerce/cornerstone/pull/2407)
 - Corrected typo with the word default previously deafault in config.json [#2410](https://github.com/bigcommerce/cornerstone/pull/2410)
 - Adding autocomplete to common input fields [2397](https://github.com/bigcommerce/cornerstone/pull/2397)
+- ADA Compliance - Expandable items should be read by screen reader [2422](https://github.com/bigcommerce/cornerstone/pull/2422)
 
 ## 6.12.0 (07-06-2023)
 - sync package lock file [#2373](https://github.com/bigcommerce/cornerstone/pull/2373)

--- a/templates/components/cart/coupon-input.html
+++ b/templates/components/cart/coupon-input.html
@@ -1,11 +1,25 @@
 <div class="cart-total-value">
+    <button
+        class="coupon-code-add"
+        aria-label="Add Coupon"
+        aria-controls="add-coupon"
+        aria-expanded="false"
+    >
+        {{lang 'cart.coupons.add_coupon'}}
+    </button>
 
-    <button class="coupon-code-add">{{lang 'cart.coupons.add_coupon'}}</button>
-
-    <button class="coupon-code-cancel" style="display: none;">{{lang 'cart.coupons.cancel'}}</button>
+    <button
+        class="coupon-code-cancel"
+        style="display: none;"
+        aria-label="Add Coupon"
+        aria-controls="add-coupon"
+        aria-expanded="true"
+    >
+        {{lang 'cart.coupons.cancel'}}
+    </button>
 </div>
 
-<div class="cart-form coupon-code" style="display: none;">
+<div id="add-coupon" class="cart-form coupon-code" style="display: none;">
     <form class="form form--hiddenLabels coupon-form" method="post" action="{{urls.cart}}">
         <label class="form-label" for="couponcode">{{lang 'cart.coupons.coupon_code'}}</label>
         <input class="form-input" data-error="{{lang 'cart.coupons.empty_error'}}"  id="couponcode" type="text" name="couponcode" value="" placeholder="{{lang 'cart.coupons.coupon_code'}}">

--- a/templates/components/cart/gift-certificate-input.html
+++ b/templates/components/cart/gift-certificate-input.html
@@ -1,11 +1,25 @@
 <div class="cart-total-value">
+    <button
+        class="gift-certificate-add"
+        aria-label="Add Certificate"
+        aria-controls="add-certificate"
+        aria-expanded="false"
+    >
+        {{lang 'cart.gift_certificates.gift_certificate'}}
+    </button>
 
-    <button class="gift-certificate-add">{{lang 'cart.gift_certificates.gift_certificate'}}</button>
-
-    <button class="gift-certificate-cancel" style="display: none;">{{lang 'cart.coupons.cancel'}}</button>
+    <button
+        class="gift-certificate-cancel"
+        style="display: none;"
+        aria-label="Add Certificate"
+        aria-controls="add-certificate"
+        aria-expanded="true"
+    >
+        {{lang 'cart.coupons.cancel'}}
+    </button>
 </div>
 
-<div class="cart-form gift-certificate-code" style="display: none;">
+<div id="add-certificate" class="cart-form gift-certificate-code" style="display: none;">
     <form class="form form--hiddenLabels cart-gift-certificate-form" method="post" action="{{urls.cart}}">
         <label class="form-label" for="certcode">{{lang 'cart.gift_certificates.cert_code'}}</label>
         <input class="form-input" id="certcode" type="text" name="certcode" value="" placeholder="{{lang 'cart.gift_certificates.add_cert_code'}}">


### PR DESCRIPTION
#### What?

This PR adds appropriate aria attributes to each element that controls expandable content that are specified by screen reader.

#### Tickets / Documentation

- [BCTHEME-1769](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1769)

#### Screen records

https://github.com/bigcommerce/cornerstone/assets/82589781/aaf3aa3a-c3dd-4af2-8df8-ab9fcf179307


[BCTHEME-1769]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ