### PR TITLE
feat(checkout): CHECKOUT-8516 Add Shipping Discount to Cart Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Address deprecated jQuery methods [#2466](https://github.com/bigcommerce/cornerstone/pull/2466)
 - Load other font weights and styles for the body-font [#2396](https://github.com/bigcommerce/cornerstone/pull/2396)
 - Stored XSS within company address field [#2485](https://github.com/bigcommerce/cornerstone/pull/2485)
+- Display shipping discount on the cart page [#2490](https://github.com/bigcommerce/cornerstone/pull/2490)
 
 ## 6.14.0 (05-15-2024)
 - Account.php <a href> is inside of a list item [#2457](https://github.com/bigcommerce/cornerstone/pull/2457)

--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -679,3 +679,7 @@ $card-preview-zoom-bottom-offset:       6rem;
     padding-bottom: spacing("single");
     padding-right: spacing("single");
 }
+
+.shipping-estimate-value #shipping-cost-discounted {
+    margin-left: spacing("quarter");
+}

--- a/templates/components/cart/shipping-estimator.html
+++ b/templates/components/cart/shipping-estimator.html
@@ -4,7 +4,12 @@
 {{#if shipping_cost}}
     <div class="cart-total-value">
         <div class="subtotal shipping-estimate-show">
-            <a href="#" class="shipping-estimate-value">{{shipping_cost.formatted}}</a>
+            <a href="#" class="shipping-estimate-value">
+                <span class="{{#if shipping_cost_discounted}}price--discounted{{/if}}">{{shipping_cost.formatted}}</span>
+                {{#if shipping_cost_discounted}}
+                    <span id="shipping-cost-discounted">{{shipping_cost_discounted.formatted}}</span>
+                {{/if}}
+            </a>
         </div>
     </div>
 {{else}}


### PR DESCRIPTION
#### What?

We are working on a new feature to allow shipping discount to be created on the promotion side and applied to a cart with a selected shipping option.

This ticket is about showing the discount on the cart page and will be composed of 2 tickets:
- a BCApp ticket to return the `discounted_shipping_cost` (https://github.com/bigcommerce/bigcommerce/pull/60385)
- a Cornerstone ticket to update the template using this new variable

This feature is protected behind a LaunchDarkly Experiment and will be slowly ramped up when the feature development is complete. 

#### Tickets / Documentation

- https://bigcommercecloud.atlassian.net/browse/CHECKOUT-8516

#### Screenshots (if appropriate)

Tested using Stencil CLI:

Without Shipping Discount:
![image](https://github.com/user-attachments/assets/3b7215a1-3a48-4778-a4b5-67ba64ef6932)

With Shipping Discount:
![image](https://github.com/user-attachments/assets/16702cf7-bc75-40d2-b86c-6b959380e011)


ping @bigcommerce/team-checkout 