### PR TITLE
fix(storefront): BCTHEME-1785 Remove shop_by_price: true from category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Remove shop_by_price: true from category.html [#2431](https://github.com/bigcommerce/cornerstone/pull/2431)
 
 ## 6.13.0 (02-12-2024)
 - Fix HTML markup for product listing and below content region [#2426](https://github.com/bigcommerce/cornerstone/pull/2426)

--- a/assets/js/theme/category.js
+++ b/assets/js/theme/category.js
@@ -79,7 +79,6 @@ export default class Category extends CatalogPage {
         const requestOptions = {
             config: {
                 category: {
-                    shop_by_price: true,
                     products: {
                         limit: productsPerPage,
                     },

--- a/templates/components/category/shop-by-price.html
+++ b/templates/components/category/shop-by-price.html
@@ -1,4 +1,4 @@
-{{#and theme_settings.shop_by_price_visibility category.shop_by_price}}
+{{#if theme_settings.shop_by_price_visibility}}
     <div class="sidebarBlock">
         <h2 class="sidebarBlock-heading heading-price" data-shop-by-price>{{lang 'category.shop_by_price'}}</h2>
 
@@ -9,4 +9,4 @@
             <span class="reset-message aria-description--hidden">{{lang 'category.filter_reset_announcement'}}</span>
         </div>
     </div>
-{{/and}}
+{{/if}}

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -1,6 +1,5 @@
 ---
 category:
-    shop_by_price: true
     products:
         limit: {{theme_settings.categorypage_products_per_page}}
 ---
@@ -39,12 +38,10 @@ category:
         <aside class="page-sidebar" id="faceted-search-container">
             {{> components/category/sidebar}}
         </aside>
-    {{else if category.shop_by_price}}
-        {{#if theme_settings.shop_by_price_visibility}}
-             <aside class="page-sidebar" id="faceted-search-container">
-                {{> components/category/sidebar}}
-            </aside>
-        {{/if}}
+    {{else if theme_settings.shop_by_price_visibility}}
+        <aside class="page-sidebar" id="faceted-search-container">
+            {{> components/category/sidebar}}
+        </aside>
     {{/if}}
 
     <main class="page-content" id="product-listing-container">


### PR DESCRIPTION
#### What?

This PR removes shop_by_price: true from category.

#### Tickets / Documentation

- [BCTHEME-1785](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1785)

#### Screen Recording
**before:**
**after:**
