### PR TITLE
fix(storefront): BCTHEME-1937 Bulk pricing modal on PLP only displays information for the first product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Bulk pricing modal on PLP only displays information for the first product [#2501](https://github.com/bigcommerce/cornerstone/pull/2501)
 - Viewing Orders after logging into customer account displays incorrect quantity of products ordered compared to Order details page. [#2482](https://github.com/bigcommerce/cornerstone/pull/2482)
 - High severity security issue [#2477](https://github.com/bigcommerce/cornerstone/pull/2477)
 - Date Field Modifier - February showing 30th and 31st [#2473](https://github.com/bigcommerce/cornerstone/pull/2473)

--- a/templates/components/products/bulk-discount-rates.html
+++ b/templates/components/products/bulk-discount-rates.html
@@ -2,11 +2,11 @@
     {{#if product}}<dt class="productView-info-name">{{lang 'products.bulk_pricing.title'}}</dt>{{/if}}
     <dd class="productView-info-value">
         <a href="{{product.url}}#bulk_pricing"
-           {{#unless is_ajax }}data-reveal-id="modal-bulk-pricing"{{/unless}}>
+           {{#unless is_ajax }}data-reveal-id="modal-bulk-pricing{{#if id}}-{{id}}{{/if}}"{{/unless}}>
             {{lang 'products.bulk_pricing.view'}}
         </a>
     </dd>
-    <div id="modal-bulk-pricing" class="modal modal--small" data-reveal>
+    <div id="modal-bulk-pricing{{#if id}}-{{id}}{{/if}}" class="modal modal--small" data-reveal>
         <div class="modal-header">
             <h2 class="modal-header-title">{{lang 'products.bulk_pricing.modal_title'}}</h2>
             {{> components/common/modal/modal-close-btn}}


### PR DESCRIPTION
## What/Why?
This PR fixes the bulk pricing modal bug on PLP.

## Testing

**Before**

https://github.com/user-attachments/assets/7fc9ea27-cccc-4d0e-81ad-f7c392ce7564


**After**

https://github.com/user-attachments/assets/6324a214-0d92-46e2-8791-49cb99656b44
