### PR TITLE
Extra quote mark

### DIFF
--- a/templates/components/products/product-info.html
+++ b/templates/components/products/product-info.html
@@ -2,4 +2,4 @@
 {{name}}, {{> components/products/product-aria-label}}
 {{else}}
 {{name}}
-{{/or}}"
+{{/or}}


### PR DESCRIPTION
#### What?

Both a leading and trailing quote are already present in the code that calls this template, so this trailing " breaks the HTML. If you look at the source in the demo theme you'll see this behavior https://cornerstone-light-demo.mybigcommerce.com/shop-all/garden/

#### Screenshots (if appropriate)

Attach images or add image links here.

![image](https://github.com/bigcommerce/cornerstone/assets/950448/e7d19937-9810-4c62-a921-8b97d36275a3)
