### PR TITLE
feat(orders): BACK-508 Render backorder prompts on Storefront "Your orders" page (My Account section for a logged in user)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Draft
 - Fix shipment info showing for cancelled orders [#2654](https://github.com/bigcommerce/cornerstone/pull/2654)
+- Render backorder prompts on My Account "Your orders" page [#2650](https://github.com/bigcommerce/cornerstone/pull/2650)
 
 ## 6.19.1 (04-09-2026)
 - Update stencil-utils versionto 6.23.0 [#2638](https://github.com/bigcommerce/cornerstone/pull/2638)

--- a/assets/scss/components/stencil/account/_account.scss
+++ b/assets/scss/components/stencil/account/_account.scss
@@ -149,6 +149,22 @@
     margin-bottom: 0;
 }
 
+.account-product-backorder-message {
+    font-size: fontSize("smaller");
+    margin-bottom: spacing("quarter");
+
+    &:last-of-type {
+        margin-bottom: 0;
+    }
+}
+
+.account-order-backorder-expectation {
+    color: color("greys", "light");
+    font-size: fontSize("smaller");
+    margin-bottom: 0;
+    margin-top: spacing("base");
+}
+
 .account-product-details {
     @include grid-row($behavior: "nest");
 }

--- a/assets/scss/components/stencil/account/_account.scss
+++ b/assets/scss/components/stencil/account/_account.scss
@@ -149,7 +149,7 @@
     margin-bottom: 0;
 }
 
-.account-product-backorder-message {
+.account-product-backorder-prompts {
     font-size: fontSize("smaller");
     margin-bottom: spacing("quarter");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bigcommerce-cornerstone",
-      "version": "6.19.0",
+      "version": "6.19.1",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/stencil-utils": "6.23.0",

--- a/templates/components/account/order-contents.html
+++ b/templates/components/account/order-contents.html
@@ -83,14 +83,14 @@
                         </dd>
                     </dl>
                 {{/if}}
-                {{#if quantity_backordered}}
+                {{#if quantity_backordered '>' 0}}
                     {{#if (subtract quantity quantity_backordered) '>' 0}}
-                        <p class="account-product-backorder-message">{{lang 'products.quantity_on_hand' quantity=(subtract quantity quantity_backordered)}}</p>
+                        <p class="account-product-backorder-prompts">{{lang 'products.quantity_on_hand' quantity=(subtract quantity quantity_backordered)}}</p>
                     {{/if}}
-                    <p class="account-product-backorder-message">{{lang 'products.quantity_backordered' quantity=quantity_backordered}}</p>
-                {{/if}}
-                {{#if backorder_message}}
-                    <p class="account-product-backorder-message">{{backorder_message}}</p>
+                    <p class="account-product-backorder-prompts">{{lang 'products.quantity_backordered' quantity=quantity_backordered}}</p>
+                    {{#if backorder_message}}
+                        <p class="account-product-backorder-prompts">{{backorder_message}}</p>
+                    {{/if}}
                 {{/if}}
                 {{#if refunded}}
                     <p class="account-product-refundQty">{{lang 'account.orders.refunded_quantity' qty=refunded_qty}}</p>

--- a/templates/components/account/order-contents.html
+++ b/templates/components/account/order-contents.html
@@ -83,6 +83,15 @@
                         </dd>
                     </dl>
                 {{/if}}
+                {{#if quantity_backordered}}
+                    {{#if (subtract quantity quantity_backordered) '>' 0}}
+                        <p class="account-product-backorder-message">{{lang 'products.quantity_on_hand' quantity=(subtract quantity quantity_backordered)}}</p>
+                    {{/if}}
+                    <p class="account-product-backorder-message">{{lang 'products.quantity_backordered' quantity=quantity_backordered}}</p>
+                {{/if}}
+                {{#if backorder_message}}
+                    <p class="account-product-backorder-message">{{backorder_message}}</p>
+                {{/if}}
                 {{#if refunded}}
                     <p class="account-product-refundQty">{{lang 'account.orders.refunded_quantity' qty=refunded_qty}}</p>
                 {{else}}

--- a/templates/pages/account/orders/details.html
+++ b/templates/pages/account/orders/details.html
@@ -69,6 +69,9 @@
                         <li>{{{ sanitize order.shipping_address.city}}}, {{{ sanitize order.shipping_address.state}}} {{{ sanitize order.shipping_address.zip}}}</li>
                         <li>{{{ sanitize order.shipping_address.country}}}</li>
                     </ul>
+                    {{#if order.backorder_shipping_expectation_message}}
+                        <p class="account-order-backorder-expectation">{{order.backorder_shipping_expectation_message}}</p>
+                    {{/if}}
                 </section>
             {{/if}}
             {{#if order.pickup_addresses}}
@@ -112,6 +115,9 @@
                         <div class="account-order-address">
                             {{lang 'account.orders.details.ship_to_multi_text'}}
                         </div>
+                        {{#if order.backorder_shipping_expectation_message}}
+                            <p class="account-order-backorder-expectation">{{order.backorder_shipping_expectation_message}}</p>
+                        {{/if}}
                     </section>
                 {{/if}}
             {{/if}}


### PR DESCRIPTION
#### What?

When a shopper goes back into their My Account > Your Orders section on the storefront, we’d want to ensure the merchant can utilize this opportunity to render backorder prompts. Note: this only applies when an order is still awaiting fulfilment. Rendering backorder display prompts for an order that is either cancelled, refunded, completed or shipped, declined or refunded does not add value

> [!IMPORTANT]
> The condition check to show each prompt, is done in the bcapp resource backend PR: https://github.com/bigcommerce/bigcommerce/pull/67916 so this theme PR's logic is simplified. 

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [BACK-508(https://bigcommercecloud.atlassian.net/browse/BACK-508)
- ...

#### Screenshots (if appropriate)

Design:
<img width="2048" height="1520" alt="image" src="https://github.com/user-attachments/assets/140f1917-43e6-470c-b430-083e38e5da47" />

Actual:
<img width="2352" height="1526" alt="image" src="https://github.com/user-attachments/assets/9d47005a-6efb-4afe-be7b-be60ea155ae8" />

