### PR TITLE
Revert "feat(payment): STRIPE-987 Add Stripe OCS ACH stored bank accounts type"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed banner widget configuration and related translations [#2561](https://github.com/bigcommerce/cornerstone/pull/2561)
 - Add support for shipping discounts in "order.total_rows" for use on the Order Details and Order Invoice pages [#2568](https://github.com/bigcommerce/cornerstone/pull/2568)
 - Updates eslint to v8 [#2570](https://github.com/bigcommerce/cornerstone/pull/2570)
-- Add stored by token ACH bank accounts type 'tokenized_ach', to the Payment methods page [#2572](https://github.com/bigcommerce/cornerstone/pull/2572)
 
 ## 6.16.2 (06-18-2025)
 - Restore indentation and quote rules to match BC Sass Style Guide [#2554](https://github.com/bigcommerce/cornerstone/pull/2554)

--- a/templates/components/account/payment-methods-list.html
+++ b/templates/components/account/payment-methods-list.html
@@ -36,9 +36,6 @@
                                     {{#if ../methodId '===' 'ach'}}
                                         <img class="methodHeader-icon" src="{{cdn 'img/payment-methods/ach.svg'}}" alt="{{lang 'account.payment_methods.ach'}}" title="{{lang 'account.payment_methods.ach'}}">
                                         <span class="methodHeader-brand">{{lang 'account.payment_methods.bank_account'}} {{lang 'account.payment_methods.card_ending_in' last_four=masked_account_number}}</span>
-                                    {{else if ../methodId '===' 'tokenized_ach'}}
-                                        <img class="methodHeader-icon" src="{{cdn 'img/payment-methods/ach.svg'}}" alt="{{lang 'account.payment_methods.ach'}}" title="{{lang 'account.payment_methods.ach'}}">
-                                        <span class="methodHeader-brand">{{lang 'account.payment_methods.bank_account'}} {{lang 'account.payment_methods.card_ending_in' last_four=masked_account_number}}</span>
                                     {{else if ../methodId '===' 'ecp'}}
                                         <img class="methodHeader-icon" src="{{cdn 'img/payment-methods/ach.svg'}}" alt="{{lang 'account.payment_methods.ach'}}" title="{{lang 'account.payment_methods.ach'}}">
                                         <span class="methodHeader-brand">{{lang 'account.payment_methods.bank_account'}} {{lang 'account.payment_methods.card_ending_in' last_four=masked_account_number}}</span>


### PR DESCRIPTION
Reverts bigcommerce/cornerstone#2572

Stripe will use default `ACH` instrument type, and no need additional logic for `tokenized_ach`  type