### PR TITLE
fix(storefront): BCTHEME-1796 Page Suggested Items still listed on Cornerstone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Page Suggested Items still listed on Cornerstone [#2438](https://github.com/bigcommerce/cornerstone/pull/2438)
 - Remove shop_by_price: true from category.html [#2431](https://github.com/bigcommerce/cornerstone/pull/2431)
 - Added SEPA and ECP stored bank accounts typesto the Payment methods page [#2434](https://github.com/bigcommerce/cornerstone/pull/2434)
 

--- a/config.json
+++ b/config.json
@@ -20,7 +20,6 @@
       "product_comparison_table",
       "complex_search_filtering",
       "customizable_product_selector",
-      "cart_suggested_products",
       "free_customer_support",
       "free_theme_upgrades",
       "high_res_product_images",


### PR DESCRIPTION
#### What?

This PR removes the **Cart Suggested Products** feature from the Cornerstone page in the Theme Marketplace

**Tickets / Documentation**

- [BCTHEME-1796](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1796)

[BCTHEME-1796]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ