### PR TITLE
fix(storefront): BCTHEME-1903 Viewing Orders after logging into customer account displays incorrect quantity of products ordered compared to Order details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Viewing Orders after logging into customer account displays incorrect quantity of products ordered compared to Order details page. [#2482](https://github.com/bigcommerce/cornerstone/pull/2482)
 - High severity security issue [#2477](https://github.com/bigcommerce/cornerstone/pull/2477)
 - Date Field Modifier - February showing 30th and 31st [#2473](https://github.com/bigcommerce/cornerstone/pull/2473)
 - Adding mobile nav dropdown focusTrap [#2465](https://github.com/bigcommerce/cornerstone/pull/2465)

--- a/templates/components/account/orders-list.html
+++ b/templates/components/account/orders-list.html
@@ -35,7 +35,7 @@
                 <h5 class="account-product-title">
                     <a href="{{this.details_url}}">{{lang 'account.orders.list.order_number' number=this.id}}</a>
                 </h5>
-                <p class="account-product-description">{{lang 'account.orders.list.product_details' num_products=this.items.length cost=this.total.formatted}}</p>
+                <p class="account-product-description">{{lang 'account.orders.list.product_details' num_products=this.total_quantity cost=this.total.formatted}}</p>
 
                 <div class="account-product-details">
                     <div class="account-product-detail">


### PR DESCRIPTION
Jira: [BCTHEME-1903](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1903)

## What/Why?
This PR fixes the bug displays incorrect quantity of products ordered.

## Rollout/Rollback
No Rollout/Rollback

## Testing

**Before**

<img width="1679" alt="before 1" src="https://github.com/user-attachments/assets/5ece144d-85e7-4ff4-b264-0f321a6ce81e">
<img width="1673" alt="before 2" src="https://github.com/user-attachments/assets/2706e0cc-7628-4c57-9ab5-c9922be5a28c">

**After**

<img width="1677" alt="after 1" src="https://github.com/user-attachments/assets/63f41265-37a0-4b1d-9a50-024318eb9e60">
<img width="1680" alt="after 2" src="https://github.com/user-attachments/assets/ff335c01-6d84-4e70-8ca1-562b95b8f407">




[BCTHEME-1903]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ