### PR TITLE
fix(cornerstone): TRAC-633 fix shipment info showing for cancelled orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Fix shipment info showing for cancelled orders [#2654](https://github.com/bigcommerce/cornerstone/pull/2654)
 
 ## 6.19.1 (04-09-2026)
 - Update stencil-utils versionto 6.23.0 [#2638](https://github.com/bigcommerce/cornerstone/pull/2638)

--- a/templates/components/account/order-contents.html
+++ b/templates/components/account/order-contents.html
@@ -2,14 +2,16 @@
 
 <ul class="account-list">
     {{#each order.items}}
-        {{#if shipping_rows.length}}
-            {{#each shipping_rows}}
-                {{#if is_shipping}}
-                    <li class="account-listShipping">
-                        <h5 class="account-listShipping-title">{{lang 'account.orders.details.ship_to_multi' street=address city=city state=state zip=zip country=country}}</h5>
-                    </li>
-                {{/if}}
-            {{/each}}
+        {{#if ../order.is_complete}}
+            {{#if shipping_rows.length}}
+                {{#each shipping_rows}}
+                    {{#if is_shipping}}
+                        <li class="account-listShipping">
+                            <h5 class="account-listShipping-title">{{lang 'account.orders.details.ship_to_multi' street=address city=city state=state zip=zip country=country}}</h5>
+                        </li>
+                    {{/if}}
+                {{/each}}
+            {{/if}}
         {{/if}}
     <li class="account-listItem">
         <div class="account-product account-product--alignMiddle">


### PR DESCRIPTION
#### What?

Cause: Shipment information was being displayed on the Order Details page for orders in a Cancelled state in cornerstone. This was caused because shipping address was tied to if an item was assigned a shipping address.

Fix: Gate is_shipping with order.is_complete. is_complete is flips to true once the order reaches a fulfilled lifecycle state (Shipped, Completed). The theme already trusts this field at templates/pages/account/orders/details.html to gate the "Return this order" button, so reusing it here should be safe.

#### Requirements

- [x] CHANGELOG.md entry added.

#### Tickets / Documentation

- https://linear.app/commerce/issue/LTRAC-648/shipment-info-shows-for-canceled-orders-in-cornerstone

#### Screenshots (if appropriate)

Attach images or add image links here.
<img width="1053" height="393" alt="Screenshot 2026-05-06 at 3 24 20 PM" src="https://github.com/user-attachments/assets/7e99d0e9-d8b5-4657-9c9b-d679290c4c6c" />
<img width="1032" height="396" alt="Screenshot 2026-05-06 at 3 24 52 PM" src="https://github.com/user-attachments/assets/3d5cee04-ef5b-4d52-a28a-afed7f41960a" />
<img width="969" height="504" alt="Screenshot 2026-05-06 at 3 25 52 PM" src="https://github.com/user-attachments/assets/7dc59cbd-f6a1-47fc-8ee4-9c4e63fa470f" />
<img width="979" height="397" alt="Screenshot 2026-05-06 at 3 26 14 PM" src="https://github.com/user-attachments/assets/0d3d9607-657f-4605-9e29-52b485454e62" />
<img width="990" height="383" alt="Screenshot 2026-05-06 at 3 26 41 PM" src="https://github.com/user-attachments/assets/0069af88-905e-489c-9e4a-6e5853029171" />
<img width="1004" height="468" alt="Screenshot 2026-05-06 at 3 25 26 PM" src="https://github.com/user-attachments/assets/4b2248a8-0060-4df5-9993-cc07e5792c9f" />
<img width="951" height="385" alt="Screenshot 2026-05-06 at 3 26 59 PM" src="https://github.com/user-attachments/assets/59dc549f-5493-4e04-a0dd-59c91136e474" />