### PR TITLE
fix(storefront): Fix the keyboard navigation on the swatch options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Draft
 
 - Update Cornerstone documentation url [#2575](https://github.com/bigcommerce/cornerstone/pull/2575)
+- Fix keyboard navigation on the swatch options [#2576](https://github.com/bigcommerce/cornerstone/pull/2576)
 
 ## 6.17.0 (10-01-2025)
 - Add net-new "order.pickup_addresses" to unify objects used on Order Details and Order Invoice pages [#2557](https://github.com/bigcommerce/cornerstone/pull/2557)

--- a/assets/js/theme/common/aria/radioOptions.js
+++ b/assets/js/theme/common/aria/radioOptions.js
@@ -35,15 +35,15 @@ const handleItemKeyDown = itemCollection => e => {
     case ariaKeyCodes.LEFT:
     case ariaKeyCodes.UP: {
         const prevItemIdx = calculateTargetItemPosition(lastCollectionItemIdx, itemIdx - 1);
-        itemCollection.get(prevItemIdx).trigger('focus');
-        setCheckedRadioItem(itemCollection, itemIdx - 1);
+        itemCollection.eq(prevItemIdx).trigger('focus');
+        setCheckedRadioItem(itemCollection, prevItemIdx);
         break;
     }
     case ariaKeyCodes.RIGHT:
     case ariaKeyCodes.DOWN: {
         const nextItemIdx = calculateTargetItemPosition(lastCollectionItemIdx, itemIdx + 1);
-        itemCollection.get(nextItemIdx).trigger('focus');
-        setCheckedRadioItem(itemCollection, itemIdx + 1);
+        itemCollection.eq(nextItemIdx).trigger('focus');
+        setCheckedRadioItem(itemCollection, nextItemIdx);
         break;
     }
 


### PR DESCRIPTION
#### What?

This PR fixes the broken keyboard navigation on the swatch options.

####  Additional Details
Fixed the issue. The problem was using .get() instead of .eq().

Why this works:
.get(index) returns a DOM element, which doesn't have .trigger()
.eq(index) returns a jQuery object, which has .trigger()


#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [SD-11413](https://bigcommercecloud.atlassian.net/browse/SD-11413)


#### Screenshots (if appropriate)

<video src="https://github.com/user-attachments/assets/2fa89146-4994-4ffe-9792-48eeeba46180"></video> 




[SD-11413]: https://bigcommercecloud.atlassian.net/browse/SD-11413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ