### PR TITLE
chore(deps): remove unused imports-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Remove unused imports-loader dependency [#2595](https://github.com/bigcommerce/cornerstone/pull/2595)
 - Out of Stock banner is duplicated and overlaps Add to cart button on PDP [#2601](https://github.com/bigcommerce/cornerstone/pull/2601)
 - Fixed YouTube video playback in Safari by adding widget_referrer and origin parameters [#2598](https://github.com/bigcommerce/cornerstone/pull/2598)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bigcommerce-cornerstone",
-      "version": "6.18.0-rc.1",
+      "version": "6.18.2",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/stencil-utils": "6.19.0",
@@ -53,7 +53,6 @@
         "grunt-run": "^0.8.1",
         "grunt-stylelint": "^0.20.1",
         "grunt-svgstore": "^2.0.0",
-        "imports-loader": "^0.7.1",
         "jest": "^30.0.5",
         "jest-environment-jsdom": "^30.0.5",
         "jest-jasmine2": "^30.0.5",
@@ -8909,51 +8908,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/imports-loader": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.7.1.tgz",
-      "integrity": "sha512-tQ1upp3IcLH8YRk9b9PlJi7BsAGQhGRlgyLil6uZ/6kFb7C0H9YH9XwDVIjxl/TxFgQ0Wkrx8VRt1Ff2Vf6Mag==",
-      "dev": true,
-      "dependencies": {
-        "loader-utils": "^1.0.2",
-        "source-map": "^0.5.6"
-      }
-    },
-    "node_modules/imports-loader/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/imports-loader/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/imports-loader/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/imurmurhash": {
@@ -22041,44 +21995,6 @@
       "requires": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
-      }
-    },
-    "imports-loader": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.7.1.tgz",
-      "integrity": "sha512-tQ1upp3IcLH8YRk9b9PlJi7BsAGQhGRlgyLil6uZ/6kFb7C0H9YH9XwDVIjxl/TxFgQ0Wkrx8VRt1Ff2Vf6Mag==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.0.2",
-        "source-map": "^0.5.6"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "loader-utils": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^1.0.1"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-          "dev": true
-        }
       }
     },
     "imurmurhash": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "grunt-run": "^0.8.1",
     "grunt-stylelint": "^0.20.1",
     "grunt-svgstore": "^2.0.0",
-    "imports-loader": "^0.7.1",
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.0.5",
     "jest-jasmine2": "^30.0.5",


### PR DESCRIPTION
### Summary

Removes the unused `imports-loader` dependency from the project.

### Details

- `imports-loader` was no longer referenced anywhere in the codebase
- Dependency removal has no impact on build output or runtime behavior
- Reduces maintenance overhead and keeps dependencies minimal

### Testing

- Local build completed successfully
- No functional or behavioral changes expected

### Notes

This is a dependency cleanup only