### PR TITLE
fix(ui): make footer phone number clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Make footer phone number clickable [#2596](https://github.com/bigcommerce/cornerstone/pull/2596)
 - Out of Stock banner is duplicated and overlaps Add to cart button on PDP [#2601](https://github.com/bigcommerce/cornerstone/pull/2601)
 - Fixed YouTube video playback in Safari by adding widget_referrer and origin parameters [#2598](https://github.com/bigcommerce/cornerstone/pull/2598)
 

--- a/templates/components/common/footer.html
+++ b/templates/components/common/footer.html
@@ -66,7 +66,7 @@
                 <h3 class="footer-info-heading">{{lang 'footer.info'}}</h3>
                 <address>{{nl2br settings.address}}</address>
                 {{#if settings.phone_number}}
-                    <strong>{{lang 'footer.call_us' phone_number=settings.phone_number}}</strong>
+                    <a href="tel:{{settings.phone_number}}"><strong>{{lang 'footer.call_us' phone_number=settings.phone_number}}</strong></a>
                 {{/if}}
             </article>
             {{/if}}


### PR DESCRIPTION
### Summary

Makes the footer phone number clickable by rendering it as a tel: link.

### Related Issue

Closes #2564 – Make footer phone number clickable

### Changes

- Updates the footer template to wrap the phone number in a tel: anchor
- Improves mobile usability by enabling tap-to-call behavior

### Testing

Verified phone number renders as a clickable link
Confirmed tap-to-call behavior on mobile