### PR TITLE
feat(storefront): SD-10943 Update behaviour to delay displaying the alert message until all required product options are selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Update behaviour to delay displaying the alert message until all required product options are selected [#2535](https://github.com/bigcommerce/cornerstone/pull/2535)
 
 ## 6.16.0 (01-15-2025)
 - Remove escaping of "=" symbol for <head> for blog and brand [#2528](https://github.com/bigcommerce/cornerstone/pull/2528)

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -19,12 +19,13 @@ export function optionChangeDecorator(areDefaultOptionsSet) {
     return (err, response) => {
         const attributesData = response.data || {};
         const attributesContent = response.content || {};
+        const shouldAttributesBeUpdated = true;
 
         this.updateProductAttributes(attributesData);
         if (areDefaultOptionsSet) {
-            this.updateView(attributesData, attributesContent, true);
+            this.updateView(attributesData, attributesContent, shouldAttributesBeUpdated);
         } else {
-            this.updateDefaultAttributesForOOS(attributesData);
+            this.updateDefaultAttributesForOOS(attributesData, shouldAttributesBeUpdated);
         }
     };
 }
@@ -278,7 +279,7 @@ export default class ProductDetailsBase {
             viewModel.stock.$input.text(data.stock);
         }
 
-        this.updateDefaultAttributesForOOS(data);
+        this.updateDefaultAttributesForOOS(data, shouldMessageAppear);
         this.updateWalletButtonsView(data);
 
         // If Bulk Pricing rendered HTML is available
@@ -366,9 +367,9 @@ export default class ProductDetailsBase {
         }
     }
 
-    updateDefaultAttributesForOOS(data) {
+    updateDefaultAttributesForOOS(data, shouldUpdateAttributes) {
         const viewModel = this.getViewModel(this.$scope);
-        if (!data.purchasable || !data.instock) {
+        if (shouldUpdateAttributes && (!data.purchasable || !data.instock)) {
             viewModel.$addToCart.prop('disabled', true);
             viewModel.$increments.prop('disabled', true);
         } else {

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -22,7 +22,7 @@ export function optionChangeDecorator(areDefaultOptionsSet) {
 
         this.updateProductAttributes(attributesData);
         if (areDefaultOptionsSet) {
-            this.updateView(attributesData, attributesContent);
+            this.updateView(attributesData, attributesContent, true);
         } else {
             this.updateDefaultAttributesForOOS(attributesData);
         }
@@ -223,11 +223,16 @@ export default class ProductDetailsBase {
     /**
      * Update the view of price, messages, SKU and stock options when a product option changes
      * @param  {Object} data Product attribute data
+     * @param  {Object} content Product attribute content
+     * @param  {Boolean} shouldMessageAppear indicates if product attributes form has no validity problems
+     * and message can be shown to User
      */
-    updateView(data, content = null) {
+    updateView(data, content, shouldMessageAppear) {
         const viewModel = this.getViewModel(this.$scope);
 
-        this.showMessageBox(data.stock_message || data.purchasing_message);
+        if (shouldMessageAppear) {
+            this.showMessageBox(data.stock_message || data.purchasing_message);
+        }
 
         if (data.price instanceof Object) {
             this.updatePriceView(viewModel, data.price);

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -255,6 +255,7 @@ export default class ProductDetails extends ProductDetailsBase {
         const $changedOption = $(event.target);
         const $form = $changedOption.parents('form');
         const productId = $('[name="product_id"]', $form).val();
+        const isFormValid = $form[0].checkValidity();
 
         // Do not trigger an ajax request if it's a file or if the browser doesn't support FormData
         if ($changedOption.attr('type') === 'file' || window.FormData === undefined) {
@@ -264,8 +265,9 @@ export default class ProductDetails extends ProductDetailsBase {
         utils.api.productAttributes.optionChange(productId, $form.serialize(), 'products/bulk-discount-rates', (err, response) => {
             const productAttributesData = response.data || {};
             const productAttributesContent = response.content || {};
+
             this.updateProductAttributes(productAttributesData);
-            this.updateView(productAttributesData, productAttributesContent);
+            this.updateView(productAttributesData, productAttributesContent, isFormValid);
             this.updateProductDetailsData();
             bannerUtils.dispatchProductBannerEvent(productAttributesData);
 


### PR DESCRIPTION
#### What?

This PR improves appearance of alert message on product attributes form. 
Previously, if product has  options, such message has been shown and updated respectfully **each time** User selects or changes aproduct option.
Now we have updated this behaviour to display a message **only after** all required product options are selected.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation
TBD

#### Screenshots (if appropriate)


https://github.com/user-attachments/assets/180e5b06-2aba-4205-b3f6-8089172e0719


https://github.com/user-attachments/assets/7e9a2d1e-7d67-4141-82c3-00c4b2a0240f


