### PR TITLE
fix: DATA-11867 Fix duplicating add_to_cart meta pixel events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Remove remote_api_scripts to avoid double firing Meta Pixel analytics [#2467](https://github.com/bigcommerce/cornerstone/pull/2467)
 - Prevent flow outside page container on account pages [#2462](https://github.com/bigcommerce/cornerstone/pull/2462)
 - Account.js - Fixed jquery selector to be template literal [#2464](https://github.com/bigcommerce/cornerstone/pull/2464)
 

--- a/templates/components/cart/preview.html
+++ b/templates/components/cart/preview.html
@@ -113,4 +113,3 @@
         </section>
     {{/if}}
 </div>
-{{{remote_api_scripts}}}


### PR DESCRIPTION
#### What?
Remove `remote_api_scripts` from cart preview template which fixes duplicating `addToCart` event for Meta Pixel integration.
Previously we've added it to fix the legacy (UA) Google Analytics integration without realising it's duplicating Meta Pixel event. Since the legacy Google Analytics is sunset now, it's not a concern anymore, so it's safe to remove these scripts.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation
[DATA-11867](https://bigcommercecloud.atlassian.net/browse/DATA-11867)

PR where the issue was initially introduced: https://github.com/bigcommerce/cornerstone/pull/2281

#### Screenshots (if appropriate)


#### Testing
- Manually tested on dev store. Verified that only one `addToCart` event is firing now when I adding a product from PDP or QuickView product form

[DATA-11867]: https://bigcommercecloud.atlassian.net/browse/DATA-11867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ