### PR TITLE
fix(storefront): SD-10894 add Karla 700 font weight to schema.json and remove italic versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Add Karla 700 font weight to schema.json and remove italic versions [#2522](https://github.com/bigcommerce/cornerstone/pull/2522)
 - Fix product filter display name in Show More modal window [#2510](https://github.com/bigcommerce/cornerstone/pull/2510)
 - Fix colour value for carousel play-pause button [#2509](https://github.com/bigcommerce/cornerstone/pull/2509)
 - Bulk pricing modal on PLP only displays information for the first product [#2501](https://github.com/bigcommerce/cornerstone/pull/2501)

--- a/config.json
+++ b/config.json
@@ -126,7 +126,7 @@
     "default_image_brand": "img/BrandDefault.gif",
     "default_image_product": "img/ProductDefault.gif",
     "default_image_gift_certificate": "img/GiftCertificate.png",
-    "body-font": "Google_Karla_400,400i,700,700i",
+    "body-font": "Google_Karla_400",
     "headings-font": "Google_Montserrat_400",
     "fontSize-root": 14,
     "fontSize-h1": 28,

--- a/schema.json
+++ b/schema.json
@@ -56,6 +56,11 @@
             "value": "Google_Karla_400"
           },
           {
+            "group": "i18n.Karla",
+            "label": "i18n.KarlaBold",
+            "value": "Google_Karla_700"
+          },
+          {
             "group": "i18n.Roboto",
             "label": "i18n.Roboto",
             "value": "Google_Roboto_400"
@@ -2243,6 +2248,11 @@
             "value": "Google_Karla_400"
           },
           {
+            "group": "i18n.Karla",
+            "label": "i18n.KarlaBold",
+            "value": "Google_Karla_700"
+          },
+          {
             "group": "i18n.Roboto",
             "label": "i18n.Roboto",
             "value": "Google_Roboto_400"
@@ -2293,6 +2303,11 @@
             "group": "i18n.Karla",
             "label": "i18n.Karla",
             "value": "Google_Karla_400"
+          },
+          {
+            "group": "i18n.Karla",
+            "label": "i18n.KarlaBold",
+            "value": "Google_Karla_700"
           },
           {
             "group": "i18n.Roboto",
@@ -2365,6 +2380,11 @@
             "value": "Google_Karla_400"
           },
           {
+            "group": "i18n.Karla",
+            "label": "i18n.KarlaBold",
+            "value": "Google_Karla_700"
+          },
+          {
             "group": "i18n.Roboto",
             "label": "i18n.Roboto",
             "value": "Google_Roboto_400"
@@ -2417,6 +2437,11 @@
             "value": "Google_Karla_400"
           },
           {
+            "group": "i18n.Karla",
+            "label": "i18n.KarlaBold",
+            "value": "Google_Karla_700"
+          },
+          {
             "group": "i18n.Roboto",
             "label": "i18n.Roboto",
             "value": "Google_Roboto_400"
@@ -2467,6 +2492,11 @@
             "group": "i18n.Karla",
             "label": "i18n.Karla",
             "value": "Google_Karla_400"
+          },
+          {
+            "group": "i18n.Karla",
+            "label": "i18n.KarlaBold",
+            "value": "Google_Karla_700"
           },
           {
             "group": "i18n.Roboto",
@@ -2528,6 +2558,11 @@
             "group": "i18n.Karla",
             "label": "i18n.Karla",
             "value": "Google_Karla_400"
+          },
+          {
+            "group": "i18n.Karla",
+            "label": "i18n.KarlaBold",
+            "value": "Google_Karla_700"
           },
           {
             "group": "i18n.Roboto",
@@ -2639,6 +2674,11 @@
             "group": "i18n.Karla",
             "label": "i18n.Karla",
             "value": "Google_Karla_400"
+          },
+          {
+            "group": "i18n.Karla",
+            "label": "i18n.KarlaBold",
+            "value": "Google_Karla_700"
           },
           {
             "group": "i18n.Roboto",

--- a/schemaTranslations.json
+++ b/schemaTranslations.json
@@ -227,6 +227,25 @@
     "pl": "Karla",
     "ja": "Karla"
   },
+  "i18n.KarlaBold": {
+    "default": "Karla Bold",
+    "fr": "Karla Bold",
+    "it": "Karla Bold",
+    "zh": "Karla Bold",
+    "de": "Karla Bold",
+    "es": "Karla Bold",
+    "nl": "Karla Bold",
+    "pt": "Karla Bold",
+    "pt-BR": "Karla Bold",
+    "sv": "Karla Bold",
+    "es-MX": "Karla Bold",
+    "es-419": "Karla Bold",
+    "da": "Karla Bold",
+    "no": "Karla Bold",
+    "ko": "Karla Bold",
+    "pl": "Karla Bold",
+    "ja": "Karla Bold"
+  },
   "i18n.Roboto": {
     "default": "Roboto",
     "fr": "Roboto",


### PR DESCRIPTION
#### What?

This PR fixes adding font weight 700 for the Karla font and removes the italic font style.
This PR is the result of discussion [here](https://github.com/bigcommerce/cornerstone/pull/2396).

#### Tickets / Documentation

- [SD-10894](https://bigcommercecloud.atlassian.net/browse/SD-10894)

#### Screenshots (if appropriate)

https://github.com/user-attachments/assets/d461c609-5225-44f1-a5ed-a9fbe47426ee


[SD-10894]: https://bigcommercecloud.atlassian.net/browse/SD-10894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ