### PR TITLE
fix(account): TRAC-686 remove duplicate id="default_instrument" on edit payment method page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Fix duplicate `id="default_instrument"` on Update Payment Method page
 - Respect `available_to_sell` on PDP so the Sold Out alert is hidden and the Add to Cart button stays enabled for backorderable products, and is disabled when quantity exceeds `available_to_sell` [#2659](https://github.com/bigcommerce/cornerstone/pull/2659)
 - Updated accessibility features [2656](https://github.com/bigcommerce/cornerstone/pull/2656)
 - Update 'Ship to' copy for multi address orders [#2655](https://github.com/bigcommerce/cornerstone/pull/2655)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
-- Fix duplicate `id="default_instrument"` on Update Payment Method page
+- Fix duplicate `id="default_instrument"` on Update Payment Method page [#2661](https://github.com/bigcommerce/cornerstone/pull/2661)
 - Respect `available_to_sell` on PDP so the Sold Out alert is hidden and the Add to Cart button stays enabled for backorderable products, and is disabled when quantity exceeds `available_to_sell` [#2659](https://github.com/bigcommerce/cornerstone/pull/2659)
 - Updated accessibility features [2656](https://github.com/bigcommerce/cornerstone/pull/2656)
 - Update 'Ship to' copy for multi address orders [#2655](https://github.com/bigcommerce/cornerstone/pull/2655)

--- a/templates/pages/account/edit-payment-method.html
+++ b/templates/pages/account/edit-payment-method.html
@@ -41,7 +41,7 @@
                         </div>
                     {{/if}}
                     <div class="form-field">
-                        <input type="checkbox" value="default_instrument" name="default_instrument" id="default_instrument" data-label="{{lang 'forms.payment_methods.default_instrument'}}" class="form-checkbox" {{#if customer.payment_methods.selected_payment_method.default_instrument}}checked{{/if}}>
+                        <input type="checkbox" value="default_instrument" name="is_default" id="default_instrument" data-label="{{lang 'forms.payment_methods.default_instrument'}}" class="form-checkbox" {{#if is_default}}checked{{/if}}>
                         <label class="form-label" for="default_instrument">{{lang 'forms.payment_methods.default_instrument'}}</label>
                     </div>
                 </div>

--- a/templates/pages/account/edit-payment-method.html
+++ b/templates/pages/account/edit-payment-method.html
@@ -41,7 +41,7 @@
                         </div>
                     {{/if}}
                     <div class="form-field">
-                        <input type="checkbox" value="default_instrument" name="is_default" id="default_instrument" data-label="{{lang 'forms.payment_methods.default_instrument'}}" class="form-checkbox" {{#if is_default}}checked{{/if}}>
+                        <input type="checkbox" value="default_instrument" name="default_instrument" id="default_instrument" data-label="{{lang 'forms.payment_methods.default_instrument'}}" class="form-checkbox" {{#if customer.payment_methods.selected_payment_method.default_instrument}}checked{{/if}}>
                         <label class="form-label" for="default_instrument">{{lang 'forms.payment_methods.default_instrument'}}</label>
                     </div>
                 </div>

--- a/templates/pages/account/edit-payment-method.html
+++ b/templates/pages/account/edit-payment-method.html
@@ -43,7 +43,6 @@
                     <div class="form-field">
                         <input type="checkbox" value="default_instrument" name="is_default" id="default_instrument" data-label="{{lang 'forms.payment_methods.default_instrument'}}" class="form-checkbox" {{#if is_default}}checked{{/if}}>
                         <label class="form-label" for="default_instrument">{{lang 'forms.payment_methods.default_instrument'}}</label>
-                        <input type="checkbox" value="default_instrument" name="default_instrument" id="default_instrument" data-label="{{lang 'forms.payment_methods.default_instrument'}}" class="form-checkbox" {{#if customer.payment_methods.selected_payment_method.default_instrument}}checked{{/if}}>
                     </div>
                 </div>
 


### PR DESCRIPTION
#### What?

The Update Payment Method page (`Account > Payment Methods > Edit`) renders two `<input type="checkbox">` elements that both have `id="default_instrument"`, producing invalid markup and an accessibility violation.

The duplicate input is leftover from the pre-`PAYMENTS-4944` template, which used `customer.payment_methods.selected_payment_method` directly. When that change refactored the form to use `{{#with customer.edit_stored_instrument}}` and renamed the field to `is_default`, it left the old `<input name="default_instrument">` in place. 

This PR removes the duplicate input so each ID is unique on the page.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [TRAC-686](https://bigcommercecloud.atlassian.net/browse/TRAC-686)

#### Screenshots (if appropriate)
<img width="984" height="366" alt="Screenshot 2026-05-21 at 18 43 03" src="https://github.com/user-attachments/assets/cb730950-f6da-46ef-b03c-0b988f8ecee5" />



[TRAC-686]: https://bigcommercecloud.atlassian.net/browse/TRAC-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ