### PR TITLE
Bump stencil-utils version to 6.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Draft
 - Fix GH build action & added package version and short commit hash to artifact names in GitHub Actions workflow for improved traceability and uniqueness. ([#2494](https://github.com/bigcommerce/cornerstone/pull/2494))
+- Bump stencil-utils to 6.18.0 ([#2493](https://github.com/bigcommerce/cornerstone/pull/2493))
 
 ## 6.15.0 (10-18-2024)
 - Cornerstone changes to support inc/ex tax price lists on PDP [#2486](https://github.com/bigcommerce/cornerstone/pull/2486)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "bigcommerce-cornerstone",
-      "version": "6.14.0",
+      "version": "6.15.0",
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/stencil-utils": "6.15.1",
+        "@bigcommerce/stencil-utils": "6.18.0",
         "core-js": "^3.9.0",
         "creditcards": "^4.2.0",
         "easyzoom": "^2.5.3",
@@ -1826,16 +1826,17 @@
       }
     },
     "node_modules/@bigcommerce/stencil-utils": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-6.15.1.tgz",
-      "integrity": "sha512-bamjczIoB3vL4tsBJ5YdKAsZNtc+Nu4rPMGWIYqzKSaSB0vhhEDJTuC6Yk3vfmk8BxMqyJkq1bCx5qxpHz2nLg==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/stencil-utils/-/stencil-utils-6.18.0.tgz",
+      "integrity": "sha512-FVtwqocVB0c7wD7OSFvKLek5f3WCs8ERAo4lq+uK2GkqPW6y+IzmZHbEi74HdtlTMuWGOg4G2NIT9RGaAVN1ng==",
+      "license": "BSD-4-Clause",
       "dependencies": {
         "eventemitter3": "^4.0.4",
         "uuid": "^9.0.0",
         "whatwg-fetch": "^3.4.0"
       },
       "engines": {
-        "node": ">=14.0.0 <19.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "BigCommerce",
   "license": "MIT",
   "dependencies": {
-    "@bigcommerce/stencil-utils": "6.15.1",
+    "@bigcommerce/stencil-utils": "6.18.0",
     "core-js": "^3.9.0",
     "creditcards": "^4.2.0",
     "easyzoom": "^2.5.3",


### PR DESCRIPTION
#### What?

This pull requests bumps the @bigcommerce/stencil-utils version to **6.18.0** that allows the dependencies to be resolved with Node v20, that is a minimum requirement for Stencil CLI

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [Issue](https://github.com/bigcommerce/cornerstone/issues/2492)
