### PR TITLE
fix: swap content/data keys in onProductOptionsChanged event detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Swap content/data keys in onProductOptionsChanged event detail [#2640](https://github.com/bigcommerce/cornerstone/pull/2640)
 
 ## 6.19.1 (04-09-2026)
 - Update stencil-utils versionto 6.23.0 [#2638](https://github.com/bigcommerce/cornerstone/pull/2638)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Swap content/data keys in onProductOptionsChanged event detail [#2640](https://github.com/bigcommerce/cornerstone/pull/2640)
 - Fix shipment info showing for cancelled orders [#2654](https://github.com/bigcommerce/cornerstone/pull/2654)
 
 ## 6.19.1 (04-09-2026)

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -289,8 +289,8 @@ export default class ProductDetails extends ProductDetailsBase {
             document.dispatchEvent(new CustomEvent('onProductOptionsChanged', {
                 bubbles: true,
                 detail: {
-                    content: productAttributesData,
-                    data: productAttributesContent,
+                    content: productAttributesContent,
+                    data: productAttributesData,
                 },
             }));
         }, { baseUrl: this.context.secureBaseUrl });


### PR DESCRIPTION
#### What?

Fixes a bug in `productOptionsChanged` where the `content` and `data` keys in the `onProductOptionsChanged` CustomEvent `detail` payload were swapped.

**Before:**
```js
detail: {
    content: productAttributesData,
    data: productAttributesContent,
}
```

**After:**
```js
detail: {
    content: productAttributesContent,
    data: productAttributesData,
}
```

`productAttributesData` is the structured data object returned from the `optionChange` API response, and should be keyed as `data`. `productAttributesContent` is the rendered template string, and should be keyed as `content`. Any listeners on `onProductOptionsChanged` expecting conventional key semantics would have received the wrong value.

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- https://github.com/bigcommerce/cornerstone/issues/2541

#### Screenshots (if appropriate)

N/A — logic fix with no visual output.