### PR TITLE
fix(storefront): Add validationDictionary on search page for price range filter error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+
+## 6.16.2 (06-11-2025)
 - Patch security vulnerabilities [#2548](https://github.com/bigcommerce/cornerstone/pull/2548)
 - Update code standards based on updated linter expectancies [#2548](https://github.com/bigcommerce/cornerstone/pull/2548)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Add validationDictionary to search page for price range filter error messages [#2553](https://github.com/bigcommerce/cornerstone/pull/2553)
 
 ## 6.16.2 (06-11-2025)
 - Patch security vulnerabilities [#2548](https://github.com/bigcommerce/cornerstone/pull/2548)

--- a/assets/js/theme/search.js
+++ b/assets/js/theme/search.js
@@ -8,11 +8,17 @@ import Url from 'url';
 import collapsibleFactory from './common/collapsible';
 import 'jstree';
 import nod from './common/nod';
+import { createTranslationDictionary } from './common/utils/translations-utils';
 
 const leftArrowKey = 37;
 const rightArrowKey = 39;
 
 export default class Search extends CatalogPage {
+    constructor(context) {
+        super(context);
+        this.validationDictionary = createTranslationDictionary(context);
+    }
+
     formatCategoryTreeForJSTree(node) {
         const nodeData = {
             text: node.data,
@@ -264,8 +270,13 @@ export default class Search extends CatalogPage {
     }
 
     initFacetedSearch() {
-        // eslint-disable-next-line object-curly-newline
-        const { onMinPriceError, onMaxPriceError, minPriceNotEntered, maxPriceNotEntered, onInvalidPrice } = this.context;
+        const {
+            price_min_evaluation: onMinPriceError,
+            price_max_evaluation: onMaxPriceError,
+            price_min_not_entered: minPriceNotEntered,
+            price_max_not_entered: maxPriceNotEntered,
+            price_invalid_value: onInvalidPrice,
+        } = this.validationDictionary;
         const $productListingContainer = $('#product-listing-container');
         const $contentListingContainer = $('#search-results-content');
         const $facetedSearchContainer = $('#faceted-search-container');

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Cornerstone",
-  "version": "6.16.2-rc.1",
+  "version": "6.16.2",
   "template_engine": "handlebars_v4",
   "meta": {
     "price": 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigcommerce-cornerstone",
-  "version": "6.16.2-rc.1",
+  "version": "6.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bigcommerce-cornerstone",
   "description": "The BigCommerce reference theme for the Stencil platform",
-  "version": "6.16.2-rc.1",
+  "version": "6.16.2",
   "private": true,
   "author": "BigCommerce",
   "license": "MIT",


### PR DESCRIPTION
#### What?
On the search page, errors for the price range faceted filter are not displayed. This can be demonstrated on [the Cornerstone demo store](https://cornerstone-light-demo.mybigcommerce.com/search.php?search_query=cup):

https://www.loom.com/share/17f6a4dfb4064c55948067615b5048e0

It seems the existing error messages are no longer available from `this.context` in [`search.js`](https://github.com/bigcommerce/cornerstone/blob/6103fb613d68530ef4b305cf46968e4a9ede2c13/assets/js/theme/search.js#L268).

To add the missing error messages, I copied [the same pattern from `category.js`](https://github.com/bigcommerce/cornerstone/blob/6103fb613d68530ef4b305cf46968e4a9ede2c13/assets/js/theme/category.js#L69-L75) and [`brand.js`](https://github.com/bigcommerce/cornerstone/blob/64348b2c6f75be9d91e26c9a9a17d253208467d1/assets/js/theme/brand.js#L25-L31).

Price range filter errors are properly displayed after the patch:
https://www.loom.com/share/4312353e373540f19103af917361da39

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation
n/a

#### Screenshots (if appropriate)
See above.
