### PR TITLE
fix(storefront): Add missing nonces to all script tags 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Add nonce to all script tags [#2539](https://github.com/bigcommerce/cornerstone/pull/2539)
 
 ## 6.16.1 (02-14-2025)
 - Refactor cart, payment account page inline event handlers to event listeners [#2536](https://github.com/bigcommerce/cornerstone/pull/2536)

--- a/templates/components/products/schema.html
+++ b/templates/components/products/schema.html
@@ -1,4 +1,4 @@
-<script type="application/ld+json">
+<script type="application/ld+json" nonce="{{nonce}}">
     {
         "@context": "https://schema.org/",
         "@type": "Product",

--- a/templates/pages/account/orders/invoice.html
+++ b/templates/pages/account/orders/invoice.html
@@ -203,7 +203,7 @@
             </div>
         </div>
     </div>
-    <script>
+    <script nonce="{{nonce}}">
         window.print();
     </script>
 {{/partial}}

--- a/templates/pages/order-confirmation.html
+++ b/templates/pages/order-confirmation.html
@@ -3,7 +3,7 @@
 {{{ stylesheet '/assets/css/optimized-checkout.css' }}}
 {{ getFontsCollection }}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{nonce}}">
     window.language = {{{langJson 'optimized_checkout'}}};
 </script>
 

--- a/templates/pages/subscribed.html
+++ b/templates/pages/subscribed.html
@@ -19,7 +19,7 @@
     </div>
 </section>
 
-<script>
+<script nonce="{{nonce}}">
     const subscriptionStatusElement = document.querySelector('.page-content > .page-heading');
     if (subscriptionStatusElement) subscriptionStatusElement.focus();
 </script>


### PR DESCRIPTION
#### What?

Add missing `nonce="{{nonce}}"` nonces to all script tags. 

Adds to nonces to following files:
- `templates/pages/account/orders/invoice.html`
- `templates/pages/order-confirmation.html`
- `templates/components/products/schema.html`
- `templates/pages/subscribed.html`

#### Requirements

- [X] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

n/a

#### Screenshots (if appropriate)

n/a
