### PR TITLE
feat(checkout): show backorder prompts for bundled items in the cart page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Render stock positions for bundled items (pick lists) on the cart page, (change to be left aligned with the quantity adjuster) [#2662](https://github.com/bigcommerce/cornerstone/pull/2662)
 - Fix duplicate `id="default_instrument"` on Update Payment Method page [#2661](https://github.com/bigcommerce/cornerstone/pull/2661)
 - Respect `available_to_sell` on PDP so the Sold Out alert is hidden and the Add to Cart button stays enabled for backorderable products, and is disabled when quantity exceeds `available_to_sell` [#2659](https://github.com/bigcommerce/cornerstone/pull/2659)
 - Updated accessibility features [2656](https://github.com/bigcommerce/cornerstone/pull/2656)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
-- Render stock positions for bundled items (pick lists) on the cart page, (change to be left aligned with the quantity adjuster) [#2662](https://github.com/bigcommerce/cornerstone/pull/2662)
+- Render stock positions for bundled items (pick lists) on the cart page, (change to be left aligned with the quantity adjuster) [#2663](https://github.com/bigcommerce/cornerstone/pull/2663)
 - Fix duplicate `id="default_instrument"` on Update Payment Method page [#2661](https://github.com/bigcommerce/cornerstone/pull/2661)
 - Respect `available_to_sell` on PDP so the Sold Out alert is hidden and the Add to Cart button stays enabled for backorderable products, and is disabled when quantity exceeds `available_to_sell` [#2659](https://github.com/bigcommerce/cornerstone/pull/2659)
 - Updated accessibility features [2656](https://github.com/bigcommerce/cornerstone/pull/2656)

--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -74,6 +74,10 @@ $card-preview-zoom-bottom-offset:       6rem;
 .cart-header-item {
     padding-bottom: spacing("base");
 
+    @include breakpoint("medium") {
+        padding: $cart-item-spacing;
+    }
+
     &:last-child {
         text-align: right;
     }
@@ -115,6 +119,7 @@ $card-preview-zoom-bottom-offset:       6rem;
 
     @include breakpoint("medium") {
         display: table-cell; // 1
+        vertical-align: top;
     }
 
     .definitionList {
@@ -140,7 +145,7 @@ $card-preview-zoom-bottom-offset:       6rem;
 
     @include breakpoint("medium") {
         float: none;
-        padding: $cart-thumbnail-paddingVertical 0;
+        padding: $cart-item-spacing;
         width: grid-calc(1, $total-columns);
     }
 }
@@ -193,10 +198,12 @@ $card-preview-zoom-bottom-offset:       6rem;
 
     @include breakpoint("medium") {
         float: none;
-        width: grid-calc(2, $total-columns);
+        padding: $cart-item-spacing;
+        width: grid-calc(1, $total-columns);
 
         &:last-child {
             text-align: right;
+            width: grid-calc(2, $total-columns);
         }
     }
 }
@@ -212,7 +219,8 @@ $card-preview-zoom-bottom-offset:       6rem;
 .cart-item-quantity {
 
     @include breakpoint("medium") {
-        text-align: center;
+        text-align: left;
+        width: grid-calc(4, $total-columns);
     }
 }
 
@@ -229,6 +237,22 @@ $card-preview-zoom-bottom-offset:       6rem;
 
     .cart-item-backorder-message {
         margin-bottom: 0;
+        margin-left: spacing("single");
+        text-align: left;
+
+        @include breakpoint("medium") {
+            margin-left: 0;
+        }
+    }
+
+    .cart-item-option-stock {
+        margin-left: spacing("single");
+        margin-top: spacing("half");
+        text-align: left;
+
+        @include breakpoint("medium") {
+            margin-left: 0;
+        }
     }
 }
 
@@ -445,7 +469,7 @@ $card-preview-zoom-bottom-offset:       6rem;
 
     .cart-total-with-savings {
         border-top: container("border");
-        
+
         .cart-total-label {
             font-size: fontSize("larger");
         }
@@ -486,7 +510,7 @@ $card-preview-zoom-bottom-offset:       6rem;
                 color: stencilColor("optimizedCheckout-link-color");
                 text-decoration: none;
                 font-weight: fontWeight("normal");
-                
+
                 &:hover {
                     text-decoration: underline;
                 }
@@ -519,14 +543,14 @@ $card-preview-zoom-bottom-offset:       6rem;
             }
         }
 
-        
+
         .gift-certificate-add, .gift-certificate-cancel {
             color: stencilColor("optimizedCheckout-link-color");
             text-decoration: none;
             display: inline-flex;
             align-items: center;
             font-weight: fontWeight("normal");
-            
+
             &:hover {
                 text-decoration: underline;
             }
@@ -551,7 +575,7 @@ $card-preview-zoom-bottom-offset:       6rem;
                 color: stencilColor("optimizedCheckout-link-color");
                 text-decoration: none;
                 font-weight: fontWeight("normal");
-                
+
                 &:hover {
                     text-decoration: underline;
                 }
@@ -567,7 +591,7 @@ $card-preview-zoom-bottom-offset:       6rem;
     .shipping-estimate-value, .shipping-estimate-show {
         text-decoration: none;
     }
-    
+
     .cart-total-discounts {
         .cart-total-label {
             cursor: pointer;
@@ -575,7 +599,7 @@ $card-preview-zoom-bottom-offset:       6rem;
 
         .cart-discount-icon {
             transition: transform 0.3s ease;
-            
+
             &.is-open {
                 transform: rotate(180deg);
             }
@@ -628,7 +652,7 @@ $card-preview-zoom-bottom-offset:       6rem;
     width: 100%;
     padding-bottom: spacing("base");
     border-bottom: container("border");
-    
+
     @include breakpoint("small") {
         float: right;
         width: grid-calc(9, $total-columns);
@@ -659,7 +683,7 @@ $card-preview-zoom-bottom-offset:       6rem;
     display: inline-flex;
     align-items: center;
     font-weight: fontWeight("normal");
-    
+
     &:hover {
         color: stencilColor("optimizedCheckout-link-color");
         text-decoration: underline;

--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -237,8 +237,12 @@ $card-preview-zoom-bottom-offset:       6rem;
 
     .cart-item-backorder-message {
         margin-bottom: 0;
-        margin-left: spacing("single");
+        margin-left: calc(#{grid-calc(4, $total-columns)} + #{spacing("single")});
         text-align: left;
+
+        @include breakpoint("small") {
+            margin-left: spacing("single");
+        }
 
         @include breakpoint("medium") {
             margin-left: 0;
@@ -246,11 +250,19 @@ $card-preview-zoom-bottom-offset:       6rem;
     }
 
     .cart-item-option-stock {
-        margin-left: spacing("single");
+        margin-left: calc(#{grid-calc(4, $total-columns)} + #{spacing("single")});
         margin-top: spacing("half");
         text-align: left;
 
+        @include breakpoint("small") {
+            margin-left: spacing("single");
+        }
+
         @include breakpoint("medium") {
+            margin-left: 0;
+        }
+
+        .cart-item-backorder-message {
             margin-left: 0;
         }
     }

--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -153,6 +153,28 @@
                                 <p class="cart-item-backorder-message">{{stock_position.backorder_message}}</p>
                             {{/if}}
                         {{/if}}
+                        {{#each options}}
+                            {{#if linked_bundled_item}}
+                                <div class="cart-item-option-stock">
+                                    <p class="cart-item-backorder-message"><strong>{{name}}:</strong></p>
+                                    {{#if ../../cart.inventory_settings.show_quantity_on_hand}}
+                                        {{#all linked_bundled_item.stock_position.quantity_on_hand linked_bundled_item.stock_position.backorder_message}}
+                                            <p class="cart-item-backorder-message">{{lang 'products.quantity_on_hand' quantity=linked_bundled_item.stock_position.quantity_on_hand}}</p>
+                                        {{/all}}
+                                    {{/if}}
+                                    {{#if ../../cart.inventory_settings.show_quantity_on_backorder}}
+                                        {{#if linked_bundled_item.stock_position.quantity_backordered}}
+                                            <p class="cart-item-backorder-message">{{lang 'products.quantity_backordered' quantity=linked_bundled_item.stock_position.quantity_backordered}}</p>
+                                        {{/if}}
+                                    {{/if}}
+                                    {{#if ../../cart.inventory_settings.show_backorder_message}}
+                                        {{#if linked_bundled_item.stock_position.backorder_message}}
+                                            <p class="cart-item-backorder-message">{{linked_bundled_item.stock_position.backorder_message}}</p>
+                                        {{/if}}
+                                    {{/if}}
+                                </div>
+                            {{/if}}
+                        {{/each}}
                     {{/if}}
                 </td>
 

--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -139,7 +139,7 @@
                     </div>
                     {{#if stock_position}}
                         {{#if ../cart.inventory_settings.show_quantity_on_hand}}
-                            {{#all stock_position.quantity_on_hand stock_position.backorder_message}}
+                            {{#all stock_position.quantity_on_hand stock_position.quantity_backordered}}
                                 <p class="cart-item-backorder-message">{{lang 'products.quantity_on_hand' quantity=stock_position.quantity_on_hand}}</p>
                             {{/all}}
                         {{/if}}
@@ -158,7 +158,7 @@
                                 <div class="cart-item-option-stock">
                                     <p class="cart-item-backorder-message"><strong>{{name}}:</strong></p>
                                     {{#if ../../cart.inventory_settings.show_quantity_on_hand}}
-                                        {{#all linked_bundled_item.stock_position.quantity_on_hand linked_bundled_item.stock_position.backorder_message}}
+                                        {{#all linked_bundled_item.stock_position.quantity_on_hand linked_bundled_item.stock_position.quantity_backordered}}
                                             <p class="cart-item-backorder-message">{{lang 'products.quantity_on_hand' quantity=linked_bundled_item.stock_position.quantity_on_hand}}</p>
                                         {{/all}}
                                     {{/if}}


### PR DESCRIPTION
#### What?

show backorder prompts for bundled items in the cart page.

- need to consider the inventory settings

also fixed some style issues that does not match the design:

<img width="700" height="247" alt="image" src="https://github.com/user-attachments/assets/9eefac91-a9b1-48f0-8824-cc69fd027367" />

- backorder prompts should be left aligned
- item block, qty block and total block should be top aligned not vertically centralized (same vertical level as qty block)


#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [Stencil Cart Resource Data PR](https://github.com/bigcommerce/storefront/pull/5091)

> [!IMPORTANT]
> Only after the PR above is rolled out can picklist backorder prompts be displayed. However, even if it hasn’t been rolled out yet, this change does not cause any critical issues — the prompts just won’t be displayed.

#### Screenshots (if appropriate)

**before the change**

🔴  No picklist's backorder prompts displayed.

🔴  style issue:

normal view
<img width="2322" height="1634" alt="image" src="https://github.com/user-attachments/assets/be854c0c-492d-429e-a7fe-c28b273bfc02" />

medium view

<img width="762" height="849" alt="Screenshot 2026-05-26 at 4 12 50 PM" src="https://github.com/user-attachments/assets/f5ede04f-6292-44e9-89a5-93479259b8e5" />

mobile view

<img width="762" height="849" alt="Screenshot 2026-05-26 at 4 14 19 PM" src="https://github.com/user-attachments/assets/db3fe8a6-baaa-4642-a485-9e6a1924b664" />


**after the change**

✅ displayed picklist items' stock positions and also fixed stying issues to match design

normal view:

<img width="2238" height="1524" alt="image" src="https://github.com/user-attachments/assets/f9ff8f2d-5d94-4bb7-80aa-031b43236eeb" />

medium view:

<img width="1524" height="1698" alt="image" src="https://github.com/user-attachments/assets/d5f5b919-3078-4e84-8241-7abf6d1033fe" />


mobile view:

<img width="1524" height="1698" alt="image" src="https://github.com/user-attachments/assets/11e7d507-bd4e-47f7-8bec-26af4bfa6a74" />

