### PR TITLE
feat(payment): PI-2764 Add a section to display the payment promotion widget in the drop-down of the cart preview.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix GH build action & added package version and short commit hash to artifact names in GitHub Actions workflow for improved traceability and uniqueness. ([#2494](https://github.com/bigcommerce/cornerstone/pull/2494))
 - Bump stencil-utils to 6.18.0 ([#2493](https://github.com/bigcommerce/cornerstone/pull/2493))
 - Bump other GH actions to fix warnings related to old versions. ([#2495](https://github.com/bigcommerce/cornerstone/pull/2495))
+- Add a section to display the payment promotion widget in the drop-down of the cart preview. ([#2523](https://github.com/bigcommerce/cornerstone/pull/2523))
 - Add support Node 20 ([#2519](https://github.com/bigcommerce/cornerstone/pull/2519))
 
 ## 6.15.0 (10-18-2024)

--- a/templates/components/common/cart-preview.html
+++ b/templates/components/common/cart-preview.html
@@ -46,6 +46,7 @@
                     </li>
                 {{/each}}
             </ul>
+            {{{cart.preview_payment_widget}}}
             <div class="previewCartAction">
                 {{#if cart.show_primary_checkout_button}}
                     <div class="previewCartAction-checkout">


### PR DESCRIPTION
#### What?

Add a section to display the payment promotion widget in the drop-down of the cart preview.

**(!) This part of the theme is rendered dynamically via an Ajax request. Therefore, we cannot use "regions" for this purpose. It is implemented in the same manner as `cart.additional_checkout_buttons` in the same file (cart-preview.html).**

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [PI-2764](https://bigcommercecloud.atlassian.net/browse/PI-2764)
- [PI-2763](https://bigcommercecloud.atlassian.net/browse/PI-2763)

#### Screenshots (if appropriate)

Use case:

![image](https://github.com/user-attachments/assets/8f1e0247-3f2c-401f-a796-9fef35fdbd17)


[PI-2764]: https://bigcommercecloud.atlassian.net/browse/PI-2764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PI-2763]: https://bigcommercecloud.atlassian.net/browse/PI-2763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ