### PR TITLE
fix(storefront): BCTHEME-1985 Fix stored XSS within company address field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Account.js - Fixed jquery selector to be template literal [#2464](https://github.com/bigcommerce/cornerstone/pull/2464)
 - Address deprecated jQuery methods [#2466](https://github.com/bigcommerce/cornerstone/pull/2466)
 - Load other font weights and styles for the body-font [#2396](https://github.com/bigcommerce/cornerstone/pull/2396)
-- Stored XSS within company address field [#](https://github.com/bigcommerce/cornerstone/pull)
+- Stored XSS within company address field [#2485](https://github.com/bigcommerce/cornerstone/pull/2485)
 
 ## 6.14.0 (05-15-2024)
 - Account.php <a href> is inside of a list item [#2457](https://github.com/bigcommerce/cornerstone/pull/2457)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Account.js - Fixed jquery selector to be template literal [#2464](https://github.com/bigcommerce/cornerstone/pull/2464)
 - Address deprecated jQuery methods [#2466](https://github.com/bigcommerce/cornerstone/pull/2466)
 - Load other font weights and styles for the body-font [#2396](https://github.com/bigcommerce/cornerstone/pull/2396)
+- Stored XSS within company address field [#](https://github.com/bigcommerce/cornerstone/pull)
 
 ## 6.14.0 (05-15-2024)
 - Account.php <a href> is inside of a list item [#2457](https://github.com/bigcommerce/cornerstone/pull/2457)

--- a/templates/components/account/address-list.html
+++ b/templates/components/account/address-list.html
@@ -9,7 +9,7 @@
                 <div class="panel-body">
                     <h5 class="address-title">{{first_name}} {{last_name}}</h5>
                     <ul class="address-details address-details--postal">
-                        <li>{{{company}}}</li>
+                        <li>{{company}}</li>
                         <li>{{address1}}</li>
                         <li>{{address2}}</li>
                         <li>{{city}}{{#if state}}, {{state}}{{/if}} {{zip}}</li>


### PR DESCRIPTION
#### What?

In the address-list.html field, the the company field should be {{}} rather than {{{}}} to prevent an XSS attack

#### Tickets/Documentation
* [BCTHEME-1985](https://bigcommercecloud.atlassian.net/browse/BCTHEME-1985)

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Screenshots

**Before:**
![image](https://github.com/user-attachments/assets/ee868faf-a728-4902-85a2-f2fcf498f561)

**After:** 
![image](https://github.com/user-attachments/assets/2c1d6fd4-52e4-4a31-a88a-d77be07039d3)


[BCTHEME-1985]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ