### PR TITLE
fix(storefront): BCTHEME-1778 Decorative SVG elements should be hidden from screen reader users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Decorative SVG elements should be hidden from screen reader users [#2432](https://github.com/bigcommerce/cornerstone/pull/2432)
 
 ## 6.13.0 (02-12-2024)
 - Fix HTML markup for product listing and below content region [#2426](https://github.com/bigcommerce/cornerstone/pull/2426)

--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -156,7 +156,7 @@
                                 data-confirm-delete="{{lang 'cart.confirm_delete'}}"
                                 aria-label="{{lang 'cart.remove_item' name=name}}"
                         >
-                            <svg><use href="#icon-close"></use></svg>
+                            <svg aria-hidden="true"><use href="#icon-close"></use></svg>
                         </button>
                     {{/or}}
                 </td>


### PR DESCRIPTION
#### What?

This PR adds attribute **aria-hidden="true"** to the decorative SVG tag to ignore voiced the text by using screen reader. In order to meet WCAG 2.0 Level A

**Tickets / Documentation**

- [BCTHEME-1778](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1778)