### PR TITLE
fix(storefront): Prevent flow outside page container on account pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Prevent flow outside page container on account pages [#2462](https://github.com/bigcommerce/cornerstone/pull/2462)
 
 ## 6.14.0 (05-15-2024)
 - Account.php <a href> is inside of a list item [#2457](https://github.com/bigcommerce/cornerstone/pull/2457)

--- a/templates/pages/account/add-address.html
+++ b/templates/pages/account/add-address.html
@@ -17,26 +17,26 @@
         {{/if}}
 
         <div class="account-body">
-
-            <form action="{{forms.address.action}}" data-address-form class="form" method="post">
-                {{#if forms.address.address_id }}
-                    <input type="hidden" name="shipid" value="{{forms.address.address_id}}">
-                {{/if}}
-                <fieldset class="form-fieldset">
-                    <div class="form-row form-row--half">
-                        {{#each forms.address.shipping_fields }}
-                            {{{dynamicComponent 'components/common/forms'}}}
-                        {{/each}}
+            <section class="account-content">
+                <form action="{{forms.address.action}}" data-address-form class="form" method="post">
+                    {{#if forms.address.address_id }}
+                        <input type="hidden" name="shipid" value="{{forms.address.address_id}}">
+                    {{/if}}
+                    <fieldset class="form-fieldset">
+                        <div class="form-row form-row--half">
+                            {{#each forms.address.shipping_fields }}
+                                {{{dynamicComponent 'components/common/forms'}}}
+                            {{/each}}
+                        </div>
+                    </fieldset>
+                    <div class="form-actions">
+                        <input type="submit" class="button button--primary" value="{{lang 'forms.address.submit_value'}}">
+                        <a href="{{urls.account.addresses}}" class="button">{{lang 'common.cancel'}}</a>
+                        {{inject 'required' (lang 'common.required')}}
+                        {{inject 'state_error' (lang 'errors.state_error')}}
                     </div>
-                </fieldset>
-                <div class="form-actions">
-                    <input type="submit" class="button button--primary" value="{{lang 'forms.address.submit_value'}}">
-                    <a href="{{urls.account.addresses}}" class="button">{{lang 'common.cancel'}}</a>
-                    {{inject 'required' (lang 'common.required')}}
-                    {{inject 'state_error' (lang 'errors.state_error')}}
-                </div>
-            </form>
-
+                </form>
+            </section>
         </div>
     </div>
 

--- a/templates/pages/account/addresses.html
+++ b/templates/pages/account/addresses.html
@@ -11,7 +11,6 @@
             {{#if customer.success}}
                 {{>components/common/alert/alert-success customer.success}}
             {{/if}}
-
             <section class="account-content">
                 {{> components/account/address-list }}
             </section>

--- a/templates/pages/account/addresses.html
+++ b/templates/pages/account/addresses.html
@@ -11,7 +11,10 @@
             {{#if customer.success}}
                 {{>components/common/alert/alert-success customer.success}}
             {{/if}}
-            {{> components/account/address-list }}
+
+            <section class="account-content">
+                {{> components/account/address-list }}
+            </section>
         </div>
     </div>
 {{/partial}}


### PR DESCRIPTION
#### What?

The main body content of the Account Address pages flows outside the main body container:
![image](https://github.com/bigcommerce/cornerstone/assets/10084927/35099396-c5cf-45d0-96d5-f7d2d90adab4)

This is happening because there is negative margin on `.account-body` but there is no padding to compensate for it. Some of the account pages([for example, orders/all.html](https://github.com/bigcommerce/cornerstone/blob/51750148ecc1158465328b0d7a128a6c3e697434/templates/pages/account/orders/all.html#L22)) use a wrapper element with class `account-content` to compensate for this negative margin, so I suggested doing the same on add-address.html and addresses.html.

Note: other account pages don't use the `account-content` class, and instead compensate for the negative margin by adding padding to other elements.


#### Requirements

- [ X] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

n/a

#### Screenshots (if appropriate)

Current state:
![image](https://github.com/bigcommerce/cornerstone/assets/10084927/35099396-c5cf-45d0-96d5-f7d2d90adab4)

Fixed:
![image](https://github.com/bigcommerce/cornerstone/assets/10084927/282e404f-e48d-4186-a5f9-278f335c81fd)

