### PR TITLE
Fix HTML markup for product listing and below content region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Fix HTML markup for product listing and below content region [#2426](https://github.com/bigcommerce/cornerstone/pull/2426)
 - With Product Filtering enabled widgets on category page disappear after navigating using pagination [#2425](https://github.com/bigcommerce/cornerstone/pull/2425)
 - Update layout with correct usage of main tag [#2421](https://github.com/bigcommerce/cornerstone/pull/2421)
 - Anchor links on category pages are not working when product filtering is enabled [#2415](https://github.com/bigcommerce/cornerstone/pull/2415)

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -49,11 +49,11 @@ category:
 
     <main class="page-content" id="product-listing-container">
         {{> components/category/product-listing}}
-    </div>
+    </main>
 
     <div class="page-region">
         {{{region name="category_below_content"}}}
-    </main>
+    </div>
 </div>
 
 {{/partial}}


### PR DESCRIPTION
#### What?

This pull request corrects an HTML markup error introduced in https://github.com/bigcommerce/cornerstone/pull/2425 on the product listing page by fixing mismatched closing tags. It ensures the main element is properly closed with **`</main>`** and the div element encapsulating the "category_below_content" region closes with **`</div>`**.