### PR TITLE
Update GH upload-artifact action to v4 to fix build

### DIFF
--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -13,11 +13,12 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
-        node: [16.x]
+        os: [ubuntu-latest]
+        node: [18.x, 20.x]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout code
@@ -28,13 +29,21 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
 
+    - name: Read package.json
+      uses: zvonimirsun/read-package-version-actions@v2
+      id: package-version
+
+    - name: Get short SHA
+      id: vars
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
     - name: npm cache
       uses: actions/cache@v2
       with:
         path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ matrix.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
-          ${{ runner.os }}-node-
+          ${{ matrix.os }}-node-${{ matrix.node }}
 
     - name: Install Stencil CLI Dependency
       run: npm install -g @bigcommerce/stencil-cli
@@ -46,17 +55,19 @@ jobs:
       run: npx grunt check
 
     - name: Validate theme successfully bundles
-      run: npx stencil bundle --name bundle
+      run: npx stencil bundle --name ${{ matrix.os }}-node-${{ matrix.node }}-v${{ steps.package-version.outputs.version }}-${{ steps.vars.outputs.sha_short }}-bundle
 
     - name: Upload bundled theme
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: Bundled Theme
-        path: bundle.zip
+        name: Bundled-Theme-${{ matrix.os }}-node-${{ matrix.node }}-v${{ steps.package-version.outputs.version }}-${{ steps.vars.outputs.sha_short }}
+        path: ${{ matrix.os }}-node-${{ matrix.node }}-v${{ steps.package-version.outputs.version }}-${{ steps.vars.outputs.sha_short }}-bundle.zip
+
+    - name: Rename bundle analysis report
+      run: mv assets/dist/report.html assets/dist/${{ matrix.os }}-node-${{ matrix.node }}-v${{ steps.package-version.outputs.version }}-${{ steps.vars.outputs.sha_short }}-report.html
 
     - name: Upload bundle analysis
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: Webpack Analysis
-        path: assets/dist/report.html
-
+        name: Webpack-Analysis-${{ matrix.os }}-node-${{ matrix.node }}-v${{ steps.package-version.outputs.version }}-${{ steps.vars.outputs.sha_short }}
+        path: assets/dist/${{ matrix.os }}-node-${{ matrix.node }}-v${{ steps.package-version.outputs.version }}-${{ steps.vars.outputs.sha_short }}-report.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Fix GH build action & added package version and short commit hash to artifact names in GitHub Actions workflow for improved traceability and uniqueness. ([#2494](https://github.com/bigcommerce/cornerstone/pull/2494))
 
 ## 6.15.0 (10-18-2024)
 - Cornerstone changes to support inc/ex tax price lists on PDP [#2486](https://github.com/bigcommerce/cornerstone/pull/2486)
@@ -65,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 6.12.0 (07-06-2023)
 - sync package lock file [#2373](https://github.com/bigcommerce/cornerstone/pull/2373)
 - Stored payment method name is not visible in Cornerstone Bold theme style  [#2371](https://github.com/bigcommerce/cornerstone/pull/2371)
-- (sanitize product.description) in the theme results to ‘error length of description’ from Google indexing for lengthy product description [#2363](https://github.com/bigcommerce/cornerstone/pull/2363)
+- (sanitize product.description) in the theme results to 'error length of description' from Google indexing for lengthy product description [#2363](https://github.com/bigcommerce/cornerstone/pull/2363)
 - Added style configs to payment buttons  [#2361](https://github.com/bigcommerce/cornerstone/pull/2361)
 - Bump Stencil utils to 6.15.1 [#2365][https://github.com/bigcommerce/cornerstone/pull/2365]
 - Write a Review on product page shows blank pop up on second click. [#2368][https://github.com/bigcommerce/cornerstone/pull/2368]


### PR DESCRIPTION
#### What?

Fix the GH action that builds Cornerstone by bumping upload-artifact:

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

While I was doing this, I improved the action in other ways:
- Update matrix strategy
- Use modern node versions (18/20)
- Improve artifact naming

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
