### PR TITLE
Remove inline handler

### DIFF
--- a/assets/js/theme/cart.js
+++ b/assets/js/theme/cart.js
@@ -402,6 +402,10 @@ export default class Cart extends PageManager {
                 this.bindGiftWrappingForm();
             });
         });
+
+        $('.cart-item-option-remove').on('click', () => {
+            window.confirm(this.context.giftWrappingRemoveMessage);
+        });
     }
 
     bindGiftWrappingForm() {

--- a/templates/components/cart/item-giftwrap.html
+++ b/templates/components/cart/item-giftwrap.html
@@ -7,7 +7,7 @@
             <dd class="cart-item-option-description">
                 {{gift_wrapping.name}}: {{gift_wrapping.price.formatted}}
                 <span class="cart-item-option-actions">
-                    (<a href="" data-item-giftwrap="{{id}}">{{lang 'cart.gift_wrapping.change'}}</a> or <a href="{{gift_wrapping.remove_url}}" onclick="return confirm('{{lang 'cart.gift_wrapping.remove_confirm'}}')">{{lang 'cart.gift_wrapping.remove'}}</a>)
+                    (<a href="" data-item-giftwrap="{{id}}">{{lang 'cart.gift_wrapping.change'}}</a> or <a class="cart-item-option-remove" href="{{gift_wrapping.remove_url}}">{{lang 'cart.gift_wrapping.remove'}}</a>)
                 </span>
             </dd>
             {{#if gift_wrapping.message}}

--- a/templates/components/common/quick-search.html
+++ b/templates/components/common/quick-search.html
@@ -1,5 +1,5 @@
 <div class="container">
-    <form class="form" onsubmit="return false" data-url="{{urls.search}}" data-quick-search-form>
+    <form class="form" data-url="{{urls.search}}" data-quick-search-form>
         <fieldset class="form-fieldset">
             <div class="form-field">
                 <label class="is-srOnly" for="{{name}}">{{lang "search.quick_search.input_label"}}</label>

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -47,6 +47,7 @@
         {{~inject 'carouselArrowAndDotAriaLabel' (lang 'carousel.arrow_and_dot_aria_label')}}
         {{~inject 'carouselActiveDotAriaLabel' (lang 'carousel.active_dot_aria_label')}}
         {{~inject 'carouselContentAnnounceMessage' (lang 'carousel.content_announce_message')}}
+        {{~inject 'giftWrappingRemoveMessage' (lang 'cart.gift_wrapping.remove_confirm')}}
     </head>
     <body>
         <svg data-src="{{cdn 'img/icon-sprite.svg'}}" class="icons-svg-sprite"></svg>
@@ -79,7 +80,16 @@
                 }
             }
         </script>
-        <script nonce="{{nonce}}" async defer src="{{cdn 'assets/dist/theme-bundle.main.js' resourceHint='preload' as='script'}}" onload="onThemeBundleMain()"></script>
+        <script id="theme-bundle-main" nonce="{{nonce}}" async defer src="{{cdn 'assets/dist/theme-bundle.main.js' resourceHint='preload' as='script'}}"></script>
+        <script nonce="{{nonce}}">
+            const scriptElement = document.getElementById('theme-bundle-main');
+
+            if (scriptElement) {
+                addEventListener('load', onThemeBundleMain);
+            } else {
+                console.error('Could not find script element with id "theme-bundle-main"');
+            }
+        </script>
 
         {{{footer.scripts}}}
     </body>


### PR DESCRIPTION
#### What?

Per PCI, inline event handlers like `onload`, `onclick`, `onsubmit`, etc, are forbidden for security reasons. Instead of doing this, we should attach the relevant handlers via a trusted script (protected by nonce)

This PR removes the following inline event handlers in order to comply with PCI since they are executed on pages that fall under PCI compliance (the Cart page and the Payments Account page)

- Gift wrapping remove anchor tag fires a `confirm` dialog that is currently handled inline. I've switched this to an event listener instead through `cart.js`, which is already protected by nonce
- The quick search functionality has an inline event handler that is safe to remove.
- The main bundle event handler has been removed. I've switched this to an event listener instead and protected it via `nonce`

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [Link 1](http://example.com)
- ...

#### Screenshots (if appropriate)

Attach images or add image links here.

![Example Image](http://placehold.it/300x200)
