### PR TITLE
Remove escaping of "=" symbol for <head> for blog and brand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Remove escaping of "=" symbol for <head> for blog and brand [#2528](https://github.com/bigcommerce/cornerstone/pull/2528)
 - Add nonce to scripts in checkout and account pages [#2525](https://github.com/bigcommerce/cornerstone/pull/2525)
 - Remove escaping of "=" symbol for <head> [#2526](https://github.com/bigcommerce/cornerstone/pull/2526)
 - Add Karla 700 font weight to schema.json and remove italic versions [#2522](https://github.com/bigcommerce/cornerstone/pull/2522)

--- a/templates/pages/blog.html
+++ b/templates/pages/blog.html
@@ -7,10 +7,10 @@ blog:
 ---
 {{#partial "head"}}
     {{#if pagination.blog.previous}}
-        <link rel="prev" href="{{pagination.blog.previous}}">
+        <link rel="prev" href="{{{pagination.blog.previous}}}">
     {{/if}}
     {{#if pagination.blog.next}}
-        <link rel="next" href="{{pagination.blog.next}}">
+        <link rel="next" href="{{{pagination.blog.next}}}">
     {{/if}}
 {{/partial}}
 

--- a/templates/pages/brand.html
+++ b/templates/pages/brand.html
@@ -6,10 +6,10 @@ brand:
 {{inject "brandProductsPerPage" theme_settings.brandpage_products_per_page}}
 {{#partial "head"}}
     {{#if pagination.brand.previous}}
-        <link rel="prev" href="{{pagination.brand.previous}}">
+        <link rel="prev" href="{{{pagination.brand.previous}}}">
     {{/if}}
     {{#if pagination.brand.next}}
-        <link rel="next" href="{{pagination.brand.next}}">
+        <link rel="next" href="{{{pagination.brand.next}}}">
     {{/if}}
 {{/partial}}
 


### PR DESCRIPTION
#### What?

While merging #2526 into our codebase, I noticed that `blog.html` and `brand.html` didn't get the update that removes escaping of = symbol for `<head>` for meta prev/next URLs.

#### Screenshots

We don't utilize the blog functionality, so I can't provide BEFORE / AFTER screenshots for that change, but here are screenshots for changes to `brand.html`

**BEFORE**
<img width="1552" alt="Screen Shot 2024-12-24 at 4 09 47 PM" src="https://github.com/user-attachments/assets/a191480b-c126-4bd2-a0fa-4c6d2823792e" />

**AFTER**
<img width="1552" alt="Screen Shot 2024-12-24 at 4 09 23 PM" src="https://github.com/user-attachments/assets/aed9669d-864a-4990-a834-c085e5bfac2d" />
