### PR TITLE
chore: remove Node.js 18 from matrix to fix CI build with stencil-cli

### DIFF
--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18.x, 20.x]
+        node: [20.x]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
#### What?

The GitHub Actions workflow currently runs on both Node.js 18.x and 20.x via a matrix strategy.
Recent updates to internal dependencies (specifically `undici`, used by `@bigcommerce/stencil-cli`) require the global File API, which is only available in Node.js 20+.

As a result, all CI jobs running under Node 18.x fail during the stencil bundle step with the error
`Error: Process completed with exit code 1.`

#### Screenshots
<img width="1470" height="689" alt="Screenshot 2025-08-01 at 17 16 32" src="https://github.com/user-attachments/assets/672365ca-915e-42ee-bc44-816e43ed965c" />

