### PR TITLE
Draft PR - Example for Supporting Missing Prices in Stencil Context Data

### DIFF
--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -15,13 +15,13 @@ const optionsTypesMap = {
     PRODUCT_LIST: 'product-list',
 };
 
-export function optionChangeDecorator(areDefaultOtionsSet) {
+export function optionChangeDecorator(areDefaultOptionsSet) {
     return (err, response) => {
         const attributesData = response.data || {};
         const attributesContent = response.content || {};
 
         this.updateProductAttributes(attributesData);
-        if (areDefaultOtionsSet) {
+        if (areDefaultOptionsSet) {
             this.updateView(attributesData, attributesContent);
         } else {
             this.updateDefaultAttributesForOOS(attributesData);
@@ -145,8 +145,14 @@ export default class ProductDetailsBase {
      */
     getViewModel($scope) {
         return {
-            $priceWithTax: $('[data-product-price-with-tax]', $scope),
-            $priceWithoutTax: $('[data-product-price-without-tax]', $scope),
+            priceWithTax: {
+            	$div: $('div.price--withTax', $scope),
+            	$span: $('[data-product-price-with-tax]', $scope)
+            },
+            priceWithoutTax: {
+            	$div: $('div.price--withoutTax', $scope),
+            	$span: $('[data-product-price-without-tax]', $scope)
+            },
             rrpWithTax: {
                 $div: $('.rrp-price--withTax', $scope),
                 $span: $('[data-product-rrp-with-tax]', $scope),
@@ -210,6 +216,8 @@ export default class ProductDetailsBase {
         viewModel.priceSaved.$div.hide();
         viewModel.priceNowLabel.$span.hide();
         viewModel.priceLabel.$span.hide();
+        viewModel.priceWithTax.$div.hide();
+        viewModel.priceWithoutTax.$div.hide();
     }
 
     /**
@@ -223,6 +231,8 @@ export default class ProductDetailsBase {
 
         if (data.price instanceof Object) {
             this.updatePriceView(viewModel, data.price);
+        } else {
+        	this.clearPricingNotFound(viewModel);
         }
 
         if (data.weight instanceof Object) {
@@ -292,7 +302,8 @@ export default class ProductDetailsBase {
                 `${price.price_range.min.with_tax.formatted} - ${price.price_range.max.with_tax.formatted}`
                 : price.with_tax.formatted;
             viewModel.priceLabel.$span.show();
-            viewModel.$priceWithTax.html(updatedPrice);
+            viewModel.priceWithTax.$div.show();
+            viewModel.priceWithTax.$span.html(updatedPrice);
         }
 
         if (price.without_tax) {
@@ -300,7 +311,8 @@ export default class ProductDetailsBase {
                 `${price.price_range.min.without_tax.formatted} - ${price.price_range.max.without_tax.formatted}`
                 : price.without_tax.formatted;
             viewModel.priceLabel.$span.show();
-            viewModel.$priceWithoutTax.html(updatedPrice);
+            viewModel.priceWithoutTax.$div.show();
+            viewModel.priceWithoutTax.$span.html(updatedPrice);
         }
 
         if (price.rrp_with_tax) {

--- a/templates/components/products/price.html
+++ b/templates/components/products/price.html
@@ -7,7 +7,6 @@ If you are making a change here or in price-range.html, you probably want to mak
 {{#and price.price_range (if theme_settings.price_ranges '==' true)}}
     {{> components/products/price-range price=price}}
 {{else}}
-    {{#if price.with_tax}}
         <div class="price-section price-section--withTax rrp-price--withTax" {{#unless price.rrp_with_tax}}style="display: none;"{{/unless}}>
             <span>
                 {{> components/products/price-label
@@ -30,7 +29,7 @@ If you are making a change here or in price-range.html, you probably want to mak
                 {{price.non_sale_price_with_tax.formatted}}
             </span>
         </div>
-        <div class="price-section price-section--withTax">
+        <div class="price-section price-section--withTax price--withTax" {{#unless price.with_tax}}style="display: none;"{{/unless}}>
             <span class="price-label" {{#if price.non_sale_price_with_tax}}style="display: none;"{{/if}}>
                 {{theme_settings.pdp-price-label}}
             </span>
@@ -45,9 +44,7 @@ If you are making a change here or in price-range.html, you probably want to mak
                 <abbr title="{{lang 'products.including_tax'}}">{{lang 'products.price_with_tax' tax_label=price.tax_label}}</abbr>
             {{/if}}
         </div>
-    {{/if}}
-    {{#if price.without_tax}}
-        <div class="price-section price-section--withoutTax rrp-price--withoutTax{{#if price.with_tax}} price-section--minor{{/if}}" {{#unless price.rrp_without_tax}}style="display: none;"{{/unless}}>
+		<div class="price-section price-section--withoutTax rrp-price--withoutTax{{#if price.with_tax}} price-section--minor{{/if}}" {{#unless price.rrp_without_tax}}style="display: none;"{{/unless}}>
             <span>
                 {{> components/products/price-label
                     label_value=theme_settings.pdp-retail-price-label
@@ -69,7 +66,7 @@ If you are making a change here or in price-range.html, you probably want to mak
                 {{price.non_sale_price_without_tax.formatted}}
             </span>
         </div>
-        <div class="price-section price-section--withoutTax">
+        <div class="price-section price-section--withoutTax price--withoutTax" {{#unless price.without_tax}}style="display: none;"{{/unless}}>
             <span class="price-label" {{#if price.non_sale_price_without_tax}}style="display: none;"{{/if}}>
                 {{theme_settings.pdp-price-label}}
             </span>
@@ -84,7 +81,6 @@ If you are making a change here or in price-range.html, you probably want to mak
                 <abbr title="{{lang 'products.excluding_tax'}}">{{lang 'products.price_without_tax' tax_label=price.tax_label}}</abbr>
             {{/if}}
         </div>
-    {{/if}}
     {{#if page_type '===' 'product'}}
          <div class="price-section price-section--saving price" {{#unless price.saved}}style="display: none;"{{/unless}}>
                 <span class="price">{{lang 'products.you_save_opening_text'}}</span>


### PR DESCRIPTION
#### What?
This is an example of some template adjustments that will allow the PDP to support new pricing behavior where `price` can be excluded from variant data if not defined in an "Inclusive" or "Exclusive" price list. These changes specifically address issues brought up in BCTHEME-1941, namely:

- If PDP page loads without a `price` then it breaks the HTML of the page and a price will never be shown even when selecting variants that have a price set
- on PDP when selecting a variant that does not have a price set, we do not hide the price on the page but instead keep showing the previous selections price

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [Link 1](http://example.com)
- ...

#### Screenshots (if appropriate)

Attach images or add image links here.

![Example Image](http://placehold.it/300x200)
