### PR TITLE
fix(storefront): SD-10928 Cornerstone update to support multiple date fields and remove blank space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use fetch when updating variants in cart [#2521](https://github.com/bigcommerce/cornerstone/pull/2521)
 - Add a region to display the payment promotion widget on the category pages [#2530](https://github.com/bigcommerce/cornerstone/pull/2530)
 - Rename the region to display the payment promotion widget on the category pages [#2531](https://github.com/bigcommerce/cornerstone/pull/2531)
+- Cornerstone update to support multiple date fields and remove blank space [#2533](https://github.com/bigcommerce/cornerstone/pull/2533)
 
 ## 6.15.0 (10-18-2024)
 - Cornerstone changes to support inc/ex tax price lists on PDP [#2486](https://github.com/bigcommerce/cornerstone/pull/2486)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -594,14 +594,13 @@ export default class ProductDetails extends ProductDetailsBase {
     }
 
     updateDateSelector() {
-        $(document).ready(() => {
-            const monthSelector = $('#month-selector');
-            const daySelector = $('#day-selector');
-            const yearSelector = $('#year-selector');
-
-            const updateDays = () => {
-                const month = parseInt(monthSelector.val(), 10);
-                const year = parseInt(yearSelector.val(), 10);
+        this.$scope.each((i, scope) => {
+            function updateDays(dateOption) {
+                const monthSelector = dateOption.querySelector('select[name$="[month]"]');
+                const daySelector = dateOption.querySelector('select[name$="[day]"]');
+                const yearSelector = dateOption.querySelector('select[name$="[year]"]');
+                const month = parseInt(monthSelector.value, 10);
+                const year = parseInt(yearSelector.value, 10);
                 let daysInMonth;
 
                 if (!Number.isNaN(month) && !Number.isNaN(year)) {
@@ -616,17 +615,28 @@ export default class ProductDetails extends ProductDetailsBase {
                         daysInMonth = 31;
                     }
 
-                    daySelector.empty();
-
-                    for (let i = 1; i <= daysInMonth; i++) {
-                        daySelector.append($('<option></option>').val(i).text(i));
+                    for (let day = 29; day <= 31; day++) {
+                        const option = daySelector.querySelector(`option[value="${day}"]`);
+                        if (day <= daysInMonth && !option) {
+                            daySelector.options.add(new Option(day, day));
+                        } else if (day > daysInMonth && option) {
+                            option.remove();
+                        }
                     }
                 }
-            };
+            }
 
-            monthSelector.on('change', updateDays);
-            yearSelector.on('change', updateDays);
-            updateDays();
+            $(scope).on('change', (e) => {
+                const dateOption = e.target && e.target.closest && e.target.closest('[data-product-attribute=date]');
+
+                if (dateOption) {
+                    updateDays(dateOption);
+                }
+            });
+
+            scope.querySelectorAll('[data-product-attribute=date]').forEach(dateOption => {
+                updateDays(dateOption);
+            });
         });
     }
 }

--- a/templates/components/products/options/date.html
+++ b/templates/components/products/options/date.html
@@ -4,7 +4,7 @@
 
         {{> components/common/requireness-msg}}
     </label>
-    <select class="form-select form-select--date" name="attribute[{{this.id}}][year]" id="year-selector" {{#if required}}required{{/if}}>
+    <select class="form-select form-select--date" name="attribute[{{this.id}}][year]" {{#if required}}required{{/if}}>
         <option value="">{{lang 'common.year'}}</option>
         {{#for earliest_year latest_year}}
             <option value="{{$index}}" {{#if ../selected_date.year '==' $index}}selected="selected"{{/if}}>
@@ -15,7 +15,7 @@
         <option value="{{earliest_year}}" selected="selected">{{earliest_year}}</option>
         {{/if}}
     </select>
-    <select class="form-select form-select--date" name="attribute[{{this.id}}][month]" id="month-selector" {{#if required}}required{{/if}}>
+    <select class="form-select form-select--date" name="attribute[{{this.id}}][month]" {{#if required}}required{{/if}}>
         <option value="">{{lang 'common.month'}}</option>
         {{#for 1 12}}
             <option value="{{$index}}" {{#if ../selected_date.month '==' $index}}selected="selected"{{/if}}>
@@ -25,12 +25,10 @@
     </select>
     <select class="form-select form-select--date" name="attribute[{{this.id}}][day]" {{#if required}}required{{/if}}>
         <option value="">{{lang 'common.day'}}</option>
-        <optgroup id="day-selector">
         {{#for 1 31}}
             <option value="{{$index}}" {{#if ../selected_date.day '==' $index}}selected="selected"{{/if}}>
                 {{$index}}
             </option>
         {{/for}}
-        </optgroup>
     </select>
 </div>


### PR DESCRIPTION
#### What?

Update `date.html` and `product_details.js` to remove the space at the stop of date fields and to support multiple date fields per page. 
The ID attributes for date fields cause invalid html when there are multiple date fields on a page due to duplicate IDs.
OPTGROUP under the Day select box causes extra space in Day dropdown.
ready() call is not necessary, there already is a $scope class member which references a containing element.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [SD-10928](https://bigcommercecloud.atlassian.net/browse/SD-10928)

#### Screenshots

Before:

https://github.com/user-attachments/assets/722fd1b7-f125-4bbc-a1fc-c8ff849c84a6

After:

https://github.com/user-attachments/assets/4ac37bdd-f018-4bf9-b8e6-98609c6eaf03

<img width="1091" alt="attributes" src="https://github.com/user-attachments/assets/127e7aff-cb01-48e1-8d22-b203ac86878d" />



[SD-10928]: https://bigcommercecloud.atlassian.net/browse/SD-10928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ