### PR TITLE
feat(sd): SD-10679 Adds nonce to Checkout and MyAccount pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Add nonce to scripts in checkout and account pages [#2525](https://github.com/bigcommerce/cornerstone/pull/2525)
 - Remove escaping of "=" symbol for <head> [#2526](https://github.com/bigcommerce/cornerstone/pull/2526)
 - Add Karla 700 font weight to schema.json and remove italic versions [#2522](https://github.com/bigcommerce/cornerstone/pull/2522)
 - Fix product filter display name in Show More modal window [#2510](https://github.com/bigcommerce/cornerstone/pull/2510)

--- a/templates/components/common/breadcrumbs.html
+++ b/templates/components/common/breadcrumbs.html
@@ -15,7 +15,7 @@
     </ol>
 </nav>
 
-<script type="application/ld+json">
+<script type="application/ld+json"  nonce="{{nonce}}">
 {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",

--- a/templates/components/common/polyfill-script.html
+++ b/templates/components/common/polyfill-script.html
@@ -1,4 +1,4 @@
-<script>
+<script nonce="{{nonce}}">
     {{!--
         Check for modern browser features, and load polyfills if browser does not appear to support features
         we need.

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -10,25 +10,25 @@
         <link href="{{{ head.favicon }}}" rel="shortcut icon">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <script>
+        <script nonce="{{nonce}}">
             {{!-- Change document class from no-js to js so we can detect this in css --}}
             document.documentElement.className = document.documentElement.className.replace('no-js', 'js');
         </script>
 
         {{> components/common/polyfill-script }}
-        <script>window.consentManagerTranslations = `{{{langJson 'consent_manager'}}}`;</script>
+        <script nonce="{{nonce}}">window.consentManagerTranslations = `{{{langJson 'consent_manager'}}}`;</script>
 
         {{!-- Load Lazysizes script ASAP so images will appear --}}
-        <script>
+        <script nonce="{{nonce}}">
             {{!-- Only load visible elements until the onload event fires, after which preload nearby elements. --}}
             window.lazySizesConfig = window.lazySizesConfig || {};
             window.lazySizesConfig.loadMode = 1;
         </script>
-        <script async src="{{cdn 'assets/dist/theme-bundle.head_async.js' resourceHint='preload' as='script'}}"></script>
+        <script nonce="{{nonce}}" async src="{{cdn 'assets/dist/theme-bundle.head_async.js' resourceHint='preload' as='script'}}"></script>
         
         {{getFontsCollection font-display='block'}}
         
-        <script async src="{{cdn 'assets/dist/theme-bundle.font.js' resourceHint='preload' as='script'}}"></script>
+        <script nonce="{{nonce}}" async src="{{cdn 'assets/dist/theme-bundle.font.js' resourceHint='preload' as='script'}}"></script>
 
         {{{stylesheet '/assets/css/theme.css'}}}
 
@@ -55,8 +55,8 @@
         {{> components/common/body }}
         {{> components/common/footer }}
 
-        <script>window.__webpack_public_path__ = "{{cdn 'assets/dist/'}}";</script>
-        <script>
+        <script nonce="{{nonce}}">window.__webpack_public_path__ = "{{cdn 'assets/dist/'}}";</script>
+        <script nonce="{{nonce}}">
             {{!-- Exported in app.js --}}
             function onThemeBundleMain() {
                 window.stencilBootstrap("{{page_type}}", {{jsContext}}).load();
@@ -79,7 +79,7 @@
                 }
             }
         </script>
-        <script async defer src="{{cdn 'assets/dist/theme-bundle.main.js' resourceHint='preload' as='script'}}" onload="onThemeBundleMain()"></script>
+        <script nonce="{{nonce}}" async defer src="{{cdn 'assets/dist/theme-bundle.main.js' resourceHint='preload' as='script'}}" onload="onThemeBundleMain()"></script>
 
         {{{footer.scripts}}}
     </body>

--- a/templates/pages/account/add-payment-method.html
+++ b/templates/pages/account/add-payment-method.html
@@ -44,7 +44,7 @@
 
         {{#if account_payments}}
             {{{ account_payments }}}
-            <script>
+            <script nonce="{{nonce}}">
                 window.BigCommerce = window.BigCommerce || {};
             </script>
         {{else}}

--- a/templates/pages/checkout.html
+++ b/templates/pages/checkout.html
@@ -4,7 +4,7 @@
 {{{ stylesheet '/assets/css/optimized-checkout.css' }}}
 {{ getFontsCollection }}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{nonce}}">
     window.language = {{{langJson 'optimized_checkout'}}};
 </script>
 


### PR DESCRIPTION
#### What?

Adds `nonce` handlebar to script tags on Checkout and Accounts pages.
A description about what this pull request implements and its purpose. Try to be detailed and describe any technical details to simplify the job of the reviewer and the individual on production support.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [SD-10679](https://bigcommercecloud.atlassian.net/browse/SD-10679)

#### Screenshots (if appropriate)


#### Checkout Page

<img width="806" alt="Screenshot 2024-12-23 at 5 42 05 PM" src="https://github.com/user-attachments/assets/4c01dd43-9ee4-49fb-a088-c111b914a43c" />

<img width="1783" alt="Screenshot 2024-12-23 at 5 43 24 PM" src="https://github.com/user-attachments/assets/1c75184f-ae13-4a61-8968-f8d546e0b6d9" />


<img width="577" alt="Screenshot 2024-12-23 at 5 41 19 PM" src="https://github.com/user-attachments/assets/d2ce0bf1-dcd9-4a2d-b9f3-fd5109f4674a" />



#### My Accounts Page

<img width="772" alt="Screenshot 2024-12-23 at 5 39 02 PM" src="https://github.com/user-attachments/assets/47f54b0e-10da-4c33-9f69-6b1409e2e686" />

<img width="1816" alt="Screenshot 2024-12-23 at 5 39 40 PM" src="https://github.com/user-attachments/assets/8c6c9cff-d50e-49e1-a013-1e7fca231931" />

<img width="1659" alt="Screenshot 2024-12-23 at 5 38 28 PM" src="https://github.com/user-attachments/assets/93446855-305d-4f5e-9384-4892e1bd5a43" />




[SD-10679]: https://bigcommercecloud.atlassian.net/browse/SD-10679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ