### PR TITLE
ES-5026: Product Filter's configured Display Name does not appear on the "Show More" modal window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Fix product filter display name in Show More modal window [#2510](https://github.com/bigcommerce/cornerstone/pull/2510)
 - Bulk pricing modal on PLP only displays information for the first product [#2501](https://github.com/bigcommerce/cornerstone/pull/2501)
 - Adding missing product reviews form validation [#2475](https://github.com/bigcommerce/cornerstone/pull/2475)
 - Fix GH build action & added package version and short commit hash to artifact names in GitHub Actions workflow for improved traceability and uniqueness. ([#2494](https://github.com/bigcommerce/cornerstone/pull/2494))

--- a/templates/components/faceted-search/show-more-facets.html
+++ b/templates/components/faceted-search/show-more-facets.html
@@ -1,6 +1,10 @@
 <div class="modal-body">
     <h1 class="facet-quick-heading">
-        {{all_facets}}
+        {{#if facet_title}}
+            {{facet_title}}
+        {{else}}
+            {{all_facets}}
+        {{/if}}
     </h1>
     <div class="form-field" id="facetedSearch-filterItems">
         <input class="form-input" type="search" placeholder="{{lang 'forms.search.search'}}">


### PR DESCRIPTION
#### What?

Product Filter's configured Display Name does not appear on the "Show More" modal window

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [ES-5026](https://bigcommercecloud.atlassian.net/browse/ES-5026)
- related BCAPP PR: https://github.com/bigcommerce/bigcommerce/pull/60722

#### Screenshots (if appropriate)

Changes tested on integration store:
<img width="934" alt="image" src="https://github.com/user-attachments/assets/387b9ae1-3747-4085-b625-d76b4890ff19">

<img width="1260" alt="image" src="https://github.com/user-attachments/assets/8acb42d7-a062-474b-8d1d-3ef851f059c2">


[ES-5026]: https://bigcommercecloud.atlassian.net/browse/ES-5026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ