### PR TITLE
refactor(orders): ORDERS-7036 refactor orders/invoice.html pickup_details section to better align with existing pickup_address output

### DIFF
--- a/templates/pages/account/orders/invoice.html
+++ b/templates/pages/account/orders/invoice.html
@@ -61,13 +61,15 @@
                     <div class="ShippingAddress">
                         <h3>{{lang 'account.orders.details.pickup_details'}}</h3>
                         <ul>
-                            <li><strong>{{order.pickup_address.line1}}</strong></li>
-                            <li>{{order.pickup_address.line2}}</li>
-                            <li>{{order.pickup_address.city}}, {{order.pickup_address.state}} {{order.pickup_address.zip}}</li>
-                            <li>{{order.pickup_address.country}}</li>
+                            {{#each order.pickup_address}}
+                            <li><strong>{{location_line_1}}</strong></li>
+                            <li>{{location_line_2}}</li>
+                            <li>{{location_city}}, {{location_state}} {{location_zip}}</li>
+                            <li>{{location_country_name}}</li>
                             <li>&nbsp;</li>
-                            <li>{{lang 'invoice.phone' number=order.pickup_address.phone}}</li>
-                            {{#if order.pickup_address.email}}<li>{{lang 'invoice.email' email=order.pickup_address.email}}</li>{{/if}}
+                            <li>{{lang 'invoice.phone' number=location_phone}}</li>
+                            {{#if location_email}}<li>{{lang 'invoice.email' email=location_email}}</li>{{/if}}
+                            {{/each}}
                         </ul>
                     </div>
                 {{/unless}}


### PR DESCRIPTION
#### What?

This PR changes the `pickup_address` fields accessed and displayed in `orders/invoice.html` to match the fields used in `orders/details.html`. 

This change, along with another PR solves an issue where the pickup address would not display on the order invoice or order details pages, if an order with a pickup consignment had only one pickup consignment (which is technically all of them based on current platform limitations).

This is also being done as part of simplifying the backend code that produces the object for `order.pickup_address`, as there is no reason to use two different output formats for the same data.

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [ORDERS-7036](https://bigcommercecloud.atlassian.net/browse/ORDERS-7036)
- https://github.com/bigcommerce/bigcommerce/pull/63822

#### Screenshots (if appropriate)

<details>
<summary>Invoice Page</summary>

Without UI or backend changes
![image](https://github.com/user-attachments/assets/fdf38707-81a9-48db-80b6-dd47d145f64c)


With backend changes only
![image](https://github.com/user-attachments/assets/42f551df-828a-4d91-8ad0-c47fef5bf610)


With UI and backend changes
![image](https://github.com/user-attachments/assets/48d6e602-a274-404b-a98c-30b8c50be24a)


</details>