### PR TITLE
feat(payment): PI-2771 Rename region for product item.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a section to display the payment promotion widget in the drop-down of the cart preview [#2523](https://github.com/bigcommerce/cornerstone/pull/2523)
 - Add support Node 20 [#2519](https://github.com/bigcommerce/cornerstone/pull/2519)
 - Use fetch when updating variants in cart [#2521](https://github.com/bigcommerce/cornerstone/pull/2521)
-- Add a region to display the payment promotion widget on the category pages. [#2530](https://github.com/bigcommerce/cornerstone/pull/2530)
+- Add a region to display the payment promotion widget on the category pages [#2530](https://github.com/bigcommerce/cornerstone/pull/2530)
+- Rename the region to display the payment promotion widget on the category pages [#2531](https://github.com/bigcommerce/cornerstone/pull/2531)
 
 ## 6.15.0 (10-18-2024)
 - Cornerstone changes to support inc/ex tax price lists on PDP [#2486](https://github.com/bigcommerce/cornerstone/pull/2486)

--- a/templates/components/products/card.html
+++ b/templates/components/products/card.html
@@ -132,7 +132,7 @@
                 {{> components/common/login-for-pricing}}
             {{/or}}
         </div>
-        {{{region name="product_below_price"}}}
+        {{{region name="product_item_below_price"}}}
         {{> components/products/bulk-discount-rates}}
     </div>
 </article>

--- a/templates/components/products/list-item.html
+++ b/templates/components/products/list-item.html
@@ -86,7 +86,7 @@
                 {{#or customer (unless settings.hide_price_from_guests)}}
                     {{#if price}}
                         <div class="listItem-price">{{> components/products/price price=price}}</div>
-                        {{{region name="product_below_price"}}}
+                        {{{region name="product_item_below_price"}}}
                     {{/if}}
                 {{else}}
                     {{> components/common/login-for-pricing}}


### PR DESCRIPTION
#### What?

Follow up PR for https://github.com/bigcommerce/cornerstone/pull/2530. 
In the previous PR, I added new regions to several shared product components. During testing, it was noticed that these components are injected not only on category pages but also on the product view page (as a list of related products at the bottom). The problem is that the product view page already has a region with the same name. Thus, injecting components with the same region name leads to the multiplication of an existing banner intended for the product details page. This fix is intended to rename the regions introduced in https://github.com/bigcommerce/cornerstone/pull/2530 to avoid unexpected behavior. The old names are not used by any store yet, as they were merged recently.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [PI-2771](https://bigcommercecloud.atlassian.net/browse/PI-2771)
- [PI-2770](https://bigcommercecloud.atlassian.net/browse/PI-2770)

#### Screenshots (if appropriate)

Attach images or add image links here.

See related bcapp PR for use cases: https://github.com/bigcommerce/bigcommerce/pull/61296


[PI-2771]: https://bigcommercecloud.atlassian.net/browse/PI-2771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PI-2770]: https://bigcommercecloud.atlassian.net/browse/PI-2770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ