### PR TITLE
fix(storefront): remove escaping of = symbol for <head>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Remove escaping of "=" symbol for <head> [#2526](https://github.com/bigcommerce/cornerstone/pull/2526)
 - Add Karla 700 font weight to schema.json and remove italic versions [#2522](https://github.com/bigcommerce/cornerstone/pull/2522)
 - Fix product filter display name in Show More modal window [#2510](https://github.com/bigcommerce/cornerstone/pull/2510)
 - Fix colour value for carousel play-pause button [#2509](https://github.com/bigcommerce/cornerstone/pull/2509)
 - Bulk pricing modal on PLP only displays information for the first product [#2501](https://github.com/bigcommerce/cornerstone/pull/2501)
 - Adding missing product reviews form validation [#2475](https://github.com/bigcommerce/cornerstone/pull/2475)
-- Fix GH build action & added package version and short commit hash to artifact names in GitHub Actions workflow for improved traceability and uniqueness. ([#2494](https://github.com/bigcommerce/cornerstone/pull/2494))
-- Bump stencil-utils to 6.18.0 ([#2493](https://github.com/bigcommerce/cornerstone/pull/2493))
-- Bump other GH actions to fix warnings related to old versions. ([#2495](https://github.com/bigcommerce/cornerstone/pull/2495))
-- Add support Node 20 ([#2519](https://github.com/bigcommerce/cornerstone/pull/2519))
+- Fix GH build action & added package version and short commit hash to artifact names in GitHub Actions workflow for improved traceability and uniqueness [#2494](https://github.com/bigcommerce/cornerstone/pull/2494)
+- Bump stencil-utils to 6.18.0 [#2493](https://github.com/bigcommerce/cornerstone/pull/2493)
+- Bump other GH actions to fix warnings related to old versions [#2495](https://github.com/bigcommerce/cornerstone/pull/2495)
+- Add support Node 20 [#2519](https://github.com/bigcommerce/cornerstone/pull/2519)
 
 ## 6.15.0 (10-18-2024)
 - Cornerstone changes to support inc/ex tax price lists on PDP [#2486](https://github.com/bigcommerce/cornerstone/pull/2486)

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -7,7 +7,7 @@
         {{{ head.config }}}
         {{#block "head"}} {{/block}}
 
-        <link href="{{ head.favicon }}" rel="shortcut icon">
+        <link href="{{{ head.favicon }}}" rel="shortcut icon">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <script>

--- a/templates/pages/category.html
+++ b/templates/pages/category.html
@@ -6,10 +6,10 @@ category:
 {{inject "categoryProductsPerPage" theme_settings.categorypage_products_per_page}}
 {{#partial "head"}}
     {{#if pagination.category.previous}}
-        <link rel="prev" href="{{pagination.category.previous}}">
+        <link rel="prev" href="{{{pagination.category.previous}}}">
     {{/if}}
     {{#if pagination.category.next}}
-        <link rel="next" href="{{pagination.category.next}}">
+        <link rel="next" href="{{{pagination.category.next}}}">
     {{/if}}
 {{/partial}}
 


### PR DESCRIPTION
#### What?

This PR removes escaping of `=` symbol for `<head>`, namely for meta prev/next URLs on the Category Page and favicon.

#### Tickets / Documentation

- [SD-10779](https://bigcommercecloud.atlassian.net/browse/SD-10779)

#### Screenshots (if appropriate)

**before:**

https://github.com/user-attachments/assets/f79e6871-e9ff-4175-9a27-84d386861e10

**after:**

https://github.com/user-attachments/assets/f6776a66-6b1e-4521-85c3-bee660536f40


[SD-10779]: https://bigcommercecloud.atlassian.net/browse/SD-10779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ