### PR TITLE
feat(backorders): BACK-655 render picklist backorder prompt on PDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Render backorder prompt for picklist products on PDP [#2662](https://github.com/bigcommerce/cornerstone/pull/2662)
 - Fix bundled item stock section showing title with no content when there is no backorder data or all inventory display settings are disabled [#2668](https://github.com/bigcommerce/cornerstone/pull/2668)
 - Render stock positions for bundled items (pick lists) on the cart page, (change to be left aligned with the quantity adjuster) [#2663](https://github.com/bigcommerce/cornerstone/pull/2663)
 - Fix duplicate `id="default_instrument"` on Update Payment Method page [#2661](https://github.com/bigcommerce/cornerstone/pull/2661)

--- a/assets/js/test-unit/theme/common/picklist-backorder.spec.js
+++ b/assets/js/test-unit/theme/common/picklist-backorder.spec.js
@@ -1,0 +1,543 @@
+import PicklistBackorder from '../../../theme/common/picklist-backorder';
+
+const detail = (overrides = {}) => ({
+    product_id: 80,
+    available_for_backorder: 10,
+    unlimited_backorder: false,
+    available_on_hand: 0,
+    available_to_sell: 10,
+    backorder_message_id: 0,
+    purchasable: true,
+    is_stock_tracked: true,
+    ...overrides,
+});
+
+const selection = (overrides = {}) => ({
+    product_attribute_id: 113,
+    attribute_value_id: 98,
+    product_id: 80,
+    auto_adjust_inventory_flag: true,
+    ...overrides,
+});
+
+const buildScope = (attributes = []) => {
+    const fieldMarkup = attributes.map(attr => {
+        const valueMarkup = (attr.values || [])
+            .map(v => `<label data-product-attribute-value="${v.id}" class="form-label">${v.label || ''}</label>`)
+            .join('');
+        return `
+            <div class="form-field" data-product-attribute="product-list">
+                <label class="form-label form-label--alternate form-label--inlineSmall">${attr.name}:<span data-option-value></span></label>
+                ${valueMarkup}
+            </div>
+        `;
+    }).join('');
+    const $scope = $(
+        `<div>
+            <div data-product-option-change>${fieldMarkup}</div>
+            <div class="form-field form-field--stock">
+                <p data-product-backordered></p>
+                <ul class="productView-picklist-backorder" data-picklist-backorder-list style="display:none;"></ul>
+            </div>
+        </div>`,
+    );
+    $scope.appendTo(document.body);
+    return $scope;
+};
+
+const oneAttr = (name, valueId, valueLabel) => [{ name, values: [{ id: valueId, label: valueLabel }] }];
+
+describe('PicklistBackorder', () => {
+    let $scope;
+
+    afterEach(() => {
+        if ($scope) {
+            $scope.remove();
+            $scope = null;
+        }
+    });
+
+    describe('render()', () => {
+        let context;
+
+        beforeEach(() => {
+            context = {
+                quantityBackorderedMessage: '__QTY__ will be backordered',
+                backorderMessages: [
+                    { id: 1, message: '', is_default: true },
+                    { id: 2, message: 'Backorder message 1' },
+                ],
+                showBackorderMessage: true,
+            };
+        });
+
+        it('no-ops when the list container is not present in scope', () => {
+            $scope = $('<div></div>').appendTo(document.body);
+            const renderer = new PicklistBackorder($scope, context);
+
+            expect(() => renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail()],
+            }, 5)).not.toThrow();
+        });
+
+        it('hides the list and renders no items when payload arrays are empty', () => {
+            $scope = buildScope();
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({ selected_picklist_options: [], picklist_products_details: [] }, 5);
+
+            const $list = $('[data-picklist-backorder-list]', $scope);
+            expect($list.children('li').length).toBe(0);
+            expect($list.css('display')).toBe('none');
+        });
+
+        it('tolerates missing payload keys', () => {
+            $scope = buildScope();
+            const renderer = new PicklistBackorder($scope, context);
+
+            expect(() => renderer.render({}, 5)).not.toThrow();
+            expect($('[data-picklist-backorder-list] li', $scope).length).toBe(0);
+        });
+
+        it('renders one line with bold attribute-name span, qty, and per-product backorder message', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'option label text'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({
+                    available_on_hand: 1,
+                    available_for_backorder: 10,
+                    backorder_message_id: 2,
+                })],
+            }, 5);
+
+            const $items = $('[data-picklist-backorder-list] li', $scope);
+            expect($items.length).toBe(1);
+            const $name = $items.eq(0).children('span.productView-picklist-backorder-name');
+            expect($name.length).toBe(1);
+            expect($name.text()).toBe('Bundle 1:');
+            const text = $items.eq(0).text();
+            expect(text).toContain('4 will be backordered');
+            expect(text).toContain('| Backorder message 1');
+            expect(text).not.toContain('(');
+            expect(text).not.toContain('option label text');
+        });
+
+        it('skips selections with auto_adjust_inventory_flag set to false', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [selection({ auto_adjust_inventory_flag: false })],
+                picklist_products_details: [detail()],
+            }, 5);
+
+            expect($('[data-picklist-backorder-list] li', $scope).length).toBe(0);
+        });
+
+        it('skips selections whose linked product is not stock-tracked (caveat 8 residue case)', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({
+                    is_stock_tracked: false,
+                    available_on_hand: 5,
+                    available_for_backorder: 10,
+                    available_to_sell: 15,
+                })],
+            }, 5);
+
+            expect($('[data-picklist-backorder-list] li', $scope).length).toBe(0);
+        });
+
+        it('renders mainQty without clamping when unlimited_backorder is true', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({
+                    unlimited_backorder: true,
+                    available_for_backorder: null,
+                    available_on_hand: 0,
+                    available_to_sell: 0,
+                })],
+            }, 7);
+
+            const $items = $('[data-picklist-backorder-list] li', $scope);
+            expect($items.length).toBe(1);
+            expect($items.eq(0).text()).toContain('7 will be backordered');
+        });
+
+        it('silently skips a selection whose product has no matching details entry', () => {
+            $scope = buildScope([
+                { name: 'Bundle 1', values: [{ id: 98, label: 'A' }] },
+                { name: 'Bundle 2', values: [{ id: 99, label: 'B' }] },
+            ]);
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [
+                    selection({ product_id: 80, attribute_value_id: 98 }),
+                    selection({ product_attribute_id: 114, product_id: 81, attribute_value_id: 99 }),
+                ],
+                picklist_products_details: [detail({ product_id: 80 })],
+            }, 5);
+
+            const $items = $('[data-picklist-backorder-list] li', $scope);
+            expect($items.length).toBe(1);
+            expect($items.eq(0).text()).toContain('Bundle 1');
+            expect($items.eq(0).text()).not.toContain('Bundle 2');
+        });
+
+        it('calculates independently when two selections share the same linked product', () => {
+            $scope = buildScope([
+                { name: 'Bundle 1', values: [{ id: 98, label: 'A' }] },
+                { name: 'Bundle 2', values: [{ id: 99, label: 'B' }] },
+            ]);
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [
+                    selection({ product_id: 80, attribute_value_id: 98, product_attribute_id: 113 }),
+                    selection({ product_id: 80, attribute_value_id: 99, product_attribute_id: 114 }),
+                ],
+                picklist_products_details: [detail({
+                    product_id: 80,
+                    available_on_hand: 2,
+                    available_for_backorder: 20,
+                    available_to_sell: 22,
+                })],
+            }, 3);
+
+            // Independent: each selection sees the full on-hand pool independently.
+            // Both: demand=3, on_hand=2 → backordered=1.
+            const $items = $('[data-picklist-backorder-list] li', $scope);
+            expect($items.length).toBe(2);
+            expect($items.eq(0).children('span.productView-picklist-backorder-name').text()).toBe('Bundle 1:');
+            expect($items.eq(0).text()).toContain('1 will be backordered');
+            expect($items.eq(1).children('span.productView-picklist-backorder-name').text()).toBe('Bundle 2:');
+            expect($items.eq(1).text()).toContain('1 will be backordered');
+        });
+
+        it('shows no backorder on either selection when on-hand covers demand independently', () => {
+            $scope = buildScope([
+                { name: 'Picklist 1', values: [{ id: 98, label: 'A' }] },
+                { name: 'Picklist 2', values: [{ id: 99, label: 'B' }] },
+            ]);
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [
+                    selection({ product_id: 80, attribute_value_id: 98, product_attribute_id: 113 }),
+                    selection({ product_id: 80, attribute_value_id: 99, product_attribute_id: 114 }),
+                ],
+                picklist_products_details: [detail({
+                    product_id: 80,
+                    available_on_hand: 1,
+                    unlimited_backorder: true,
+                    available_for_backorder: null,
+                })],
+            }, 1);
+
+            // Independent: each selection sees on_hand=1 vs demand=1. No backorder for either.
+            expect($('[data-picklist-backorder-list] li', $scope).length).toBe(0);
+        });
+
+        it('shows no backorder when selections use distinct products with sufficient on-hand', () => {
+            $scope = buildScope([
+                { name: 'Picklist 1', values: [{ id: 98, label: 'A' }] },
+                { name: 'Picklist 2', values: [{ id: 99, label: 'B' }] },
+            ]);
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [
+                    selection({ product_id: 80, attribute_value_id: 98, product_attribute_id: 113 }),
+                    selection({ product_id: 81, attribute_value_id: 99, product_attribute_id: 114 }),
+                ],
+                picklist_products_details: [
+                    detail({ product_id: 80, available_on_hand: 5, available_for_backorder: 10 }),
+                    detail({ product_id: 81, available_on_hand: 5, available_for_backorder: 10 }),
+                ],
+            }, 3);
+
+            // Distinct products — each has its own pool. on-hand=5 covers demand=3. No backorder.
+            expect($('[data-picklist-backorder-list] li', $scope).length).toBe(0);
+        });
+
+        it('clamps backorder to AFB independently for each selection', () => {
+            $scope = buildScope([
+                { name: 'Bundle 1', values: [{ id: 98, label: 'A' }] },
+                { name: 'Bundle 2', values: [{ id: 99, label: 'B' }] },
+            ]);
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [
+                    selection({ product_id: 80, attribute_value_id: 98, product_attribute_id: 113 }),
+                    selection({ product_id: 80, attribute_value_id: 99, product_attribute_id: 114 }),
+                ],
+                picklist_products_details: [detail({
+                    product_id: 80,
+                    available_on_hand: 0,
+                    available_for_backorder: 5,
+                    available_to_sell: 20,
+                })],
+            }, 4);
+
+            // Independent: each selection sees OH=0, AFB=5, demand=4 → backordered=min(4,5)=4.
+            const $items = $('[data-picklist-backorder-list] li', $scope);
+            expect($items.length).toBe(2);
+            expect($items.eq(0).text()).toContain('4 will be backordered');
+            expect($items.eq(1).text()).toContain('4 will be backordered');
+        });
+
+        it('clamps the backordered qty to available_for_backorder', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({
+                    available_on_hand: 0,
+                    available_for_backorder: 3,
+                    available_to_sell: 10,
+                })],
+            }, 8);
+
+            const $items = $('[data-picklist-backorder-list] li', $scope);
+            expect($items.length).toBe(1);
+            expect($items.eq(0).text()).toContain('3 will be backordered');
+        });
+
+        it('does not render a line when on-hand stock covers the requested qty', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({
+                    available_on_hand: 20,
+                    available_for_backorder: 10,
+                    available_to_sell: 30,
+                })],
+            }, 5);
+
+            expect($('[data-picklist-backorder-list] li', $scope).length).toBe(0);
+        });
+
+        it('full-sweep clears prior rendered lines on a subsequent render with empty arrays', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail()],
+            }, 5);
+            expect($('[data-picklist-backorder-list] li', $scope).length).toBe(1);
+
+            renderer.render({ selected_picklist_options: [], picklist_products_details: [] }, 5);
+            expect($('[data-picklist-backorder-list] li', $scope).length).toBe(0);
+            expect($('[data-picklist-backorder-list]', $scope).css('display')).toBe('none');
+        });
+
+        it('omits the message suffix when backorder_message_id points at the default-empty record', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({ backorder_message_id: 1 })],
+            }, 5);
+
+            const $items = $('[data-picklist-backorder-list] li', $scope);
+            expect($items.length).toBe(1);
+            expect($items.eq(0).text()).not.toContain('|');
+        });
+
+        it('omits the message suffix when backorder_message_id has no matching entry', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({ backorder_message_id: 9999 })],
+            }, 5);
+
+            const $items = $('[data-picklist-backorder-list] li', $scope);
+            expect($items.length).toBe(1);
+            expect($items.eq(0).text()).not.toContain('|');
+        });
+
+        it('omits the message suffix when context.backorderMessages is missing', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder(
+                $scope,
+                { quantityBackorderedMessage: '__QTY__ will be backordered' },
+            );
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({ backorder_message_id: 2 })],
+            }, 5);
+
+            const $items = $('[data-picklist-backorder-list] li', $scope);
+            expect($items.length).toBe(1);
+            expect($items.eq(0).text()).not.toContain('|');
+        });
+
+        it('rerender(qty) re-applies cached data with the new qty', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail()],
+            }, 1);
+            expect($('[data-picklist-backorder-list] li', $scope).eq(0).text()).toContain('1 will be backordered');
+
+            renderer.rerender(5);
+            expect($('[data-picklist-backorder-list] li', $scope).eq(0).text()).toContain('5 will be backordered');
+        });
+
+        it('rerender(qty) no-ops when no prior render has captured data', () => {
+            $scope = buildScope();
+            const renderer = new PicklistBackorder($scope, context);
+            expect(() => renderer.rerender(5)).not.toThrow();
+            expect($('[data-picklist-backorder-list] li', $scope).length).toBe(0);
+        });
+
+        it('skips a selection when the linked product is not purchasable', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({ purchasable: false })],
+            }, 5);
+
+            expect($('[data-picklist-backorder-list] li', $scope).length).toBe(0);
+        });
+
+        it('skips the entire line when context.showQuantityOnBackorder is false', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder(
+                $scope,
+                { ...context, showQuantityOnBackorder: false },
+            );
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({
+                    available_on_hand: 0,
+                    available_for_backorder: 10,
+                    backorder_message_id: 2,
+                })],
+            }, 5);
+
+            const $list = $('[data-picklist-backorder-list]', $scope);
+            expect($list.children('li').length).toBe(0);
+            expect($list.css('display')).toBe('none');
+        });
+
+        it('skips a selection when requested qty exceeds the linked product available_to_sell', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({
+                    available_on_hand: 2,
+                    available_for_backorder: 5,
+                    available_to_sell: 7,
+                })],
+            }, 10);
+
+            expect($('[data-picklist-backorder-list] li', $scope).length).toBe(0);
+        });
+
+        it('renders the line when requested qty is within the linked product available_to_sell', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({
+                    available_on_hand: 2,
+                    available_for_backorder: 5,
+                    available_to_sell: 7,
+                })],
+            }, 5);
+
+            const $items = $('[data-picklist-backorder-list] li', $scope);
+            expect($items.length).toBe(1);
+            expect($items.eq(0).text()).toContain('3 will be backordered');
+        });
+
+        it('does not apply a sell-limit clamp when available_to_sell is 0 (no limit set)', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({
+                    available_on_hand: 0,
+                    available_for_backorder: 100,
+                    available_to_sell: 0,
+                })],
+            }, 50);
+
+            const $items = $('[data-picklist-backorder-list] li', $scope);
+            expect($items.length).toBe(1);
+            expect($items.eq(0).text()).toContain('50 will be backordered');
+        });
+
+        it('does not suppress unlimited-backorder products via the sell-limit gate', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({
+                    available_on_hand: 1,
+                    unlimited_backorder: true,
+                    available_for_backorder: null,
+                    available_to_sell: 1,
+                })],
+            }, 3);
+
+            const $items = $('[data-picklist-backorder-list] li', $scope);
+            expect($items.length).toBe(1);
+            expect($items.eq(0).text()).toContain('2 will be backordered');
+        });
+
+        it('omits the message suffix when context.showBackorderMessage is false', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder(
+                $scope,
+                { ...context, showBackorderMessage: false },
+            );
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({
+                    available_on_hand: 0,
+                    available_for_backorder: 10,
+                    backorder_message_id: 2,
+                })],
+            }, 5);
+
+            const $items = $('[data-picklist-backorder-list] li', $scope);
+            expect($items.length).toBe(1);
+            const text = $items.eq(0).text();
+            expect(text).toContain('5 will be backordered');
+            expect(text).not.toContain('|');
+            expect(text).not.toContain('Backorder message 1');
+        });
+    });
+});

--- a/assets/js/theme/common/picklist-backorder.js
+++ b/assets/js/theme/common/picklist-backorder.js
@@ -1,0 +1,132 @@
+export default class PicklistBackorder {
+    constructor($scope, context) {
+        this.$scope = $scope;
+        this.context = context;
+        this.$list = $('[data-picklist-backorder-list]', $scope);
+        this.lastData = null;
+        this.detailsByProductId = new Map();
+    }
+
+    render(data, mainQty) {
+        if (!this.$list.length) return;
+        this.lastData = data;
+
+        const selections = Array.isArray(data && data.selected_picklist_options)
+            ? data.selected_picklist_options
+            : [];
+        const details = Array.isArray(data && data.picklist_products_details)
+            ? data.picklist_products_details
+            : [];
+
+        this.detailsByProductId = new Map(
+            details
+                .filter(d => d && typeof d.product_id === 'number')
+                .map(d => [d.product_id, d]),
+        );
+
+        const lines = this.buildLines(selections, this.detailsByProductId, mainQty);
+        this.paint(lines);
+    }
+
+    rerender(mainQty) {
+        if (this.lastData) this.render(this.lastData, mainQty);
+    }
+
+    buildLines(selections, detailsByProductId, mainQty) {
+        if (this.context.showQuantityOnBackorder === false) {
+            return [];
+        }
+
+        const lines = [];
+        const requestedQty = parseInt(mainQty, 10) || 0;
+
+        selections.forEach(sel => {
+            if (!sel || sel.auto_adjust_inventory_flag !== true) return;
+            if (typeof sel.product_id !== 'number') return;
+
+            const detail = detailsByProductId.get(sel.product_id);
+            if (!detail) return;
+            if (detail.is_stock_tracked === false) return;
+            if (detail.purchasable === false) return;
+
+            const unlimited = detail.unlimited_backorder === true;
+            const availableToSell = parseInt(detail.available_to_sell, 10) || 0;
+            const withinSellLimit = unlimited
+                || (availableToSell > 0 ? requestedQty <= availableToSell : true);
+            if (!withinSellLimit) return;
+
+            const onHand = parseInt(detail.available_on_hand, 10) || 0;
+            const afb = unlimited
+                ? Infinity
+                : parseInt(detail.available_for_backorder, 10) || 0;
+            const needsBackorder = requestedQty - Math.min(requestedQty, onHand);
+            const backordered = Math.min(needsBackorder, afb);
+
+            if (backordered <= 0) return;
+
+            const name = this.findAttributeName(sel.attribute_value_id);
+            if (!name) return;
+
+            lines.push({ productId: sel.product_id, name, qty: backordered });
+        });
+
+        return lines;
+    }
+
+    findAttributeName(attributeValueId) {
+        if (attributeValueId === undefined || attributeValueId === null) return '';
+        const $optionLabel = $(`label[data-product-attribute-value="${attributeValueId}"]`, this.$scope);
+        if (!$optionLabel.length) return '';
+        const $field = $optionLabel.closest('[data-product-attribute="product-list"]');
+        if (!$field.length) return '';
+        const $attrLabel = $field.children('label').first();
+        if (!$attrLabel.length) return '';
+        const firstText = $attrLabel.contents()
+            .filter((_, node) => node.nodeType === 3 && node.nodeValue.trim())
+            .first();
+        return firstText.length ? firstText.text().trim().replace(/:\s*$/, '') : '';
+    }
+
+    paint(lines) {
+        this.$list.empty();
+
+        if (!lines.length) {
+            this.$list.hide();
+            return;
+        }
+
+        const qtyTemplate = this.context.quantityBackorderedMessage
+            || '__QTY__ will be backordered';
+
+        lines.forEach(({ name, qty, productId }) => {
+            const qtyMsg = qtyTemplate.replace('__QTY__', qty);
+            const messageText = this.lookupBackorderMessage(productId);
+            const suffix = messageText ? ` | ${messageText}` : '';
+            const $li = $('<li>', {
+                class: 'productView-picklist-backorder-item',
+            });
+            $('<span>', {
+                class: 'productView-picklist-backorder-name',
+            }).text(`${name}:`).appendTo($li);
+            $li.append(document.createTextNode(` ${qtyMsg}${suffix}`));
+            this.$list.append($li);
+        });
+
+        this.$list.show();
+    }
+
+    lookupBackorderMessage(productId) {
+        const detail = this.detailsByProductId && this.detailsByProductId.get(productId);
+        if (!detail) return '';
+
+        const messageId = detail.backorder_message_id;
+        if (messageId == null) return '';
+
+        const { backorderMessages, showBackorderMessage } = this.context;
+        if (!showBackorderMessage) return '';
+        if (!Array.isArray(backorderMessages)) return '';
+
+        const messageObj = backorderMessages.find(m => m.id === messageId);
+        return messageObj && messageObj.message ? messageObj.message : '';
+    }
+}

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -1,5 +1,6 @@
 import Wishlist from '../wishlist';
 import { initRadioOptions } from './aria';
+import PicklistBackorder from './picklist-backorder';
 
 const optionsTypesMap = {
     INPUT_FILE: 'input-file',
@@ -34,6 +35,7 @@ export default class ProductDetailsBase {
     constructor($scope, context) {
         this.$scope = $scope;
         this.context = context;
+        this.picklistBackorder = new PicklistBackorder($scope, this.context);
         this.initRadioAttributes();
         Wishlist.load(this.context);
         this.getTabRequests();
@@ -234,7 +236,7 @@ export default class ProductDetailsBase {
 
         if (!viewModel.$backordered.length) return;
 
-        if (this.context.showBackorderAvailabilityPrompt === false) {
+        if (this.context.showQuantityOnBackorder === false) {
             viewModel.$backorderedQtyMessage.text('');
             this.toggleBackorderedContainer(viewModel);
             return;
@@ -359,7 +361,7 @@ export default class ProductDetailsBase {
         const promptText = this.context.backorderAvailabilityPrompt;
 
         if (showPrompt && availableToSell > 0 && availableForBackorder > 0 && promptText) {
-            viewModel.$backorderPrompt.text(`(${promptText})`).show();
+            viewModel.$backorderPrompt.text(promptText).show();
         } else {
             viewModel.$backorderPrompt.hide();
         }
@@ -424,6 +426,7 @@ export default class ProductDetailsBase {
         const currentQty = parseInt(viewModel.quantity.$input.val(), 10) || 0;
         this.updateQtyBackorderedMessage(currentQty, viewModel);
         this.updateBackorderMessage(viewModel);
+        this.picklistBackorder.render(data, currentQty);
 
         this.updateDefaultAttributesForOOS(data);
         this.updateAddToCartForQty(currentQty, viewModel);

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -91,6 +91,7 @@ export default class ProductDetails extends ProductDetailsBase {
             const qty = parseInt(vm.quantity.$input.val(), 10) || 0;
             this.updateQtyBackorderedMessage(qty, vm);
             this.updateBackorderMessage(vm);
+            this.picklistBackorder.render(response.data, qty);
             this.updateDefaultAttributesForOOS(response.data);
             this.updateAddToCartForQty(qty, vm);
         });
@@ -394,6 +395,7 @@ export default class ProductDetails extends ProductDetailsBase {
             this.updateQtyBackorderedMessage(qty, viewModel);
             this.updateBackorderMessage(viewModel);
             this.updateAddToCartForQty(qty, viewModel);
+            this.picklistBackorder.rerender(qty);
         });
 
         // Prevent triggering quantity change when pressing enter
@@ -413,6 +415,7 @@ export default class ProductDetails extends ProductDetailsBase {
             this.updateQtyBackorderedMessage(qty, viewModel);
             this.updateBackorderMessage(viewModel);
             this.updateAddToCartForQty(qty, viewModel);
+            this.picklistBackorder.rerender(qty);
         });
     }
 

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -219,12 +219,45 @@
 // Details - Product backorder message
 // -----------------------------------------------------------------------------
 
-.productView-backorder-availability-prompt {
-    margin-left: spacing("half");
+.productView-stock-message {
+    font-weight: fontWeight("bold");
 }
 
-[data-backorder-message] {
-    margin-left: spacing("half");
+.productView-backorder-availability-prompt::before {
+    content: "| ";
+}
+
+[data-qty-backordered-message]:not(:empty) {
+    font-weight: fontWeight("bold");
+}
+
+[data-backorder-message]:not(:empty)::before {
+    content: "| ";
+}
+
+.productView-picklist-backorder {
+    font-size: 1rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.productView-picklist-backorder-item {
+    color: stencilColor("form-label-font-color");
+    font-family: fontFamily("headingSans");
+    font-size: fontSize("smallest");
+    line-height: 1.8;
+    margin-top: 0;
+}
+
+.productView-picklist-backorder-name {
+    font-weight: fontWeight("bold");
+}
+
+// Unify vertical rhythm across the four stacked lines (stock, main-product
+// backordered, per-picklist bundles) so the group reads as one cluster.
+.form-field--stock .form-label--alternate {
+    margin: 0;
 }
 
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -726,6 +726,7 @@
     },
     "products": {
         "current_stock": "Current Stock:",
+        "in_stock": "in stock",
         "quantity": "Quantity:",
         "change_product_options": "Change options for {name}",
         "quantity_decrease": "Decrease Quantity of {name}",

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -2,6 +2,7 @@
 {{inject 'availableOnHand' product.available_on_hand}}
 {{inject 'availableForBackorder' product.available_for_backorder}}
 {{inject 'availableToSell' product.available_to_sell}}
+{{inject 'showQuantityOnBackorder' product.show_quantity_on_backorder}}
 {{inject 'showBackorderAvailabilityPrompt' product.show_backorder_availability_prompt}}
 {{inject 'backorderAvailabilityPrompt' product.backorder_availability_prompt}}
 {{inject 'quantityBackorderedMessage' (lang 'products.quantity_backordered' quantity='__QTY__')}}
@@ -254,10 +255,12 @@
                 </div>
                 <div class="form-field form-field--stock{{#unless product.stock_level}} u-hiddenVisually{{/unless}}">
                     <label class="form-label form-label--alternate">
-                        {{lang 'products.current_stock'}}
-                        <span data-product-stock>{{product.stock_level}}</span>
+                        <span class="productView-stock-message">
+                            <span data-product-stock>{{product.stock_level}}</span>
+                            {{lang 'products.in_stock'}}
+                        </span>
                         {{#all product.show_backorder_availability_prompt product.available_to_sell product.available_for_backorder}}
-                            <span class="productView-backorder-availability-prompt" data-backorder-prompt>({{product.backorder_availability_prompt}})</span>
+                            <span class="productView-backorder-availability-prompt" data-backorder-prompt>{{product.backorder_availability_prompt}}</span>
                         {{else}}
                             <span class="productView-backorder-availability-prompt" data-backorder-prompt style="display:none;"></span>
                         {{/all}}
@@ -266,6 +269,7 @@
                         <span data-qty-backordered-message></span>
                         <span data-backorder-message></span>
                     </p>
+                    <ul class="productView-picklist-backorder" data-picklist-backorder-list style="display:none;"></ul>
                 </div>
                 {{> components/products/add-to-cart with_wallet_buttons=true}}
             </form>


### PR DESCRIPTION
#### What?
- Use the `selected_picklist_options` and `picklist_products_details` from `POST /remote/v1/product-attributes/:productId` and render a per picklist backorder prompt in addition to the main product stock on the Stencil PDP.

#### Requirements

- [X] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [BACK-655](https://bigcommercecloud.atlassian.net/browse/BACK-655)

#### Screenshots (if appropriate)

### Display backorder prompt when picklist 'Adjust inventory for these products...' is selected
  - Main product (103) 
     - {on_hand: 10, backorder_limit: 15, backorder_message: 'Backorder message 1'}                                                                                               
      - Picklist_1 product (id: 80) - {on_hand: 0, backorder_limit: unlimited, backorder_message: 'Backorder message 1'}.
         - `Adjust inventory for these products when purchased` is enabled
      - Picklist_2 product (id: 80) - {on_hand: 0, backorder_limit: unlimited, backorder_message: 'Backorder message 1'}.   
         - `Adjust inventory for these products when purchased` is enabled

https://github.com/user-attachments/assets/87944077-8f6c-4ae5-966f-0128ca49ed45

**Explanation**
When a picklist item is selected, the backorder prompt is displayed.

### Display backorder prompt when picklist 'Adjust inventory for these products...' is NOT selected
  - Main product (103) 
     - {on_hand: 10, backorder_limit: 15, backorder_message: 'Backorder message 1'}                                                                                               
      - Picklist_1 product (id: 80) - {on_hand: 0, backorder_limit: unlimited, backorder_message: 'Backorder message 1'}.
         - `Adjust inventory for these products when purchased` is NOT enabled
      - Picklist_2 product (id: 80) - {on_hand: 0, backorder_limit: unlimited, backorder_message: 'Backorder message 1'}.   
         - `Adjust inventory for these products when purchased` is NOT enabled

https://github.com/user-attachments/assets/f455f629-0a24-4b54-bd5f-c9b7c930c7db

**Explanation**
When a picklist item is selected, the backorder prompt is NOT displayed.

### Display backorder prompt when 'Qty on backorder display'  is selected AND picklist 'Adjust inventory for these products...' is and is NOT selected
  - Inventory Settings - Qty on backorder display and backorder message is selected
  - Main product (103) 
     - {on_hand: 10, backorder_limit: 15, backorder_message: 'Backorder message 1'}                                                                                               
      - Picklist_1 product (id: 80) - {on_hand: 0, backorder_limit: unlimited, backorder_message: 'Backorder message 1'}.
         - `Adjust inventory for these products when purchased` is enabled
      - Picklist_2 product (id: 80) - {on_hand: 0, backorder_limit: unlimited, backorder_message: 'Backorder message 1'}.   
         - `Adjust inventory for these products when purchased` is NOT enabled

https://github.com/user-attachments/assets/ae486d24-1aaf-4746-9fb5-7a073e4c138e

**Explanation**

We can see that only the qty for backorder for picklist item 1 (Bundle 1) is displayed.

### Display backorder prompt when 'Qty on backorder display' is not selected AND picklist 'Adjust inventory for these products...' is and is NOT selected
  - Inventory Settings - Qty on backorder display and backorder message is not selected
  - Main product (103) 
     - {on_hand: 10, backorder_limit: 15, backorder_message: 'Backorder message 1'}                                                                                               
      - Picklist_1 product (id: 80) - {on_hand: 0, backorder_limit: unlimited, backorder_message: 'Backorder message 1'}.
         - `Adjust inventory for these products when purchased` is enabled
      - Picklist_2 product (id: 80) - {on_hand: 0, backorder_limit: unlimited, backorder_message: 'Backorder message 1'}.   
         - `Adjust inventory for these products when purchased` is NOT enabled


https://github.com/user-attachments/assets/3f6245fa-cca5-4c73-b46e-322cd9040190

**Explanation**
No backorder message is displayed and the qty for backorder for both the main product and the picklist item is not displayed


ping @bc-shawnwang @animesh1987 @bigcommerce/team-trac 

[BACK-655]: https://bigcommercecloud.atlassian.net/browse/BACK-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PDP inventory/backorder UX and quantity messaging logic; incorrect clamping or flags could misstate backorder qty for bundled picklist products.
> 
> **Overview**
> Adds **per-picklist backorder messaging** on the PDP using `selected_picklist_options` and `picklist_products_details` from the product-attributes API. A new `PicklistBackorder` module renders a list under the stock block (attribute name, backordered qty, optional message), wired into option changes and quantity updates via `render` / `rerender`.
> 
> **Inventory display tweaks:** main-product qty-on-backorder now respects `showQuantityOnBackorder` (replacing the prior flag check), and the backorder availability prompt is shown without wrapping parentheses. Stock copy uses **“in stock”** next to the level, with SCSS to align stock, main backorder, and picklist lines.
> 
> **Tests:** broad unit coverage for picklist backorder rules (auto-adjust flag, sell limits, AFB clamping, settings toggles).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d9d71e56fcd84da8b2a7aeb9136e7c41424ded8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->