### PR TITLE
fix(storefront): SD-7619 Update colour value for carousel play-pause button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Fix colour value for carousel play-pause button [#2509](https://github.com/bigcommerce/cornerstone/pull/2509)
 - Bulk pricing modal on PLP only displays information for the first product [#2501](https://github.com/bigcommerce/cornerstone/pull/2501)
 - Adding missing product reviews form validation [#2475](https://github.com/bigcommerce/cornerstone/pull/2475)
 - Fix GH build action & added package version and short commit hash to artifact names in GitHub Actions workflow for improved traceability and uniqueness. ([#2494](https://github.com/bigcommerce/cornerstone/pull/2494))

--- a/config.json
+++ b/config.json
@@ -203,7 +203,7 @@
     "carousel-arrow-color--hover": "#474747",
     "carousel-arrow-bgColor": "#ffffff",
     "carousel-arrow-borderColor": "#ffffff",
-    "carousel-play-pause-button-textColor": "8f8f8f",
+    "carousel-play-pause-button-textColor": "#8f8f8f",
     "carousel-play-pause-button-textColor--hover": "#474747",
     "carousel-play-pause-button-bgColor": "#ffffff",
     "carousel-play-pause-button-borderColor": "#ffffff",


### PR DESCRIPTION

#### What?

This PR basically fixes colour value in `config.json` file for `carousel-play-pause-button-textColor`. Previously # was missed  in Settings there that caused issues with showing correct colour in 

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [SD-7619](https://bigcommercecloud.atlassian.net/browse/SD-10726)


#### Screenshots (if appropriate)
locally


[SD-7619]: https://bigcommercecloud.atlassian.net/browse/SD-7619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ