### PR TITLE
feat(returns): ORDERS-7704 condition for new returns on orders page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Gate account orders list "Return Items" link on returns settings (ORDERS-7704) [#2653](https://github.com/bigcommerce/cornerstone/pull/2653)
 
-- Gate account orders list "Return Items" on `settings.returns_v2_enabled` and `settings.returns_enabled`. Key `returns_v2_enabled` is provisional until [ORDERS-7767](https://bigcommercecloud.atlassian.net/browse/ORDERS-7767) ships the final Stencil `settings` field (ORDERS-7704). **TODO:** confirm settings key with backend before merge to master.
 ## 6.19.1 (04-09-2026)
 - Update stencil-utils versionto 6.23.0 [#2638](https://github.com/bigcommerce/cornerstone/pull/2638)
 - Audit and fix Stencil theme remote API calls for multi-language subfolder support [#2635](https://github.com/bigcommerce/cornerstone/pull/2635)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Draft
 
+- Gate account orders list "Return Items" on `settings.returns_v2_enabled` and `settings.returns_enabled`. Key `returns_v2_enabled` is provisional until [ORDERS-7767](https://bigcommercecloud.atlassian.net/browse/ORDERS-7767) ships the final Stencil `settings` field (ORDERS-7704). **TODO:** confirm settings key with backend before merge to master.
 ## 6.19.1 (04-09-2026)
 - Update stencil-utils versionto 6.23.0 [#2638](https://github.com/bigcommerce/cornerstone/pull/2638)
 - Audit and fix Stencil theme remote API calls for multi-language subfolder support [#2635](https://github.com/bigcommerce/cornerstone/pull/2635)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bigcommerce-cornerstone",
-      "version": "6.19.0",
+      "version": "6.19.1",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/stencil-utils": "6.23.0",

--- a/templates/components/account/orders-list.html
+++ b/templates/components/account/orders-list.html
@@ -23,7 +23,6 @@
             <div class="account-product-body">
                 <div class="account-orderStatus">
                     <h6 class="account-orderStatus-label">{{this.status}}</h6>
-                    {{!-- TODO(ORDERS-7704 / ORDERS-7767): Confirm final `settings.*` key name with backend before merge to master — provisional `returns_v2_enabled`.--}}
                     {{#if this.return_url}}
                         {{#or ../settings.returns_v2_enabled ../settings.returns_enabled}}
                             <a class="account-orderStatus-action" href="{{this.return_url}}">

--- a/templates/components/account/orders-list.html
+++ b/templates/components/account/orders-list.html
@@ -23,12 +23,13 @@
             <div class="account-product-body">
                 <div class="account-orderStatus">
                     <h6 class="account-orderStatus-label">{{this.status}}</h6>
-                    {{#if ../settings.returns_enabled}}
-                        {{#if this.return_url}}
+                    {{!-- TODO(ORDERS-7704 / ORDERS-7767): Confirm final `settings.*` key name with backend before merge to master — provisional `returns_v2_enabled`.--}}
+                    {{#if this.return_url}}
+                        {{#or ../settings.returns_v2_enabled ../settings.returns_enabled}}
                             <a class="account-orderStatus-action" href="{{this.return_url}}">
                                 {{lang 'account.orders.return_items' }}
                             </a>
-                        {{/if}}
+                        {{/or}}
                     {{/if}}
                 </div>
 


### PR DESCRIPTION
#### What?

This PR is to add new conditional flag(returns_v2_enabled) on orders page to allow customers to land on new returns flow.
implementation of flag: [ORDERS-7663](https://bigcommercecloud.atlassian.net/browse/ORDERS-7663) and [ORDERS-7767](https://bigcommercecloud.atlassian.net/browse/ORDERS-7767)

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [ORDERS-7704](https://bigcommercecloud.atlassian.net/browse/ORDERS-7704)

#### Screenshots (if appropriate)

<img width="1051" height="923" alt="image" src="https://github.com/user-attachments/assets/ac6ddfc7-958b-4f59-a123-30144c3c46aa" />



[ORDERS-7663]: https://bigcommercecloud.atlassian.net/browse/ORDERS-7663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ORDERS-7767]: https://bigcommercecloud.atlassian.net/browse/ORDERS-7767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ORDERS-7704]: https://bigcommercecloud.atlassian.net/browse/ORDERS-7704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ