### PR TITLE
feat(payment): STRIPE-987 Add Stripe OCS ACH stored bank accounts type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed banner widget configuration and related translations [#2561](https://github.com/bigcommerce/cornerstone/pull/2561)
 - Add support for shipping discounts in "order.total_rows" for use on the Order Details and Order Invoice pages [#2568](https://github.com/bigcommerce/cornerstone/pull/2568)
 - Updates eslint to v8 [#2570](https://github.com/bigcommerce/cornerstone/pull/2570)
+- Add stored by token ACH bank accounts type 'tokenized_ach', to the Payment methods page [#2572](https://github.com/bigcommerce/cornerstone/pull/2572)
 
 ## 6.16.2 (06-18-2025)
 - Restore indentation and quote rules to match BC Sass Style Guide [#2554](https://github.com/bigcommerce/cornerstone/pull/2554)

--- a/templates/components/account/payment-methods-list.html
+++ b/templates/components/account/payment-methods-list.html
@@ -36,6 +36,9 @@
                                     {{#if ../methodId '===' 'ach'}}
                                         <img class="methodHeader-icon" src="{{cdn 'img/payment-methods/ach.svg'}}" alt="{{lang 'account.payment_methods.ach'}}" title="{{lang 'account.payment_methods.ach'}}">
                                         <span class="methodHeader-brand">{{lang 'account.payment_methods.bank_account'}} {{lang 'account.payment_methods.card_ending_in' last_four=masked_account_number}}</span>
+                                    {{else if ../methodId '===' 'tokenized_ach'}}
+                                        <img class="methodHeader-icon" src="{{cdn 'img/payment-methods/ach.svg'}}" alt="{{lang 'account.payment_methods.ach'}}" title="{{lang 'account.payment_methods.ach'}}">
+                                        <span class="methodHeader-brand">{{lang 'account.payment_methods.bank_account'}} {{lang 'account.payment_methods.card_ending_in' last_four=masked_account_number}}</span>
                                     {{else if ../methodId '===' 'ecp'}}
                                         <img class="methodHeader-icon" src="{{cdn 'img/payment-methods/ach.svg'}}" alt="{{lang 'account.payment_methods.ach'}}" title="{{lang 'account.payment_methods.ach'}}">
                                         <span class="methodHeader-brand">{{lang 'account.payment_methods.bank_account'}} {{lang 'account.payment_methods.card_ending_in' last_four=masked_account_number}}</span>


### PR DESCRIPTION
#### What?
Add Stripe ACH stored bank accounts type `tokenized_ach` to payment methods type.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [STRIPE-987](https://bigcommercecloud.atlassian.net/browse/STRIPE-987)

#### Screenshots (if appropriate)

Attach images or add image links here.

<img width="1253" height="721" alt="Screenshot 2025-09-11 at 16 28 58" src="https://github.com/user-attachments/assets/27d3a5ba-fa2c-424e-bd0d-ecbc7944cd1f" />



[STRIPE-987]: https://bigcommercecloud.atlassian.net/browse/STRIPE-987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ