### PR TITLE
feat(payment): PAYPAL-3991 added min-height for vaulted payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Page Suggested Items still listed on Cornerstone [#2438](https://github.com/bigcommerce/cornerstone/pull/2438)
 - Remove shop_by_price: true from category.html [#2431](https://github.com/bigcommerce/cornerstone/pull/2431)
 - Added SEPA and ECP stored bank accounts typesto the Payment methods page [#2434](https://github.com/bigcommerce/cornerstone/pull/2434)
-
+- Added min-height for vaulted payment methods [#2455](https://github.com/bigcommerce/cornerstone/pull/2455)
 
 ## 6.13.0 (02-12-2024)
 - Fix HTML markup for product listing and below content region [#2426](https://github.com/bigcommerce/cornerstone/pull/2426)

--- a/assets/scss/components/stencil/paymentMethods/_paymentMethods.scss
+++ b/assets/scss/components/stencil/paymentMethods/_paymentMethods.scss
@@ -16,6 +16,7 @@
     margin-bottom: spacing("single");
 
     &-item {
+        min-height: remCalc(250px);
         padding: spacing("half");
         width: 100%;
 


### PR DESCRIPTION
#### What?
Added min-height for vaulted payment methods

#### Screenshots (if appropriate)
Before:
<img width="929" alt="Screenshot 2024-04-11 at 17 05 29" src="https://github.com/bigcommerce/cornerstone/assets/130665807/41eba08a-9e90-4a80-b8c3-8af482b0556a">

After:
<img width="937" alt="Screenshot 2024-04-11 at 17 05 35" src="https://github.com/bigcommerce/cornerstone/assets/130665807/9d50d2a9-4965-43a3-bbb4-9ab9aa159f7a">
