### PR TITLE
chore(storefront): SD-10900 update documentation url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Draft
 
+- Update Cornerstone documentation url [#2575](https://github.com/bigcommerce/cornerstone/pull/2575)
+
 ## 6.17.0 (10-01-2025)
 - Add net-new "order.pickup_addresses" to unify objects used on Order Details and Order Invoice pages [#2557](https://github.com/bigcommerce/cornerstone/pull/2557)
 - Removed banner widget configuration and related translations [#2561](https://github.com/bigcommerce/cornerstone/pull/2561)

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "template_engine": "handlebars_v4",
   "meta": {
     "price": 0,
-    "documentation_url": "https://support.bigcommerce.com/articles/Public/Cornerstone-Theme-Manual",
+    "documentation_url": "https://support.bigcommerce.com/s/article/Cornerstone-Theme-Manual",
     "author_name": "BigCommerce",
     "author_email": "support@bigcommerce.com",
     "author_support_url": "https://support.bigcommerce.com/",


### PR DESCRIPTION
#### What?

This PR updates Cornerstone documentation URL

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [SD-10900](https://bigcommercecloud.atlassian.net/browse/SD-10900)


#### Screenshots (if appropriate)
<img width="1692" height="999" alt="image" src="https://github.com/user-attachments/assets/28eae2c3-7efe-419b-851e-af49f8bea4e3" />


[SD-10900]: https://bigcommercecloud.atlassian.net/browse/SD-10900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ