### PR TITLE
feat(returns): ORDERS-7705 condition for new returns on order details…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update 'Ship to' copy for multi address orders [#2655](https://github.com/bigcommerce/cornerstone/pull/2655)
 - Fixed typo in category page reset-filters live region handler [#2643](https://github.com/bigcommerce/cornerstone/pull/2643)
 - Swap content/data keys in onProductOptionsChanged event detail [#2640](https://github.com/bigcommerce/cornerstone/pull/2640)
+- Gate Order Details "Return" button on `settings.returns_v2_enabled` with `settings.returns_enabled` fallback (ORDERS-7705)
 - Fix shipment info showing for cancelled orders [#2654](https://github.com/bigcommerce/cornerstone/pull/2654)
 - Render backorder prompts on My Account "Your orders" page [#2650](https://github.com/bigcommerce/cornerstone/pull/2650)
 - Gate account orders list "Return Items" link on returns settings (ORDERS-7704) [#2653](https://github.com/bigcommerce/cornerstone/pull/2653)

--- a/templates/pages/account/orders/details.html
+++ b/templates/pages/account/orders/details.html
@@ -183,11 +183,11 @@
                         {{/each}}
                         <input type="submit" class="button" value="{{lang 'account.orders.details.reorder'}}">
                     </form>
-                    {{#if settings.returns_enabled}}
+                    {{#or settings.returns_v2_enabled settings.returns_enabled}}
                         {{#if order.is_complete}}
                             <a href="{{order.return_url}}" class="button">{{lang 'account.orders.details.return'}}</a>
                         {{/if}}
-                    {{/if}}
+                    {{/or}}
                 </div>
             </section>
         </aside>


### PR DESCRIPTION
#### What?

This PR is to add new conditional flag(returns_v2_enabled) on order details page to allow customers to land on new returns flow.
implementation of flag: [ORDERS-7663](https://bigcommercecloud.atlassian.net/browse/ORDERS-7663) and [ORDERS-7767](https://bigcommercecloud.atlassian.net/browse/ORDERS-7767)

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

[ORDERS-7705](https://bigcommercecloud.atlassian.net/browse/ORDERS-7705)

#### Screenshots (if appropriate)

Tested if the flow is not broken and existing flag is working correctly => Test the new flag once flag value is available.

<img width="1052" height="991" alt="image" src="https://github.com/user-attachments/assets/aca7e26c-948f-47db-88fd-ec06825e9845" />


[ORDERS-7663]: https://bigcommercecloud.atlassian.net/browse/ORDERS-7663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ORDERS-7767]: https://bigcommercecloud.atlassian.net/browse/ORDERS-7767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ORDERS-7705]: https://bigcommercecloud.atlassian.net/browse/ORDERS-7705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ