### PR TITLE
Add arabic translations

### DIFF
--- a/compare_json.py
+++ b/compare_json.py
@@ -1,0 +1,62 @@
+import json
+
+def get_all_keys(data, parent_key=''):
+    """Recursively flattens a nested dictionary and returns a set of all keys."""
+    keys = set()
+    for k, v in data.items():
+        new_key = f"{parent_key}.{k}" if parent_key else k
+        keys.add(new_key)
+        if isinstance(v, dict):
+            keys.update(get_all_keys(v, new_key))
+    return keys
+
+def compare_keys(file1_path, file2_path):
+    """Compares the keys in two JSON files and returns keys present in file1 but not in file2."""
+    try:
+        with open(file1_path, 'r', encoding='utf-8') as f1:
+            data1 = json.load(f1)
+        keys1 = get_all_keys(data1)
+    except FileNotFoundError:
+        return f"Error: File not found - {file1_path}"
+    except json.JSONDecodeError:
+        return f"Error: Could not decode JSON from {file1_path}"
+
+    try:
+        with open(file2_path, 'r', encoding='utf-8') as f2:
+            data2 = json.load(f2)
+        keys2 = get_all_keys(data2)
+    except FileNotFoundError:
+        return f"Error: File not found - {file2_path}"
+    except json.JSONDecodeError:
+        return f"Error: Could not decode JSON from {file2_path}"
+
+    missing_keys = keys1 - keys2
+    return sorted(list(missing_keys))
+
+if __name__ == "__main__":
+    en_file = "lang/en.json"
+    ar_file = "lang/ar.json"
+
+    missing_in_ar = compare_keys(en_file, ar_file)
+
+    if isinstance(missing_in_ar, str): # Error message
+        print(missing_in_ar)
+    elif missing_in_ar:
+        print(f"Keys present in '{en_file}' but missing in '{ar_file}':")
+        for key in missing_in_ar:
+            print(key)
+    else:
+        print(f"All keys from '{en_file}' are present in '{ar_file}'.")
+
+    print("\n--- Comparison Complete ---")
+
+    # For testing the other way around (optional)
+    # missing_in_en = compare_keys(ar_file, en_file)
+    # if isinstance(missing_in_en, str):
+    #     print(missing_in_en)
+    # elif missing_in_en:
+    #     print(f"\nKeys present in '{ar_file}' but missing in '{en_file}':")
+    #     for key in missing_in_en:
+    #         print(key)
+    # else:
+    #     print(f"All keys from '{ar_file}' are present in '{en_file}'.")

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -75,6 +75,7 @@
         "remove_file": "إزالة هذا الملف",
         "freeshipping": "شحن مجاني",
         "reconfigure_product": "إعادة تهيئة '{name}'",
+        "shipping_peritem": "[NEEDS TRANSLATION] Per Item Shipping",
         "remove_item": "إزالة {name} من السلة",
         "confirm_delete": "هل أنت متأكد أنك تريد حذف هذا العنصر؟",
         "coupons": {
@@ -709,6 +710,7 @@
         "reviews": {
             "rating": "لا يمكن أن يكون حقل 'التقييم' فارغاً.",
             "title": "لا يمكن أن يكون حقل 'موضوع المراجعة' فارغاً.",
+            "name": "[NEEDS TRANSLATION] The 'Name' field cannot be blank.",
             "comment": "لا يمكن أن يكون حقل 'التعليقات' فارغاً."
         }
     }

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -1,0 +1,1036 @@
+{
+    "header": {
+        "welcome_back": "مرحباً بعودتك، {name}",
+        "skip_to_main": "تخطي إلى المحتوى الرئيسي"
+    },
+    "footer": {
+        "title": "بداية التذييل",
+        "brands": "العلامات التجارية الشهيرة",
+        "navigate": "تصفح",
+        "info": "معلومات",
+        "categories": "الفئات",
+        "call_us": "اتصل بنا على {phone_number}",
+        "powered_by": "مشغل بواسطة"
+    },
+    "home": {
+        "heading": "الرئيسية"
+    },
+    "blog": {
+        "recent_posts": "أحدث المنشورات",
+        "label": "المدونة",
+        "posted_by": "نشر بواسطة {name}",
+        "read_more": "اقرأ المزيد"
+    },
+    "unavailable": {
+        "hibernation_title": "سنعود قريباً",
+        "hibernation_message": "شكراً لزيارتكم. متجرنا غير متوفر حالياً. نعتذر عن أي إزعاج.",
+        "maintenance_title": "تحت الصيانة",
+        "maintenance_message": "هذا المتجر غير متوفر حاليًا بسبب الصيانة. يجب أن يكون متاحًا مرة أخرى قريبًا. نعتذر عن أي إزعاج."
+    },
+    "brands": {
+        "no_products": "لا توجد منتجات مدرجة تحت هذه العلامة التجارية."
+    },
+    "categories": {
+        "no_products": "لا توجد منتجات مدرجة تحت هذه الفئة."
+    },
+    "checkout": {
+        "title": "الدفع"
+    },
+    "cart": {
+        "nav_aria_label": "السلة تحتوي على 0 عنصر",
+        "continue_shopping": "انقر هنا لمتابعة التسوق",
+        "login_to_checkout": "تسجيل الدخول للمتابعة إلى الدفع",
+        "items": "{NUM, plural, =0{(0 عناصر)} one {(عنصر واحد)} two {(عنصران)} few {(# عناصر)} many {(# عنصرًا)} other {(# عنصر)}}",
+        "checkout": {
+            "address": {
+                "multiple": "الدفع بعناوين متعددة",
+                "or": "أو"
+            },
+            "button": "الدفع",
+            "empty_cart": "سلتك فارغة",
+            "title": "انقر هنا للمتابعة إلى الدفع",
+            "item": "العنصر",
+            "price": "السعر",
+            "quantity": "الكمية",
+            "total": "الإجمالي",
+            "subtotal": "المجموع الفرعي",
+            "enter_code": "رمز القسيمة / شهادة الهدية",
+            "gift_wrapping": "تغليف الهدايا",
+            "shipping": "الشحن",
+            "grand_total": "المجموع الكلي",
+            "select": "اختر",
+            "update": "تحديث تكلفة الشحن"
+        },
+        "preview": {
+            "checkout_now": "الدفع الآن",
+            "checkout_multiple": "أو الدفع بعناوين متعددة",
+            "view_cart": "عرض السلة"
+        },
+        "label": "سلتك ({quantity, plural, one {# عنصر} other {# عناصر}})",
+        "is_empty": "سلتك فارغة",
+        "invalid_entry_message": "[ENTRY] ليس إدخالاً صالحًا",
+        "coupon_code": "رمز القسيمة",
+        "discount": "الخصم",
+        "included_in_total": "مضمن في الإجمالي",
+        "remove_file": "إزالة هذا الملف",
+        "freeshipping": "شحن مجاني",
+        "reconfigure_product": "إعادة تهيئة '{name}'",
+        "remove_item": "إزالة {name} من السلة",
+        "confirm_delete": "هل أنت متأكد أنك تريد حذف هذا العنصر؟",
+        "coupons": {
+            "apply_coupon": "تطبيق القسيمة",
+            "empty_error": "الرجاء إدخال رمز القسيمة.",
+            "cancel": "إلغاء",
+            "add_code": "إضافة رمز",
+            "add_coupon": "إضافة قسيمة",
+            "button": "تطبيق",
+            "coupon_code": "أدخل رمز القسيمة",
+            "code_label": "القسيمة ({code})",
+            "remove": "إزالة"
+        },
+        "gift_certificates": {
+            "apply_gift_certificate": "تطبيق شهادة الهدية",
+            "change_gift_certificate": "تغيير {certificate_name}",
+            "add_cert_code": "إضافة شهادة",
+            "gift_certificate": "شهادة هدية",
+            "code_label": "شهادة هدية ({code})",
+            "cert_code": "أدخل رمز الشهادة",
+            "remove": "إزالة"
+        },
+        "shipping_estimator": {
+            "add_info": "إضافة معلومات",
+            "cancel": "إلغاء",
+            "select_a_country": "الدولة",
+            "select_a_state": "الولاية/المقاطعة",
+            "estimate_shipping": "تقدير الشحن",
+            "suburb_city": "الضاحية/المدينة",
+            "zip_postal_code": "الرمز البريدي",
+            "free_shipping": "شحن مجاني",
+            "hide_ups_rates": "إخفاء أسعار UPS",
+            "show_ups_rates": "إظهار أسعار UPS",
+            "empty_country_error": "لا يمكن أن يكون حقل 'الدولة' فارغًا.",
+            "empty_province_error": "لا يمكن أن يكون حقل 'الولاية/المقاطعة' فارغًا."
+        },
+        "gift_wrapping": {
+            "title": "تغليف الهدايا",
+            "add": "إضافة",
+            "change": "تغيير",
+            "remove": "إزالة",
+            "choose_how": "الرجاء اختيار الطريقة التي ترغب بها في تغليف هذا العنصر.",
+            "option_same": "أرغب في تغليف كل عنصر من هذا المنتج باستخدام نفس خيارات التغليف",
+            "item_single": "تغليف الهدايا - {name}",
+            "item_multiple": "العنصر {index} - {name}",
+            "option_different": "أرغب في تغليف كل عنصر على حدة",
+            "choose_type": "الرجاء اختيار نوع تغليف الهدايا",
+            "gift_message": "رسالة الهدية",
+            "remove_confirm": "هل أنت متأكد أنك تريد إزالة تغليف الهدايا من هذا العنصر؟",
+            "preview": "معاينة"
+        },
+        "added_to_cart": {
+            "what_next": "حسنًا، {num_products, plural, one {تمت إضافة عنصر واحد} other {تمت إضافة # عناصر}} إلى سلتك. ماذا بعد؟",
+            "your_cart_contains": "تحتوي سلتك على {num_products, plural, one {عنصر واحد} other {# عناصر}}",
+            "proceed_to_checkout": "المتابعة إلى الدفع",
+            "order_subtotal": "المجموع الفرعي للطلب",
+            "continue_shopping": "مواصلة التسوق",
+            "view_or_edit_cart": "عرض أو تعديل سلتك",
+            "you_might_also_like": "قد يعجبك أيضًا"
+        }
+    },
+    "common": {
+        "store_credit": "لديك <strong>{store_credit}</strong> من رصيد المتجر. لاستخدامه، ما عليك سوى تقديم طلبك وستتمكن من اختيار رصيد المتجر كطريقة دفع عندما يحين وقت الدفع.",
+        "store_credit_overview": "{credit} رصيد المتجر",
+        "generic_error": "عفواً! حدث خطأ ما.",
+        "currency": "العملة: {code}",
+        "currency_switch_promotion": "ستتم إزالة العروض الترويجية وشهادات الهدايا التي لا تنطبق على العملة الجديدة من سلتك. هل أنت متأكد أنك تريد المتابعة؟",
+        "channel": "المتجر: {code}",
+        "channel_switch_warning": "نص تحذير لتبديل المتجر",
+        "newsletter_signup": "اشترك في قائمتنا البريدية",
+        "form_submit": "إرسال",
+        "no_preference": "لا أفضلية",
+        "other_details": "تفاصيل أخرى",
+        "required": "مطلوب",
+        "optional": "اختياري",
+        "email_address": "عنوان البريد الإلكتروني",
+        "edit": "تعديل",
+        "not_applicable": "غير متاح",
+        "no": "لا",
+        "yes": "نعم",
+        "from": "من",
+        "to": "إلى",
+        "ok": "موافق",
+        "cancel": "إلغاء",
+        "close": "إغلاق",
+        "or": "أو",
+        "and": "و",
+        "compare": "مقارنة",
+        "change": "تغيير",
+        "sign_up": "تسجيل",
+        "login": "تسجيل الدخول",
+        "login_for_pricing": "تسجيل الدخول لمعرفة الأسعار",
+        "logout": "تسجيل الخروج",
+        "account": "الحساب",
+        "cart": "السلة",
+        "search": "بحث",
+        "gift_cert": "شهادات الهدايا",
+        "save": "حفظ",
+        "share": "مشاركة",
+        "delete": "حذف",
+        "public": "عام",
+        "private": "خاص",
+        "view_all": "عرض الكل",
+        "all": "الكل",
+        "paginator": {
+            "page_of": "الصفحة {current} من {total}"
+        },
+        "pagination": "ترقيم الصفحات",
+        "prices_are_in": "الأسعار بـ {CODE}",
+        "previous": "السابق",
+        "next": "التالي",
+        "sorter": {
+            "relevance": "الأهمية",
+            "sort_by": "ترتيب حسب:",
+            "featured": "العناصر المميزة",
+            "top_sellers": "الأكثر مبيعًا",
+            "newest": "أحدث العناصر",
+            "alpha_asc": "من الألف إلى الياء",
+            "alpha_desc": "من الياء إلى الألف",
+            "reviews": "حسب التقييم",
+            "price_asc": "السعر: تصاعدي",
+            "price_desc": "السعر: تنازلي"
+        },
+        "loading": "جار التحميل",
+        "month": "الشهر",
+        "day": "اليوم",
+        "year": "السنة",
+        "short_months": {
+            "1": "يناير",
+            "2": "فبراير",
+            "3": "مارس",
+            "4": "أبريل",
+            "5": "مايو",
+            "6": "يونيو",
+            "7": "يوليو",
+            "8": "أغسطس",
+            "9": "سبتمبر",
+            "10": "أكتوبر",
+            "11": "نوفمبر",
+            "12": "ديسمبر"
+        }
+    },
+    "compare": {
+        "button": "مقارنة المنتجات",
+        "header": "مقارنة {products, plural, one {# منتج} other {# منتجات}}",
+        "remove": "إزالة",
+        "no_remove": "هناك حاجة إلى منتجين على الأقل لإجراء مقارنة صحيحة.",
+        "add_to_cart": "أضف إلى السلة",
+        "no_compare": "يجب عليك تحديد منتجين على الأقل للمقارنة"
+    },
+    "category": {
+        "label": "الفئات",
+        "product_label": "المنتجات المفلترة",
+        "shop_by_price": "تسوق حسب السعر",
+        "shop_by_price_range_aria": "نطاق السعر من {from} إلى {to}",
+        "filter_price_range": "نطاق السعر:",
+        "add_cart_announcement": "تمت إضافة العنصر",
+        "reset": "إعادة تعيين",
+        "filter_reset_announcement": "تمت إعادة تعيين الفلتر",
+        "filter_select_announcement": "تم تطبيق الفلتر",
+        "view_all": {
+            "name": "الكل {category}"
+        }
+    },
+    "brand": {
+        "label": "العلامات التجارية",
+        "view_brands": "عرض جميع العلامات التجارية"
+    },
+    "gift_certificate": {
+        "heading": "شهادات الهدايا",
+        "purchase": {
+            "heading": "شراء شهادة هدية"
+        },
+        "redeem": {
+            "heading": "استرداد شهادة الهدية",
+            "intro": "لاسترداد شهادة هدية في {store_name}، اتبع الخطوات البسيطة التالية.",
+            "item1": "تحتاج إلى رمز شهادة الهدية الفريد الخاص بك، وهو جزء من شهادة الهدية التي تم إرسالها إليك بالبريد الإلكتروني كمرفق.  سيبدو مثل Z50-Y6K-COS-402.",
+            "item2": "تصفح المتجر وأضف العناصر إلى سلتك كالمعتاد.",
+            "item3": "انقر على الرابط '<a href=\"{cart_url}\">عرض السلة</a>' لعرض محتويات سلة التسوق الخاصة بك.",
+            "item4": "اكتب رمز شهادة الهدية الخاص بك في مربع 'استرداد شهادة الهدية' وانقر على 'انتقال'."
+        },
+        "balance": {
+            "heading": "التحقق من رصيد شهادة الهدية",
+            "intro": "يمكنك التحقق من رصيد شهادة الهدية بكتابة الرمز في المربع أدناه."
+        }
+    },
+    "create_account": {
+        "heading": "حساب جديد",
+        "created": {
+            "heading": "تم إنشاء حسابك",
+            "intro": "شكراً لإنشاء حسابك في {store_name}. تم إرسال تفاصيل حسابك إلى {email}",
+            "continue": "مواصلة التسوق"
+        },
+        "recaptcha_title": "Google recaptcha"
+    },
+    "login": {
+        "heading": "تسجيل الدخول",
+        "field_email": "عنوان البريد الإلكتروني:",
+        "field_password": "كلمة المرور:",
+        "submit_value": "تسجيل الدخول",
+        "forgot_password": "هل نسيت كلمة المرور؟",
+        "new_customer": {
+            "heading": "عميل جديد؟",
+            "intro": "أنشئ حسابًا معنا وستتمكن من:",
+            "fact1": "الدفع بشكل أسرع",
+            "fact2": "حفظ عناوين شحن متعددة",
+            "fact3": "الوصول إلى سجل طلباتك",
+            "fact4": "تتبع الطلبات الجديدة",
+            "fact5": "حفظ العناصر في قائمة الرغبات الخاصة بك",
+            "create_account": "إنشاء حساب"
+        }
+    },
+    "reset_password": {
+        "heading": "إعادة تعيين كلمة المرور",
+        "intro": "املأ بريدك الإلكتروني أدناه لطلب كلمة مرور جديدة. سيتم إرسال بريد إلكتروني إلى العنوان أدناه يحتوي على رابط للتحقق من عنوان بريدك الإلكتروني."
+    },
+    "account": {
+        "breadcrumb": "حسابك",
+        "nav": {
+            "overview": "نظرة عامة",
+            "orders": "الطلبات",
+            "returns": "المرتجعات",
+            "messages": "الرسائل ({num_new_messages})",
+            "wishlists": "قوائم الرغبات",
+            "recently_viewed": "تمت مشاهدته مؤخرًا",
+            "settings": "إعدادات الحساب",
+            "addresses": "العناوين",
+            "payment_methods": "طرق الدفع"
+        },
+        "mobile_nav": {
+            "messages": "الرسائل",
+            "wishlists": "قوائم الرغبات"
+        },
+        "addresses": {
+            "heading": "العناوين",
+            "add_heading": "إضافة عنوان جديد",
+            "primary": "أساسي",
+            "phone": "الهاتف:",
+            "new_address": "عنوان جديد",
+            "no_addresses": "ليس لديك حاليًا أي عناوين مضافة إلى ملفك الشخصي"
+        },
+        "messages": {
+            "heading": "الرسائل",
+            "customer_said": "قلت:",
+            "merchant_said": "{store_name} قال:"
+        },
+        "orders": {
+          "heading": "الطلبات",
+            "none": "لم تقم بتقديم أي طلبات معنا. عندما تفعل ذلك، ستظهر حالتها على هذه الصفحة.",
+            "return": {
+                "already_returned": "لا يحتوي هذا الطلب على أي منتجات يمكن إرجاعها. هل قمت بالفعل بإرجاع جميع العناصر الموجودة في هذا الطلب؟",
+                "back_button": "الرجوع",
+                "order_item": "العنصر",
+                "item_price": "السعر",
+                "quantity": "الكمية المراد إرجاعها",
+                "why": "لماذا تقوم بإرجاع هذه العناصر؟",
+                "reason": "سبب الإرجاع",
+                "action": "إجراء الإرجاع",
+                "comments": "تعليقات"
+            },
+            "gift_wrapping": "تغليف الهدايا:",
+            "refunded": "(تم استرداد المبلغ)",
+            "refunded_quantity": "(تم استرداد {qty})",
+            "return_item": "إرجاع",
+            "return_items": "إرجاع العناصر؟",
+           "order_placed": "تم تقديم الطلب",
+            "last_update": "آخر تحديث",
+             "list": {
+                "order_number": "الطلب #{number}",
+                "product_details": "{num_products, plural, one {منتج واحد} other {# منتجات}} بإجمالي {cost}"
+            },
+            "details": {
+               "heading": "الطلب #{number}",
+                "order_contents": "محتويات الطلب",
+                "ship_to": "الشحن إلى",
+                "ship_to_multi": "تم شحن العناصر إلى {street}، {city}، {state}، {zip}، {country}",
+                "ship_to_multi_text": "سيتم شحن الطلب إلى عناوين متعددة",
+                "pickup_details": "تفاصيل الاستلام",
+                "bill_to": "الفاتورة إلى",
+                "how_to_pay": "إليك كيفية الدفع مقابل طلبك:",
+                "order_details": "تفاصيل الطلب",
+                "order_total": "إجمالي الطلب:",
+                "order_status": "حالة الطلب:",
+                "payment_date": "تاريخ الطلب:",
+                "payment_method": "طريقة الدفع:",
+                "comments": "تعليقات الطلب",
+                "download_items": "تنزيل العناصر",
+                "card_ending": "ينتهي بـ {card}",
+                 "shipments": {
+                    "date": "تاريخ الشحن",
+                    "method": "طريقة الشحن",
+                    "link": "رابط التتبع",
+                    "header": "تفاصيل الشحن"
+                },
+                "actions": "الإجراءات",
+                "reorder": "إعادة الطلب",
+                "return": "إرجاع",
+                "pickup": "تفاصيل الاستلام",
+                "pickup_method": "طريقة الاستلام",
+                 "in_store_pickup": "الاستلام من المتجر",
+                "print_invoice": "طباعة الفاتورة",
+                "phone": "الهاتف",
+                "email": "البريد الإلكتروني",
+                "opening_hours": "ساعات العمل"
+            },
+            "downloads": {
+                "heading": "تنزيلات الطلب #{number}",
+                "download_files_below": "أدناه يمكنك تنزيل ملفات",
+                "expired_content": "انتهت صلاحية الملف",
+                "days_remaining": "{number, plural, one {يوم واحد} other {# أيام}}",
+                 "downloads_remaining": "{number, plural, one {تنزيل واحد} other {# تنزيلات}} متبقية",
+                "days_or_downloads": "أو {number} تنزيلات",
+                "remaining": "متبقية"
+            }
+        },
+         "payment_methods": {
+            "heading": "طرق الدفع",
+            "payment_method": "طريقة الدفع",
+            "bank_account": "الحساب المصرفي",
+            "billing_address": "عنوان الفواتير",
+            "card_ending_in": "ينتهي بـ {last_four}",
+            "card_expiry": "{month}/{year}",
+            "new_payment_method": "إضافة طريقة دفع جديدة",
+             "no_methods": "ليس لديك حاليًا أي طرق دفع مضافة إلى حسابك",
+            "name_on_card": "الاسم على البطاقة",
+            "credit_card_number": "رقم بطاقة الائتمان",
+            "expiration": "تاريخ الانتهاء",
+            "cvv": "CVV",
+            "payment_icons_label": "أيقونات الدفع",
+             "card_types": {
+                "american_express": "أمريكان إكسبريس",
+                "credit_card": "بطاقة ائتمان",
+                "dankort": "دانكورت",
+                "diners_club": "داينرز كلوب",
+                "discover": "ديسكفر",
+                "jcb": "JCB",
+                "maestro": "مايسترو",
+                "mastercard": "ماستركارد",
+                "unionpay": "يونيون باي",
+                "visa": "فيزا"
+            },
+            "ach": "ACH",
+            "sepa_direct_debit": "SEPA Direct Debit",
+             "paypal": "PayPal",
+            "billing_address_labels": {
+                "address_line_1": "العنوان 1",
+                "address_line_2": "العنوان 2",
+                "suburb_city": "الضاحية/المدينة",
+                "state_province": "الولاية/المقاطعة",
+                 "choose_state": "اختر ولاية",
+                "country": "الدولة",
+                "choose_country": "اختر دولة",
+                "zip_postcode": "الرمز البريدي"
+            }
+        },
+        "returns": {
+           "heading": "المرتجعات",
+            "instructions": "تعليمات الإرجاع",
+            "error_no_qty": "الرجاء تحديد عنصر واحد أو أكثر للإرجاع.",
+            "none": "لم تقم بتقديم أي مرتجعات معنا. عندما تفعل ذلك، ستظهر على هذه الصفحة.",
+            "new_return": "إرجاع جديد",
+            "from_order": "إرجاع العناصر من الطلب #{id}",
+            "date_requested": "طلب الإرجاع",
+             "successful_heading": "تم تقديم طلب الإرجاع",
+            "successful": "تم تقديم طلب الإرجاع بنجاح. سنرد عليك في أقرب وقت ممكن.",
+            "return": "العودة إلى الطلبات",
+            "last_update": "آخر تحديث",
+             "reason": "سبب الإرجاع",
+            "action": "إجراء الإرجاع",
+            "comments": "تعليقاتك",
+             "submit_request": "إرسال طلب الإرجاع",
+            "list": {
+                "return_number": "الإرجاع #{id}",
+                 "product_details": "إرجاع {num_products}"
+            },
+           "status": {
+                "pending": "قيد الانتظار",
+                "received": "تم الاستلام",
+                "authorized": "مُصرّح به",
+                "repaired": "تم الإصلاح",
+                "refunded": "تم استرداد المبلغ",
+                "rejected": "مرفوض",
+                "cancelled": "ملغى"
+            }
+        },
+         "settings": {
+            "heading": "إعدادات الحساب",
+            "first_name": "الاسم الأول",
+            "last_name": "اسم العائلة",
+            "email": "عنوان البريد الإلكتروني",
+            "company": "الشركة",
+            "phone": "رقم الهاتف",
+            "old_password": "كلمة المرور القديمة",
+             "new_password": "كلمة المرور الجديدة",
+            "confirm_password": "تأكيد كلمة المرور",
+            "update_details": "تحديث التفاصيل"
+        },
+         "recent_items": {
+            "heading": "تمت مشاهدته مؤخرًا",
+            "no_items": "ستظهر العناصر التي شاهدتها مؤخرًا على موقعنا أدناه."
+        },
+       "wishlists": {
+            "heading": "قوائم الرغبات",
+            "tag_line": "املأ النموذج أدناه لإنشاء قائمة رغبات جديدة. انقر على زر \"إنشاء قائمة الرغبات\" عند الانتهاء.",
+            "new": "قائمة رغبات جديدة",
+            "you_have_none": "ليس لديك أي قوائم رغبات، أضف واحدة الآن.",
+            "empty_wishlist": "قائمة رغباتك فارغة. عندما تضيف عناصر إلى قائمة رغباتك، ستظهر هنا.",
+            "num_items": "العناصر",
+            "add_item": "إضافة إلى قائمة الرغبات",
+           "remove_item": "إزالة العنصر",
+            "name": "اسم قائمة الرغبات",
+            "shared": "مشتركة",
+            "action": "الإجراء",
+            "add": "إضافة قائمة رغبات",
+            "delete_all": "حذف الكل",
+             "edit": "تعديل قائمة الرغبات",
+            "view_heading": "قائمة الرغبات: {name}",
+            "share_intro": "شارك قائمة الرغبات هذه مع الأصدقاء:",
+             "num_products": "{num_products, plural, one {منتج واحد} other {# منتجات}}",
+            "create": "إنشاء قائمة الرغبات",
+            "save": "حفظ قائمة الرغبات",
+             "delete_alert": "هل أنت متأكد أنك تريد حذف قائمة (قوائم) الرغبات الخاصة بك؟ لا يمكن التراجع عن هذا الإجراء.",
+            "create_new": "إنشاء قائمة رغبات جديدة",
+            "add_to_default": "إضافة إلى قائمة رغباتي",
+            "enter_wishlist_name_error": "يجب عليك إدخال اسم قائمة الرغبات."
+        }
+    },
+     "page": {
+        "label": "روابط سريعة",
+        "rss": {
+           "intro": "تُستخدم خلاصات RSS لمزامنة المحتوى المتغير بانتظام على موقع ويب، بما في ذلك هذا الموقع. يمكنك فتح خلاصة RSS باستخدام قارئ RSS واستخدامها لمعرفة ما إذا كان هناك أي محتوى جديد على هذا الموقع أو يمكنك إعداد برنامج نصي من جانب الخادم لتحليل الخلاصة وعرضها على موقع الويب الخاص بك.",
+            "heading": "مزامنة RSS",
+            "blog": {
+                "heading": "أحدث منشورات المدونة",
+                 "intro": "تحتوي خلاصة المنشورات الحديثة على أحدث {limit} منشورات مدونة منشورة على {store}.",
+                "rss": "أحدث {limit} منشورات المدونة (RSS)",
+                "rss_atom": "أحدث {limit} منشورات المدونة (Atom)"
+            },
+           "products": {
+                "new": {
+                    "heading": "المنتجات الجديدة",
+                     "intro": "تحتوي خلاصة أحدث المنتجات على أحدث {limit} منتج مضاف إلى {store}.",
+                    "rss": "أحدث {limit} منتج جديد (RSS)",
+                     "rss_atom": "أحدث {limit} منتج جديد (Atom)"
+                },
+                "popular": {
+                    "heading": "المنتجات الشائعة",
+                    "intro": "تحتوي خلاصة المنتجات الشائعة على أفضل {limit} منتج شائع على {store} حسب تقييم المستخدمين.",
+                     "rss": "أحدث {limit} منتج شائع (RSS)",
+                    "rss_atom": "أحدث {limit} منتج شائع (Atom)"
+                },
+                "featured": {
+                   "heading": "المنتجات المميزة",
+                    "intro": "تحتوي خلاصة المنتجات المميزة على أحدث {limit} منتج مميز على {store}.",
+                    "rss": "أحدث {limit} منتج مميز (RSS)",
+                    "rss_atom": "أحدث {limit} منتج مميز (Atom)"
+                }
+            },
+           "search": {
+                "heading": "عمليات البحث عن المنتجات",
+                "intro1": "تتيح لك خلاصات البحث عن المنتجات حفظ عمليات البحث المخصصة عن المنتجات كخلاصة مزامنة سيتم تحديثها دائمًا عند وجود نتائج جديدة.",
+                "intro2": "لإنشاء خلاصة بحث عن منتج، قم بإجراء بحث قياسي على {store} وفي أسفل الصفحة انقر على أحد خيارات المزامنة."
+            }
+        }
+    },
+    "forms": {
+        "range": "تحتاج إلى إدخال أرقام فقط بين: {limitTo} و {limitFrom}",
+        "contact_us": {
+           "full_name": "الاسم الكامل",
+            "email": "عنوان البريد الإلكتروني",
+            "company": "اسم الشركة",
+            "phone": "رقم الهاتف",
+            "order": "رقم الطلب",
+            "rma": "رقم RMA",
+           "question": "التعليقات/الأسئلة",
+            "submit": "إرسال النموذج",
+            "successful": "لقد تلقينا ملاحظاتك وسنرد عليك قريبًا إذا لزم الأمر. <a href=\"{shopPath}\">متابعة</a>.",
+            "manual_captcha_instruction": "الرجاء الإجابة على السؤال أدناه للتحقق الإضافي."
+        },
+        "create_account": {
+            "submit_value": "إنشاء حساب"
+        },
+         "new_password": {
+            "heading": "تغيير كلمة المرور",
+            "password": "كلمة المرور الجديدة",
+            "password2": "تأكيد كلمة المرور",
+            "submit_value": "متابعة"
+        },
+        "address": {
+           "add": {
+                "heading": "إضافة عنوان جديد",
+                "description": "استخدم النموذج أدناه لتغيير أي/جميع تفاصيل عنوان الشحن الخاص بك. انقر على زر 'حفظ العنوان' عند الانتهاء."
+            },
+             "edit": {
+                "heading": "تحديث العنوان"
+
+            },
+            "confirm_delete": "هل أنت متأكد أنك تريد حذف هذا العنوان؟",
+            "submit_value": "حفظ العنوان"
+        },
+       "payment_methods": {
+            "add": {
+                "heading": "إضافة طريقة دفع"
+            },
+             "edit": {
+                "heading": "تحديث طريقة الدفع"
+            },
+            "confirm_delete": "هل أنت متأكد أنك تريد حذف طريقة الدفع هذه؟",
+            "submit_value": "حفظ طريقة الدفع",
+            "first_name": "الاسم الأول",
+            "last_name": "اسم العائلة",
+            "company": "اسم الشركة",
+            "phone": "رقم الهاتف",
+            "address1": "العنوان 1",
+            "address2": "العنوان 2",
+           "city": "الضاحية/المدينة",
+            "country": "الدولة",
+             "state": "الولاية/المقاطعة",
+            "postal_code": "الرمز البريدي",
+            "choose_country": "اختر دولة",
+             "default_instrument": "طريقة الدفع الافتراضية"
+        },
+       "gift_certificate": {
+            "purchase": {
+                "to_name": "اسم المستلم",
+                "to_email": "البريد الإلكتروني للمستلم",
+                "from_name": "اسمك",
+                 "from_email": "بريدك الإلكتروني",
+                "message": "رسالة اختيارية",
+                "amount": "المبلغ",
+                "theme": "سمة شهادة الهدية",
+                "custom_range": "(يجب أن تكون القيمة بين {min} و {max})",
+                "agree": "أتفهم أن شهادات الهدايا تنتهي صلاحيتها بعد {days, plural, one {يوم واحد} other {# أيام}}",
+                "agree2": "أوافق على أن شهادات الهدايا غير قابلة للاسترداد",
+                "preview": "معاينة",
+               "preview_error": "حدثت مشكلة أثناء تحميل المعاينة. يرجى المحاولة مرة أخرى لاحقًا.",
+                "submit_value": "إضافة شهادة الهدية إلى السلة"
+            },
+             "balance": {
+                "code": "رمز شهادة الهدية",
+                "submit_value": "التحقق من الرصيد"
+            }
+        },
+       "inbox": {
+            "order": "الطلب:",
+            "order_display": "الطلب #{id} - تم تقديمه في {date} مقابل {total}",
+             "subject": "الموضوع",
+            "message": "الرسالة",
+            "submit_value": "إرسال الرسالة",
+             "send_message": "إرسال رسالة",
+            "clear_value": "مسح",
+           "no_orders": "بمجرد تقديم طلب، سيكون لديك حق الوصول الكامل لإرسال الرسائل من هذه الصفحة."
+         },
+        "search": {
+            "query": "كلمة البحث",
+            "show": "إظهار نموذج البحث",
+            "hide": "إخفاء نموذج البحث",
+            "title": "بحث متقدم",
+            "price_range": "نطاق السعر",
+            "by_price": "البحث حسب السعر",
+            "by_setting": "البحث حسب الإعداد",
+            "search": "بحث",
+            "free_shipping": {
+                "title": "شحن مجاني",
+                "free": "شحن مجاني فقط",
+                "paid": "شحن مدفوع فقط"
+        },
+        "featured_products": {
+            "title": "المنتجات المميزة",
+            "enabled": "المنتجات المميزة فقط",
+            "disabled": "المنتجات غير المميزة فقط"
+        },
+        "categories": "الفئات",
+        "did_you_mean": "هل تقصد:",
+        "your_search_for": "بحثك عن",
+        "no_match": "لم يطابق أي منتجات أو معلومات.",
+        "suggestions": {
+            "title": "اقتراحات:",
+            "line1": "تأكد من تهجئة جميع الكلمات بشكل صحيح.",
+            "line2": "جرب كلمات مفتاحية مختلفة.",
+            "line3": "جرب كلمات مفتاحية أكثر عمومية."
+        },
+        "refine": "تنقية البحث",
+        "brand": "العلامات التجارية",
+        "searchsubs": "البحث تلقائياً في الفئات الفرعية"
+    },
+    "wishlist": {
+        "name": "اسم قائمة الرغبات:",
+        "public": "مشاركة قائمة الرغبات؟"
+    },
+    "validate": {
+        "account": {
+            "edit": {
+                "password": "يجب عليك إدخال كلمة المرور الحالية الخاصة بك.",
+                "first_name": "يجب عليك إدخال الاسم الأول.",
+                "last_name": "يجب عليك إدخال اسم العائلة.",
+                "phone": "يجب عليك إدخال رقم هاتف."
+            },
+            "reorder": {
+                "select_item": "يرجى تحديد عنصر واحد أو أكثر لإعادة الطلب."
+            },
+            "inbox": {
+                "order": "يجب عليك تحديد طلب.",
+                "subject": "يجب عليك إدخال موضوع.",
+                "message": "يجب عليك إدخال رسالة."
+            }
+        },
+        "common": {
+            "name": "يجب عليك إدخال اسمك.",
+            "password": "يجب عليك إدخال كلمة مرور.",
+            "password_match": "كلمات المرور الخاصة بك غير متطابقة.",
+            "email_address": "يرجى استخدام عنوان بريد إلكتروني صالح، مثل user@example.com."
+        },
+        "contact": {
+            "email_address": "يرجى استخدام عنوان بريد إلكتروني صالح، مثل user@example.com.",
+            "question": "يجب عليك إدخال سؤالك."
+        },
+        "gift": {
+            "to_name": "يجب عليك إدخال اسم مستلم صالح.",
+            "to_email": "يجب عليك إدخال بريد إلكتروني صالح للمستلم.",
+            "from_name": "يجب عليك إدخال اسمك.",
+            "from_email": "يجب عليك إدخال بريد إلكتروني صالح.",
+            "cert_theme": "يجب عليك تحديد سمة شهادة هدية.",
+            "agree_terms": "يجب أن توافق على هذه الشروط."
+        },
+        "payment_method": {
+            "credit_card_number": "يجب عليك إدخال رقم بطاقة ائتمان صالح.",
+            "expiration": "يجب عليك إدخال تاريخ انتهاء صلاحية صالح.",
+            "name_on_card": "يجب عليك إدخال اسم.",
+            "cvv": "يجب عليك إدخال رمز CVV صالح."
+        },
+        "reviews": {
+            "rating": "لا يمكن أن يكون حقل 'التقييم' فارغاً.",
+            "title": "لا يمكن أن يكون حقل 'موضوع المراجعة' فارغاً.",
+            "comment": "لا يمكن أن يكون حقل 'التعليقات' فارغاً."
+        }
+    }
+},
+"products": {
+    "current_stock": "المخزون الحالي:",
+    "quantity": "الكمية:",
+    "change_product_options": "تغيير خيارات {name}",
+    "quantity_decrease": "تقليل كمية {name}",
+    "quantity_increase": "زيادة كمية {name}",
+    "quantity_error_message":"يجب أن تحتوي الكمية على أرقام فقط",
+    "purchase_units": "{quantity, plural, =0{0 وحدات} one {وحدة واحدة} two {وحدتان} few {# وحدات} many {# وحدة} other {# وحدة}}",
+    "max_purchase_quantity": "الحد الأقصى للشراء:",
+    "min_purchase_quantity": "الحد الأدنى للشراء:",
+    "related_products": "منتجات ذات صلة",
+    "top": "المنتجات الأكثر شعبية",
+    "similar_by_views": "شاهده العملاء أيضاً",
+    "featured": "المنتجات المميزة",
+    "file_option_set": "حالياً: <a href=\"{url}\" target=\"_blank\">{name}</a>",
+    "new": "منتجات جديدة",
+    "warranty": "معلومات الضمان",
+    "reviews": {
+        "hide": "إخفاء المراجعات",
+        "new": "اكتب مراجعة",
+        "show": "إظهار المراجعات",
+        "header": "{total, plural, =0{0 مراجعات} one {مراجعة واحدة} two {مراجعتان} few {# مراجعات} many {# مراجعة} other {# مراجعة}}",
+        "link_to_review": "({total, plural, =0{لا توجد مراجعات حتى الآن} one {مراجعة واحدة} two {مراجعتان} few {# مراجعات} many {# مراجعة} other {# مراجعة}})",
+        "post_on_by": "نشر بواسطة {name} في {date}",
+        "rating_label": "التقييم",
+        "select_rating": "حدد التقييم",
+        "anonymous_poster": "غير معروف",
+        "rating_aria_label": "تقييم {rating_target} هو {current_rating} من {max_rating}",
+        "rating": {
+            "1": "نجمة واحدة (الأسوأ)",
+            "2": "نجمتان",
+            "3": "3 نجوم (متوسط)",
+            "4": "4 نجوم",
+            "5": "5 نجوم (الأفضل)"
+        },
+        "write_a_review": "اكتب مراجعة",
+        "no_reviews": "لا توجد مراجعات",
+        "form_write": {
+            "name": "الاسم",
+            "email": "البريد الإلكتروني",
+            "subject": "موضوع المراجعة",
+            "comments": "التعليقات",
+            "submit_value": "إرسال المراجعة"
+        }
+    },
+    "videos": {
+        "header": "مقاطع الفيديو",
+        "hide": "إخفاء مقاطع الفيديو",
+        "show": "إظهار مقاطع الفيديو"
+    },
+    "add_to_cart": "أضف إلى السلة",
+    "adding_to_cart": "جار الإضافة إلى السلة...",
+    "options": "الخيارات",
+    "none": "لا شيء",
+    "sku": "SKU:",
+    "upc": "UPC:",
+    "condition": "الحالة:",
+    "availability": "التوفر:",
+    "swatch_option_announcement": "تم تحديد {swatch_name} هو",
+    "shipping": "الشحن:",
+    "shipping_fixed": "{amount} (تكلفة شحن ثابتة)",
+    "shipping_free": "شحن مجاني",
+    "shipping_calculated": "يتم حسابه عند الدفع",
+    "sold_out": "نفذ",
+    "out_of_stock_default_message": "نفذ",
+    "pre_order": "اطلب مسبقاً الآن",
+    "choose_options": "اختر الخيارات",
+    "quick_view": "عرض سريع",
+    "compare": "مقارنة",
+    "max_filesize": "الحد الأقصى لحجم الملف هو",
+    "kilobytes_abbreviation": "كيلوبايت",
+    "filetypes": "أنواع الملفات هي",
+    "choose_an_option": "يرجى اختيار خيار",
+    "select_one": "يرجى تحديد واحد",
+    "description": "الوصف",
+    "price_with_tax": "(شاملاً {tax_label})",
+    "price_without_tax": "(غير شامل {tax_label})",
+    "including_tax": "شاملاً الضريبة",
+    "excluding_tax": "غير شامل الضريبة",
+    "weight": "الوزن:",
+    "width": "العرض:",
+    "height": "الارتفاع:",
+    "depth": "العمق:",
+    "measurement": {
+        "metric": "سم",
+        "imperial": "بوصة"
+    },
+    "you_save_opening_text": "(أنت توفر",
+    "you_save_closing_bracket": ")",
+    "gift_wrapping": "تغليف الهدايا:",
+    "gift_wrapping_available": "الخيارات المتاحة",
+    "quantity_min": "الحد الأدنى للكمية القابلة للشراء هو {quantity}",
+    "quantity_max": "الحد الأقصى للكمية القابلة للشراء هو {quantity}",
+    "bulk_pricing": {
+        "title": "أسعار الجملة:",
+        "view": "اشترِ بالجملة ووفر",
+        "modal_title": "أسعار الخصم بالجملة",
+        "instructions": "فيما يلي أسعار الخصم بالجملة المتاحة لكل عنصر على حدة عند شراء كمية معينة",
+        "range": "اشترِ {min} {max, plural, =0{أو أكثر} other {- #}}",
+        "percent": "واحصل على خصم {discount}",
+        "price": "واحصل على خصم {discount}",
+        "fixed": "وادفع فقط {discount} لكل منها"
+    },
+    "card_default_image_alt": "الصورة قادمة قريباً"
+},
+"invoice": {
+    "for_order": "فاتورة {name} للطلب #{id}",
+    "phone": "الهاتف: {number}",
+    "email": "البريد الإلكتروني: {email}",
+    "order": "الطلب:",
+    "payment_method": "طريقة الدفع:",
+    "order_date": "تاريخ الطلب:",
+    "shipping_method": "طريقة الشحن:",
+    "order_items": "عناصر الطلب",
+    "qty": "الكمية",
+    "code": "الرمز/SKU",
+    "shipping_address": "عنوان الشحن",
+    "fulfillment": "التنفيذ",
+    "digital": "رقمي",
+    "shipping": "الشحن",
+    "pickup": "الاستلام",
+    "product_name": "اسم المنتج",
+    "price": "السعر",
+    "total": "المجموع",
+    "comments": "التعليقات"
+},
+"newsletter": {
+    "subscribe": "اشترك في نشرتنا الإخبارية",
+    "subscribe_intro": "احصل على آخر التحديثات حول المنتجات الجديدة والمبيعات القادمة",
+    "subscribe_submit": "اشتراك",
+    "email_placeholder": "عنوان بريدك الإلكتروني",
+    "subscribed_heading": "شكراً لاشتراكك!",
+    "subscribed_heading_error": "عفواً...",
+    "subscribed_message": "شكراً لانضمامك إلى قائمتنا البريدية. سيتم إرسال الإصدار التالي من نشرتنا الإخبارية إليك قريباً",
+    "unsubscribed_heading": "تم إلغاء الاشتراك!",
+    "unsubscribed_message": "لن تتلقى بعد الآن رسائل بريد إلكتروني تسويقية من <b>{store_name}</b>"
+},
+"social": {
+    "connect": "تواصل معنا"
+},
+"errors": {
+    "shipping_quote_failure": "حدثت مشكلة في استرداد عرض أسعار الشحن الخاص بك",
+    "state_error": "حدثت مشكلة في استرداد الولايات/المقاطعات"
+},
+"search": {
+    "errorMessage": "حدثت مشكلة في استرداد نتائجك. يرجى المحاولة مرة أخرى في غضون بضع ثوانٍ.",
+    "quick_search": {
+        "input_label": "بحث",
+        "input_placeholder": "ابحث في المتجر"
+    },
+    "results": {
+        "form_label": "كلمة البحث:",
+        "form_button_text": "بحث",
+        "count": "{count, plural, one {# نتيجة} two {# نتيجتان} few {# نتائج} many {# نتيجة} other {# نتيجة}} لـ '{search_query}'",
+        "quick_count": "{count, plural, one {# نتيجة منتج} two {# نتيجتا منتج} few {# نتائج منتج} many {# نتيجة منتج} other {# نتيجة منتج}} لـ '{search_query}'",
+        "quick_count_live": "نتائج المنتج لـ",
+        "product_count": "المنتجات ({count})",
+        "content_count": "الأخبار والمعلومات ({count})"
+    },
+    "faceted": {
+        "selected": {
+            "title": "تنقية بواسطة",
+            "facet-label": "الفلاتر المطبقة",
+            "rating-label": "تم التقييم بـ {rating, plural, one {نجمة واحدة} two {نجمتين} few {# نجوم} many {# نجمة} other {# نجمة}} أو أكثر",
+            "no-filters": "لم يتم تطبيق أي فلاتر",
+            "clear-all": "مسح الكل"
+        },
+        "range": {
+            "update": "تحديث",
+            "min-placeholder": "الحد الأدنى",
+            "max-placeholder": "الحد الأقصى",
+            "min-description": "أدخل الحد الأدنى للسعر لتصفية المنتجات حسب",
+            "max-description": "أدخل الحد الأقصى للسعر لتصفية المنتجات حسب"
+        },
+        "rating": {
+            "and-up": "وأعلى"
+        },
+        "label": "يقوم حقل النص التالي بتصفية النتائج التي تليها أثناء الكتابة",
+        "toggleSection": "تبديل قسم التصفية {title}",
+        "clear": "مسح",
+        "more": "المزيد",
+        "show-more": "إظهار المزيد",
+        "show-less": "إظهار الأقل",
+        "show-filters": "إظهار الفلاتر",
+        "hide-filters": "إخفاء الفلاتر",
+        "browse-by": "تصفح حسب"
+    },
+    "error": {
+        "empty_field": "لا يمكن أن يكون حقل البحث فارغاً."
+    },
+    "tabs_accesibility_hint": "استخدم السهمين الأيسر والأيمن للتنقل بين علامات التبويب."
+},
+"page_not_found": {
+    "page_heading": "خطأ 404 - الصفحة غير موجودة",
+    "message": "عفواً، يبدو أن الصفحة التي تبحث عنها قد تم نقلها أو لم تعد موجودة."
+},
+"server_error": {
+    "page_heading": "حدث خطأ ما...",
+    "message": "المتجر غير متوفر حالياً، يرجى المحاولة مرة أخرى في غضون بضع دقائق"
+},
+"forbidden": {
+    "page_heading": "عذراً! يرجى تسجيل الدخول للمتابعة",
+    "if_you_were_signed_in": "إذا كنت قد سجلت الدخول،",
+    "sign_in": "يرجى تسجيل الدخول مرة أخرى",
+    "to_continue": "، لاستئناف عملك في جلسة جديدة."
+},
+"sitemap": {
+    "page_title": "خريطة الموقع",
+    "show_all_link": "إظهار الكل"
+},
+"text_truncate": {
+    "view_more": "عرض المزيد من التفاصيل",
+    "view_less": "إخفاء التفاصيل"
+},
+"maintenance": {
+    "down": "تحت الصيانة"
+},
+"carousel": {
+    "arrow_and_dot_aria_label": "انتقل إلى الشريحة [SLIDE_NUMBER] من [SLIDES_QUANTITY]",
+    "active_dot_aria_label": "نشط",
+    "content_announce_message": "أنت حالياً على الشريحة [SLIDE_NUMBER] من [SLIDES_QUANTITY]",
+    "play_pause_button_play": "تشغيل",
+    "play_pause_button_pause": "إيقاف مؤقت",
+    "play_pause_button_aria_play": "تشغيل العرض الدائري",
+    "play_pause_button_aria_pause": "إيقاف العرض الدائري مؤقتاً",
+    "slide_number": "رقم الشريحة {slide_number}"
+},
+"validation_messages": {
+    "valid_email": "يجب عليك إدخال بريد إلكتروني صالح.",
+    "password": "يجب عليك إدخال كلمة مرور.",
+    "password_match": "كلمات المرور الخاصة بك غير متطابقة.",
+    "invalid_password": "يجب أن تتكون كلمات المرور من 7 أحرف على الأقل وأن تحتوي على أحرف أبجدية ورقمية.",
+    "field_not_blank": "لا يمكن أن يكون الحقل فارغاً.",
+    "certificate_amount": "يجب عليك إدخال مبلغ شهادة هدية.",
+    "certificate_amount_range": "يجب عليك إدخال مبلغ شهادة بين [MIN] و [MAX]",
+    "price_min_evaluation": "يجب أن يكون الحد الأدنى للسعر أقل من الحد الأقصى للسعر.",
+    "price_max_evaluation": "يجب أن يكون الحد الأدنى للسعر أقل من الحد الأقصى للسعر.",
+    "price_min_not_entered": "الحد الأدنى للسعر مطلوب.",
+    "price_max_not_entered": "الحد الأقصى للسعر مطلوب.",
+    "price_invalid_value": "يجب أن يكون الإدخال أكبر من 0.",
+    "invalid_gift_certificate": "يرجى إدخال رمز الشهادة الصالح الخاص بك."
+},
+"validation_fallback_messages": {
+    "valid_email": "يجب عليك إدخال بريد إلكتروني صالح.",
+    "password": "يجب عليك إدخال كلمة مرور.",
+    "password_match": "كلمات المرور الخاصة بك غير متطابقة.",
+    "invalid_password": "يجب أن تتكون كلمات المرور من 7 أحرف على الأقل وأن تحتوي على أحرف أبجدية ورقمية.",
+    "field_not_blank": "لا يمكن أن يكون الحقل فارغاً.",
+    "certificate_amount": "يجب عليك إدخال مبلغ شهادة هدية.",
+    "certificate_amount_range": "يجب عليك إدخال مبلغ شهادة بين [MIN] و [MAX]",
+    "price_min_evaluation": "يجب أن يكون الحد الأدنى للسعر أقل من الحد الأقصى للسعر.",
+    "price_max_evaluation": "يجب أن يكون الحد الأدنى للسعر أقل من الحد الأقصى للسعر.",
+    "price_min_not_entered": "الحد الأدنى للسعر مطلوب.",
+    "price_max_not_entered": "الحد الأقصى للسعر مطلوب.",
+    "price_invalid_value": "يجب أن يكون الإدخال أكبر من 0.",
+    "invalid_gift_certificate": "يرجى إدخال رمز الشهادة الصالح الخاص بك."
+},
+"validation_default_messages": {
+    "valid_email": "يجب عليك إدخال بريد إلكتروني صالح.",
+    "password": "يجب عليك إدخال كلمة مرور.",
+    "password_match": "كلمات المرور الخاصة بك غير متطابقة.",
+    "invalid_password": "يجب أن تتكون كلمات المرور من 7 أحرف على الأقل وأن تحتوي على أحرف أبجدية ورقمية.",
+    "field_not_blank": "لا يمكن أن يكون الحقل فارغاً.",
+    "certificate_amount": "يجب عليك إدخال مبلغ شهادة هدية.",
+    "certificate_amount_range": "يجب عليك إدخال مبلغ شهادة بين [MIN] و [MAX]",
+    "price_min_evaluation": "يجب أن يكون الحد الأدنى للسعر أقل من الحد الأقصى للسعر.",
+    "price_max_evaluation": "يجب أن يكون الحد الأدنى للسعر أقل من الحد الأقصى للسعر.",
+    "price_min_not_entered": "الحد الأدنى للسعر مطلوب.",
+    "price_max_not_entered": "الحد الأقصى للسعر مطلوب.",
+    "price_invalid_value": "يجب أن يكون الإدخال أكبر من 0.",
+    "invalid_gift_certificate": "يرجى إدخال رمز الشهادة الصالح الخاص بك."
+},
+"page_builder": {
+  "pdp_sale_badge_label": "تخفيض!",
+  "pdp_sold_out_label": "نفذ",
+  "pdp-sale-price-label": "الآن:",
+  "pdp-non-sale-price-label": "كان:",
+  "pdp-retail-price-label": "سعر التجزئة المقترح:",
+  "pdp-custom-fields-tab-label": "معلومات إضافية"
+},
+"consent_manager": {
+    "data_collection_warning": "نحن نستخدم ملفات تعريف الارتباط (وتقنيات مشابهة أخرى) لجمع البيانات لتحسين تجربة التسوق الخاصة بك.",
+    "accept_all_cookies": "قبول جميع ملفات تعريف الارتباط",
+    "gdpr_settings": "الإعدادات",
+    "data_collection_preferences": "تفضيلات جمع بيانات الموقع",
+    "manage_data_collection_preferences": "إدارة تفضيلات جمع بيانات الموقع",
+    "use_data_by_cookies": " يستخدم البيانات التي تم جمعها بواسطة ملفات تعريف الارتباط ومكتبات JavaScript لتحسين تجربة التسوق الخاصة بك.",
+    "data_categories_table": "يوضح الجدول أدناه كيفية استخدامنا لهذه البيانات حسب الفئة. لإلغاء الاشتراك في فئة من جمع البيانات، حدد 'لا' واحفظ تفضيلاتك.",
+    "allow": "السماح",
+    "accept": "قبول",
+    "deny": "رفض",
+    "dismiss": "تجاهل",
+    "reject_all": "رفض الكل",
+    "category": "الفئة",
+    "purpose": "الغرض",
+    "functional_category": "وظيفية",
+    "functional_purpose": "تمكن الوظائف المحسنة، مثل مقاطع الفيديو والدردشة المباشرة. إذا لم تسمح بذلك، فقد لا تعمل بعض أو كل هذه الوظائف بشكل صحيح.",
+    "analytics_category": "التحليلات",
+    "analytics_purpose": "توفير معلومات إحصائية حول استخدام الموقع، على سبيل المثال، تحليلات الويب حتى نتمكن من تحسين هذا الموقع بمرور الوقت.",
+    "targeting_category": "الاستهداف",
+    "advertising_category": "الإعلان",
+    "advertising_purpose": "تستخدم لإنشاء ملفات تعريف أو تخصيص المحتوى لتحسين تجربة التسوق الخاصة بك.",
+    "essential_category": "أساسي",
+    "esential_purpose": "ضروري للموقع وأي خدمات مطلوبة للعمل، ولكنه لا يؤدي أي وظيفة إضافية أو ثانوية.",
+    "yes": "نعم",
+    "no": "لا",
+    "not_available": "غير متاح",
+    "cancel": "إلغاء",
+    "save": "حفظ",
+    "back_to_preferences": "العودة إلى التفضيلات",
+    "close_without_changes": "لديك تغييرات غير محفوظة في تفضيلات جمع البيانات الخاصة بك. هل أنت متأكد أنك تريد الإغلاق دون حفظ؟",
+    "unsaved_changes": "لديك تغييرات غير محفوظة",
+    "by_using": "باستخدام موقعنا، فإنك توافق على",
+    "agree_on_data_collection":"باستخدام موقعنا، فإنك توافق على جمع البيانات كما هو موضح في ",
+    "change_preferences": "يمكنك تغيير تفضيلاتك في أي وقت",
+    "cancel_dialog_title": "هل أنت متأكد أنك تريد الإلغاء؟",
+    "privacy_policy": "سياسة الخصوصية",
+    "allow_category_tracking": "السماح بتتبع [CATEGORY_NAME]",
+    "disallow_category_tracking": "عدم السماح بتتبع [CATEGORY_NAME]"
+}
+}


### PR DESCRIPTION
I've identified and added 2 missing keys to your Arabic translation file (lang/ar.json) by comparing it with your English version (lang/en.json).

These keys currently have placeholder text and will need you to provide the actual Arabic translations:
- cart.shipping_peritem
- forms.validate.reviews.name