### PR TITLE
feat(orders): ORDERS-7706 add new return page layout

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3,6 +3,7 @@ __webpack_public_path__ = window.__webpack_public_path__; // eslint-disable-line
 import Global from './theme/global';
 
 const getAccount = () => import('./theme/account');
+const getAddReturnNew = () => import('./theme/add-return-new');
 const getLogin = () => import('./theme/auth');
 const noop = null;
 
@@ -11,7 +12,7 @@ const pageClasses = {
     account_order: getAccount,
     account_addressbook: getAccount,
     shippingaddressform: getAccount,
-    account_new_return: getAccount,
+    account_new_return: getAddReturnNew,
     'add-wishlist': () => import('./theme/wishlist'),
     account_recentitems: getAccount,
     account_downloaditem: getAccount,

--- a/assets/js/theme/add-return-new.js
+++ b/assets/js/theme/add-return-new.js
@@ -1,0 +1,245 @@
+import { escape } from 'lodash';
+import PageManager from './page-manager';
+
+export default class AddReturnNew extends PageManager {
+    onReady() {
+        const $form = $('[data-new-return-form]');
+        if (!$form.length) return;
+
+        // ---------------------------------------------------------------------------
+        // Hardcoded page data which mirrors the TypeScript returns-ui interface.
+        // Replace with Stencil context when it is available.
+        // ---------------------------------------------------------------------------
+        this.pageData = {
+            order: {
+                id: '101',
+                datePlaced: new Date('2024-01-01'),
+                status: 'Completed',
+                currency: 'AUD',
+                isTaxInclusive: true,
+                shipping: {
+                    address: {
+                        fullName: 'Jane Smith',
+                        address1: '1-3 Smail Street',
+                        city: 'Ultimo',
+                        state: 'NSW',
+                        zip: '2007',
+                        country: 'Australia',
+                    },
+                    method: 'Australia Post',
+                    dateShipped: 'May 15, 2024',
+                    trackingNumber: '7E27315406641',
+                },
+                items: [
+                    {
+                        id: 'item-1',
+                        name: 'Product Name',
+                        variant: 'Blue / Black / Green',
+                        sku: 'SKU-001',
+                        quantity: 1,
+                        returnableQuantity: 1,
+                        thumbnailUrl: '',
+                        totalIncTax: 123.99,
+                        totalExTax: 110.71,
+                    },
+                    {
+                        id: 'item-2',
+                        name: 'Product Name',
+                        variant: 'Blue / Black / Green',
+                        sku: 'SKU-002',
+                        quantity: 1,
+                        returnableQuantity: 1,
+                        thumbnailUrl: '',
+                        totalIncTax: 123.99,
+                        totalExTax: 110.71,
+                    },
+                    {
+                        id: 'item-3',
+                        name: 'Product Name',
+                        variant: 'Blue / Black / Green',
+                        sku: 'SKU-003',
+                        quantity: 1,
+                        returnableQuantity: 1,
+                        thumbnailUrl: '',
+                        totalIncTax: 123.99,
+                        totalExTax: 110.71,
+                    },
+                ],
+            },
+            reasons: [
+                { id: 'reason-1', nameForMerchant: 'Damaged or defective', active: true },
+                { id: 'reason-2', nameForMerchant: 'Wrong item received', active: true },
+                { id: 'reason-3', nameForMerchant: 'Changed my mind', active: true },
+                { id: 'reason-4', nameForMerchant: 'Item not as described', active: true },
+                { id: 'reason-5', nameForMerchant: 'Arrived too late', active: true },
+            ],
+            resolutions: [
+                { resolutionType: 'Refund' },
+                { resolutionType: 'Exchange' },
+                { resolutionType: 'Store Credit' },
+            ],
+        };
+
+        this.renderHeader();
+        this.renderShippingAddress();
+        this.renderShippingMethod();
+        this.renderOrderLineItems();
+        this.bindSubmit($form);
+    }
+
+    renderHeader() {
+        const { order } = this.pageData;
+        const dateLabel = order.datePlaced.toLocaleDateString('en-AU', { year: 'numeric', month: 'long', day: 'numeric' });
+
+        document.getElementById('return-new-orderId').textContent = order.id;
+        document.getElementById('return-new-statusBadge').textContent = order.status.toUpperCase();
+        document.getElementById('return-new-datePlaced').textContent = `Order date: ${dateLabel}`;
+    }
+
+    renderShippingAddress() {
+        const { address } = this.pageData.order.shipping;
+        const shippingAddressHtml = `<h4>Shipping address</h4>
+            <p>${escape(address.fullName)}</p>
+            <p>${escape(address.address1)}</p>
+            <p>${escape(address.city)}, ${escape(address.state)} ${escape(address.zip)}</p>
+            <p>${escape(address.country)}</p>`;
+
+        document.getElementById('return-new-shippingAddress').innerHTML = shippingAddressHtml;
+    }
+
+    renderShippingMethod() {
+        const { shipping } = this.pageData.order;
+        const shippingMethodHtml = `<h4>Shipping method</h4>
+            <p>${escape(shipping.method)}</p>
+            <p>Shipped on ${escape(shipping.dateShipped)}</p>
+            <p>${escape(shipping.trackingNumber)}</p>`;
+
+        document.getElementById('return-new-shippingMethod').innerHTML = shippingMethodHtml;
+    }
+
+    renderOrderLineItems() {
+        const { order, reasons, resolutions } = this.pageData;
+
+        const resolutionOptions = [
+            '<option value="">Select a return request</option>',
+            ...resolutions.map(resolution => {
+                const optionValue = this.isCustomResolution(resolution) ? escape(resolution.id) : escape(resolution.resolutionType);
+                const optionLabel = this.isCustomResolution(resolution) ? escape(resolution.nameForMerchant) : escape(resolution.resolutionType);
+                return `<option value="${optionValue}">${optionLabel}</option>`;
+            }),
+        ].join('');
+
+        const reasonOptions = [
+            '<option value="">Select a return reason</option>',
+            ...reasons
+                .filter(reason => reason.active)
+                .map(reason => `<option value="${escape(reason.id)}">${escape(reason.nameForMerchant)}</option>`),
+        ].join('');
+
+        const orderLineItemsHtml = order.items.map(item => {
+            const price = new Intl.NumberFormat('en-AU', { style: 'currency', currency: order.currency }).format(item.totalIncTax);
+            const thumbnailHtml = item.thumbnailUrl
+                ? `<img class="newReturn-orderLineItemThumbnail" src="${escape(item.thumbnailUrl)}" alt="${escape(item.name)}">`
+                : '<div class="newReturn-orderLineItemThumbnail--placeholder">No image</div>';
+
+            return `
+                <div class="newReturn-orderLineItem" data-item-id="${escape(item.id)}">
+                    ${thumbnailHtml}
+                    <div class="newReturn-orderLineItemInfo">
+                        <p class="newReturn-orderLineItemName">${escape(item.name)}</p>
+                        <p class="newReturn-orderLineItemVariant">${escape(item.variant)}</p>
+                        <p class="newReturn-orderLineItemPrice">${price} x ${item.quantity}</p>
+                    </div>
+                    <div class="newReturn-orderLineItemControls">
+                        <div class="form-increment">
+                            <button class="button button--icon" type="button"
+                                    data-action="dec" data-item-id="${escape(item.id)}" disabled>
+                                <span class="is-srOnly">Decrease quantity</span>
+                                <i class="icon" aria-hidden="true"><svg><use href="#icon-keyboard-arrow-down"></use></svg></i>
+                            </button>
+                            <input class="form-input form-input--incrementTotal"
+                                   id="qty-${escape(item.id)}"
+                                   type="tel" value="0" min="0" max="${item.returnableQuantity}"
+                                   pattern="[0-9]*" aria-label="Quantity" readonly>
+                            <button class="button button--icon" type="button"
+                                    data-action="inc" data-item-id="${escape(item.id)}"
+                                    ${item.returnableQuantity === 0 ? 'disabled' : ''}>
+                                <span class="is-srOnly">Increase quantity</span>
+                                <i class="icon" aria-hidden="true"><svg><use href="#icon-keyboard-arrow-up"></use></svg></i>
+                            </button>
+                        </div>
+                        <select class="newReturn-select" id="resolution-${escape(item.id)}" aria-label="Resolution dropdown">
+                            ${resolutionOptions}
+                        </select>
+                        <select class="newReturn-select" id="reason-${escape(item.id)}" aria-label="Return reason">
+                            ${reasonOptions}
+                        </select>
+                    </div>
+                </div>`;
+        }).join('');
+
+        document.getElementById('return-new-itemsList').innerHTML = orderLineItemsHtml;
+        this.bindOrderLineItemEvents();
+    }
+
+    bindOrderLineItemEvents() {
+        document.querySelectorAll('.form-increment .button--icon').forEach(button => {
+            button.addEventListener('click', () => {
+                const itemId = button.getAttribute('data-item-id');
+                const action = button.getAttribute('data-action');
+                const item = this.pageData.order.items.find(orderLineItem => orderLineItem.id === itemId);
+                const quantityInput = document.getElementById(`qty-${itemId}`);
+                let quantity = parseInt(quantityInput.value, 10);
+
+                if (action === 'inc' && quantity < item.returnableQuantity) quantity++;
+                else if (action === 'dec' && quantity > 0) quantity--;
+
+                quantityInput.value = quantity;
+                document.querySelector(`[data-action="dec"][data-item-id="${itemId}"]`).disabled = quantity === 0;
+                document.querySelector(`[data-action="inc"][data-item-id="${itemId}"]`).disabled = quantity >= item.returnableQuantity;
+
+                this.updateSubmitState();
+            });
+        });
+
+        document.querySelectorAll('.newReturn-select').forEach(selectElement => {
+            selectElement.addEventListener('change', () => this.updateSubmitState());
+        });
+    }
+
+    updateSubmitState() {
+        const selectedItems = this.pageData.order.items.filter(item => parseInt(document.getElementById(`qty-${item.id}`).value, 10) > 0);
+
+        const isValid = selectedItems.length > 0 && selectedItems.every(item => (
+            document.getElementById(`resolution-${item.id}`).value
+            && document.getElementById(`reason-${item.id}`).value
+        ));
+
+        document.getElementById('return-new-submitBtn').disabled = !isValid;
+    }
+
+    bindSubmit($form) {
+        $form.on('submit', event => {
+            event.preventDefault();
+
+            const selectedItems = this.pageData.order.items.filter(item => parseInt(document.getElementById(`qty-${item.id}`).value, 10) > 0);
+
+            const newReturn = {
+                orderId: this.pageData.order.id,
+                items: selectedItems.map(item => ({
+                    id: item.id,
+                    quantity: parseInt(document.getElementById(`qty-${item.id}`).value, 10),
+                    reasonId: document.getElementById(`reason-${item.id}`).value,
+                    resolution: document.getElementById(`resolution-${item.id}`).value,
+                })),
+            };
+
+            // TODO: wire up API call when available
+            console.log('Submitting return:', JSON.stringify(newReturn, null, 2));
+        });
+    }
+
+    isCustomResolution(resolution) {
+        return 'id' in resolution;
+    }
+}

--- a/assets/scss/components/stencil/addReturn/_addReturn.scss
+++ b/assets/scss/components/stencil/addReturn/_addReturn.scss
@@ -1,6 +1,10 @@
 // =============================================================================
 // ADD RETURN REQUEST (CSS)
 // =============================================================================
+//
+// Styles shared by both the legacy add-return page (.account--addReturn)
+// and the new add-return-new page (.newReturn).
+// =============================================================================
 
 
 .account--addReturn {
@@ -135,5 +139,248 @@
 
     @include breakpoint("small") {
         width: grid-calc(6, $total-columns);
+    }
+}
+
+
+// =============================================================================
+// NEW RETURN PAGE (.newReturn)
+// =============================================================================
+
+.newReturn {
+    color: color("link");
+    max-width: remCalc(1100px);
+    margin: 0 auto;
+    padding: 0 spacing("single") spacing("double");
+}
+
+.newReturn-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: spacing("eighth");
+}
+
+.newReturn-titleGroup {
+    display: flex;
+    align-items: center;
+    gap: spacing("half");
+}
+
+.newReturn-title {
+    font-size: remCalc(28px);
+    font-weight: fontWeight("bold");
+    margin: 0;
+}
+
+.newReturn-statusBadge {
+    display: inline-block;
+    padding: spacing("eighth") spacing("quarter");
+    border: remCalc(1.5px) solid color("orderStatus", "completed");
+    border-radius: remCalc(4px);
+    font-size: remCalc(11px);
+    font-weight: fontWeight("bold");
+    letter-spacing: remCalc(1px);
+    color: color("orderStatus", "completed");
+    text-transform: uppercase;
+}
+
+.newReturn-headerActions {
+    display: flex;
+    align-items: center;
+    gap: spacing("half");
+}
+
+.newReturn-btnBack {
+    padding: spacing("quarter") spacing("single") * 0.83;
+    border: remCalc(1.5px) solid color("link");
+    border-radius: remCalc(6px);
+    background: color("whites", "bright");
+    font-size: fontSize("smallest");
+    font-weight: fontWeight("medium");
+    cursor: pointer;
+    text-decoration: none;
+    color: color("link");
+}
+
+.newReturn-btnPolicy {
+    padding: spacing("quarter") spacing("single") * 0.83;
+    border: 0;
+    border-radius: remCalc(6px);
+    background: color("greys", "darkest");
+    color: color("whites", "bright");
+    font-size: fontSize("smallest");
+    font-weight: fontWeight("medium");
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.newReturn-orderDate {
+    font-size: remCalc(13px);
+    color: color("greys", "base");
+    margin: spacing("eighth") 0 spacing("single") * 0.83;
+}
+
+.newReturn-divider {
+    border: 0;
+    border-top: container("border");
+    margin: spacing("single") 0;
+}
+
+
+.newReturn-shippingGrid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: remCalc(32px);
+}
+
+.newReturn-shippingSection {
+
+    h4 {
+        font-size: fontSize("smallest");
+        font-weight: fontWeight("semibold");
+        color: color("link");
+        margin: 0 0 spacing("quarter");
+    }
+
+    p,
+    a {
+        font-size: remCalc(13px);
+        margin: remCalc(2px) 0;
+        text-decoration: none;
+    }
+
+    p {
+        color: color("greys", "dark");
+    }
+}
+
+
+.newReturn-orderLineItem {
+    display: flex;
+    align-items: center;
+    gap: remCalc(16px);
+    padding: remCalc(16px) 0;
+    border-bottom: container("border");
+
+    &:last-child {
+        border-bottom: 0;
+    }
+}
+
+.newReturn-orderLineItemThumbnail {
+    width: remCalc(72px);
+    height: remCalc(72px);
+    object-fit: cover;
+    border-radius: remCalc(6px);
+    flex-shrink: 0;
+    background: color("greys", "lighter");
+}
+
+.newReturn-orderLineItemThumbnail--placeholder {
+    width: remCalc(72px);
+    height: remCalc(72px);
+    border-radius: remCalc(6px);
+    flex-shrink: 0;
+    background: color("greys", "light");
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: color("greys", "medium");
+    font-size: remCalc(11px);
+}
+
+.newReturn-orderLineItemInfo {
+    flex: 1;
+    min-width: 0;
+}
+
+.newReturn-orderLineItemName {
+    font-size: remCalc(15px);
+    font-weight: fontWeight("semibold");
+    margin: 0 0 remCalc(2px);
+}
+
+.newReturn-orderLineItemVariant {
+    font-size: remCalc(13px);
+    color: color("greys", "base");
+    margin: 0 0 remCalc(2px);
+}
+
+.newReturn-orderLineItemPrice {
+    font-size: remCalc(13px);
+    color: color("greys", "dark");
+    margin: 0;
+}
+
+.newReturn-orderLineItemControls {
+    display: flex;
+    align-items: center;
+    gap: spacing("half");
+    flex-shrink: 0;
+
+    //Override layout here so the counter sits in a horizontal row
+    // without touching the shared component.
+    .form-increment {
+        display: flex;
+        align-items: center;
+
+    }
+
+    .form-input--incrementTotal {
+        height: remCalc(36px);
+        line-height: remCalc(36px);
+        vertical-align: middle;
+    }
+}
+
+.newReturn-select {
+    height: remCalc(36px);
+    padding: 0 remCalc(28px) 0 spacing("quarter") * 1.67;
+    border: remCalc(1.5px) solid color("greys", "medium");
+    border-radius: remCalc(6px);
+    font-size: remCalc(13px);
+    color: color("greys", "dark");
+    // stylelint-disable-next-line function-url-quotes
+    background: color("whites", "bright") url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23798289'/%3E%3C/svg%3E") no-repeat right spacing("quarter") * 1.67 center;
+    background-size: remCalc(10px);
+    appearance: none;
+    cursor: pointer;
+    min-width: remCalc(180px);
+
+    &:disabled {
+        background-color: color("greys", "lighter");
+        color: color("greys", "medium");
+        cursor: not-allowed;
+        border-color: color("greys", "light");
+    }
+}
+
+.newReturn-submitRow {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: spacing("half");
+}
+
+.newReturn-submitBtn {
+    width: 100%;
+    max-width: remCalc(520px);
+    padding: remCalc(14px);
+    background: color("greys", "darkest");
+    color: color("whites", "bright");
+    border: 0;
+    border-radius: remCalc(8px);
+    font-size: remCalc(15px);
+    font-weight: fontWeight("semibold");
+    cursor: pointer;
+    transition: background 0.2s;
+
+    &:hover {
+        background: color("greys", "dark");
+    }
+
+    &:disabled {
+        background: color("greys", "medium");
+        cursor: not-allowed;
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bigcommerce-cornerstone",
-      "version": "6.19.0",
+      "version": "6.19.1",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/stencil-utils": "6.23.0",

--- a/templates/pages/account/add-return-new.html
+++ b/templates/pages/account/add-return-new.html
@@ -1,0 +1,44 @@
+{{#partial "page"}}
+
+{{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
+{{> components/account/navigation account_page='returns'}}
+
+<main class="newReturn">
+
+    <div class="newReturn-header">
+        <div class="newReturn-titleGroup">
+            <h1 class="newReturn-title">Request Return for Order #<span id="return-new-orderId"></span></h1>
+            <span class="newReturn-statusBadge" id="return-new-statusBadge"></span>
+        </div>
+        <div class="newReturn-headerActions">
+            <a href="{{urls.account.orders.all}}" class="newReturn-btnBack">Back</a>
+            <a href="/return-policy" class="newReturn-btnPolicy">View return policy &rarr;</a>
+        </div>
+    </div>
+    <p class="newReturn-orderDate" id="return-new-datePlaced"></p>
+
+    <hr class="newReturn-divider">
+
+    <div class="newReturn-shippingGrid">
+        <div class="newReturn-shippingSection" id="return-new-shippingAddress"></div>
+        <div class="newReturn-shippingSection" id="return-new-shippingMethod"></div>
+    </div>
+
+    <hr class="newReturn-divider">
+
+    <form data-new-return-form>
+
+        <div id="return-new-itemsList"></div>
+
+        <div class="newReturn-submitRow">
+            <button class="newReturn-submitBtn" id="return-new-submitBtn" type="submit" disabled>
+                Submit Return
+            </button>
+        </div>
+
+    </form>
+
+</main>
+
+{{/partial}}
+{{> layout/base}}


### PR DESCRIPTION
#### What?

A description about what this pull request implements and its purpose. Try to be detailed and describe any technical details to simplify the job of the reviewer and the individual on production support.


This PR introduces the layout as per designs in ORDERS-7706 for the shopper facing new returns page.

This PR currently uses the same shape as the `returns-ui` merchant facing repo and has hardcoded objects until we have decided on the shape and passing it to the stencil context.

This PR currently does not call any backend when submitting the form, and has conditional rendering, if conditional rendering is not the pattern or we do not want to introduce this, we may have to figure out how to shape the backend response so that the front-end can remail purely handlebars / presentational.


#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.


- [ORDERS-7706(https://bigcommercecloud.atlassian.net/browse/ORDERS-7706
- ...

#### Screenshots (if appropriate)

Attach images or add image links here.


https://github.com/user-attachments/assets/11f41d62-137f-466c-a78a-e1c3abf14cec

