### PR TITLE
feat(orders): ORDERS-6497 add support for shipping discounts on orders/details and orders/invoice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Draft
 - Add net-new "order.pickup_addresses" to unify objects used on Order Details and Order Invoice pages [#2557](https://github.com/bigcommerce/cornerstone/pull/2557)
 - Removed banner widget configuration and related translations [#2561](https://github.com/bigcommerce/cornerstone/pull/2561)
+- Add support for shipping discounts in "order.total_rows" for use on the Order Details and Order Invoice pages [#2568](https://github.com/bigcommerce/cornerstone/pull/2568)
 
 ## 6.16.2 (06-18-2025)
 - Restore indentation and quote rules to match BC Sass Style Guide [#2554](https://github.com/bigcommerce/cornerstone/pull/2554)

--- a/assets/scss/components/stencil/account/_account.scss
+++ b/assets/scss/components/stencil/account/_account.scss
@@ -286,6 +286,19 @@
     }
 }
 
+.account-orderTotal-discount {
+    margin: 0;
+    text-align: right;
+    font-weight: fontWeight("normal");
+    padding: spacing("half") 0;
+    border-bottom: 0;
+
+    &:last-of-type {
+        border-bottom: container("border");
+        padding-top: 0;
+    }
+}
+
 
 // Account status
 // -----------------------------------------------------------------------------

--- a/templates/pages/account/orders/details.html
+++ b/templates/pages/account/orders/details.html
@@ -18,6 +18,13 @@
                     {{#if value.value}}
                         <dt class="account-orderTotal-key">{{label}}:</dt>
                         <dd class="account-orderTotal-value">{{value.formatted}}</dd>
+                        {{#if shipping_discounts}}
+                            <dl>
+                                {{#each shipping_discounts}}
+                                    <dt class="account-orderTotal-discount">{{label}}</dt>
+                                {{/each}}
+                            </dl>
+                        {{/if}}
                     {{/if}}
                 {{/each}}
             </dl>

--- a/templates/pages/account/orders/invoice.html
+++ b/templates/pages/account/orders/invoice.html
@@ -194,6 +194,13 @@
                         <td class="Title" colspan="{{#if ../order.has_multiple_shipping_addresses}}5{{else}}4{{/if}}">{{label}}</td>
                         <td class="Total">{{value.formatted}}</td>
                     </tr>
+                    {{#if shipping_discounts}}
+                        {{#each shipping_discounts}}
+                            <tr class="InvoiceTotalRow">
+                                <td class="Title" colspan="5">{{label}}</td>
+                            </tr>
+                        {{/each}}
+                    {{/if}}
                 {{/each}}
                 </tfoot>
             </table>


### PR DESCRIPTION
#### What?
This PR adds support for displaying shipping discounts as part of the `total_rows` object used on the `orders/details.html` and `orders/invoice.html` pages. It also adds some CSS to `assets/scss/components/stencil/account/_account.scss` to support shipping discounts when displayed on `orders/details.html`.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [ORDERS-6497](https://bigcommercecloud.atlassian.net/browse/ORDERS-6497)

#### Screenshots (if appropriate)

##### `orders/details.html`

Before change (Order with shipping discounts applied)

<img width="1272" height="908" alt="image" src="https://github.com/user-attachments/assets/780f927d-e369-4d7c-9066-ca70a97b3a89" />


After change (Order with shipping discounts applied)

<img width="1182" height="906" alt="image" src="https://github.com/user-attachments/assets/0cf70e8c-f006-4b9c-ad7a-4ef3e105f39f" />


##### `orders/invoice.html`

Before change (Order with shipping discounts applied)

<img width="1914" height="607" alt="image" src="https://github.com/user-attachments/assets/7fdf2132-656c-46e7-9355-66832a2b8a2f" />


After change (Order with shipping discounts applied)

<img width="1911" height="656" alt="image" src="https://github.com/user-attachments/assets/db77b646-6e6f-4ea5-a581-51d8f4a86d49" />


[ORDERS-6497]: https://bigcommercecloud.atlassian.net/browse/ORDERS-6497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ