### PR TITLE
 fix(storefront): TRAC-633 show ship-to address only for completed or shipped orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Update shipping message for order page [#2647](https://github.com/bigcommerce/cornerstone/pull/2647)
 
 ## 6.19.1 (04-09-2026)
 - Update stencil-utils versionto 6.23.0 [#2638](https://github.com/bigcommerce/cornerstone/pull/2638)

--- a/lang/en.json
+++ b/lang/en.json
@@ -360,7 +360,7 @@
                 "heading": "Order #{number}",
                 "order_contents": "Order Contents",
                 "ship_to": "Ship To",
-                "ship_to_multi": "Items shipped to {street}, {city}, {state}, {zip}, {country}",
+                "ship_to_multi": "Ship to {street}, {city}, {state}, {zip}, {country}",
                 "ship_to_multi_text": "Order will be shipped to multiple addresses",
                 "pickup_details": "Pickup Details",
                 "bill_to": "Bill To",

--- a/templates/components/account/order-contents.html
+++ b/templates/components/account/order-contents.html
@@ -2,15 +2,13 @@
 
 <ul class="account-list">
     {{#each order.items}}
-        {{#if shipping_rows.length}}
-            {{#each shipping_rows}}
-                {{#if is_shipping}}
-                    <li class="account-listShipping">
-                        <h5 class="account-listShipping-title">{{lang 'account.orders.details.ship_to_multi' street=address city=city state=state zip=zip country=country}}</h5>
-                    </li>
-                {{/if}}
-            {{/each}}
+    {{#each shipping_rows}}
+        {{#if is_shipping}}
+            <li class="account-listShipping">
+                <h5 class="account-listShipping-title">{{lang 'account.orders.details.ship_to_multi' street=address city=city state=state zip=zip country=country}}</h5>
+            </li>
         {{/if}}
+    {{/each}}
     <li class="account-listItem">
         <div class="account-product account-product--alignMiddle">
             <div class="account-product-checkItem">


### PR DESCRIPTION

#### What?

The `Ship To` message on the Order page has been updated to align with the order confirmation email and reduce confusion around different order statuses.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

[TRAC-633](https://bigcommercecloud.atlassian.net/browse/TRAC-633)
#### Screenshots 

Before:

<img width="1201" height="774" alt="Screenshot 2026-04-30 at 12 27 18" src="https://github.com/user-attachments/assets/24150dd1-b9dd-404f-b0d8-06540da69fe1" />

After:

<img width="1501" height="797" alt="Screenshot 2026-05-05 at 10 02 31" src="https://github.com/user-attachments/assets/3691ede9-d711-4000-b2bf-0bcdef4710f4" />

https://github.com/user-attachments/assets/048ddf46-b2c4-4539-b431-6b18447f5b53





[TRAC-633]: https://bigcommercecloud.atlassian.net/browse/TRAC-633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ