### PR TITLE
fix(storefront): SD-11448 fix Cart Page not updating when adding product via Quick View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix keyboard navigation on the swatch options [#2576](https://github.com/bigcommerce/cornerstone/pull/2576)
 - CHECKOUT-9688 Introduce new coupon management section on cart page [#2578](https://github.com/bigcommerce/cornerstone/pull/2578)
 - CHECKOUT-9692 show the display name and coupon code under line item [#2579](https://github.com/bigcommerce/cornerstone/pull/2579)
+- Fix Cart Page not updating when adding product via Quick View [#2581](https://github.com/bigcommerce/cornerstone/pull/2581)
 
 ## 6.17.0 (10-01-2025)
 - Add net-new "order.pickup_addresses" to unify objects used on Order Details and Order Invoice pages [#2557](https://github.com/bigcommerce/cornerstone/pull/2557)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -3,7 +3,7 @@ import ProductDetailsBase, { optionChangeDecorator } from './product-details-bas
 import 'foundation-sites/js/foundation/foundation';
 import 'foundation-sites/js/foundation/foundation.reveal';
 import ImageGallery from '../product/image-gallery';
-import modalFactory, { alertModal, showAlertModal } from '../global/modal';
+import modalFactory, { alertModal, showAlertModal, ModalEvents } from '../global/modal';
 import { isEmpty, isPlainObject } from 'lodash';
 import nod from './nod';
 import { announceInputErrorMessage } from './utils/form-utils';
@@ -17,6 +17,7 @@ export default class ProductDetails extends ProductDetailsBase {
     constructor($scope, context, productAttributesData = {}) {
         super($scope, context);
 
+        this.isCartPage = context.template === 'pages/cart';
         this.$overlay = $('[data-cart-item-add] .loadingOverlay');
         this.imageGallery = new ImageGallery($('[data-image-gallery]', this.$scope));
         this.imageGallery.init();
@@ -542,7 +543,16 @@ export default class ProductDetails extends ProductDetailsBase {
                 onComplete(response);
             }
 
-            if ($promotionBanner.length && $backToShopppingBtn.length) {
+            if (this.isCartPage) {
+                modal.$modal.one(ModalEvents.closed, () => {
+                    // Close quick search overlay if it's open (ESC and backdrop click don't close it automatically)
+                    const $searchContainer = $('#quickSearch');
+                    if ($searchContainer.hasClass('is-open')) {
+                        $searchContainer.removeClass('is-open').attr('aria-hidden', 'true');
+                    }
+                    bannerUpdateHandler();
+                });
+            } else if ($promotionBanner.length && $backToShopppingBtn.length) {
                 $backToShopppingBtn.on('click', bannerUpdateHandler);
                 $modalCloseBtn.on('click', bannerUpdateHandler);
             }


### PR DESCRIPTION
#### What?
This PR fixes an issue where the cart page does not refresh when adding a product via Quick View. The mini-cart updates correctly, but the cart page remains stale until manual reload. Now the cart page automatically reloads when the preview modal is closed.

**Steps to reproduce:** go to cart page → use search → Quick View → add product → close modal

Also fixed UX bug:
When the modal closes and page starts reloading, there's a ~1-2 second delay where search results are still visible and interactive. User could click on another product during this time, then reload completes and interrupts their action.
Closing the search overlay immediately prevents this confusing state

#### Tickets / Documentation

- [SD-11448](https://bigcommercecloud.atlassian.net/browse/SD-11448)

#### Screenshots (if appropriate)
tested locally:
**bug:**

https://github.com/user-attachments/assets/c0a297ff-9fda-4d58-b68e-317a38969f2b

https://github.com/user-attachments/assets/df6557bf-67a2-4e7d-813b-41edce8c3408

**fix:**

https://github.com/user-attachments/assets/70feebf5-d289-4221-9d01-f5cf861a8537


[SD-11448]: https://bigcommercecloud.atlassian.net/browse/SD-11448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ