### PR TITLE
feat(returns): ORDERS-7717 - add new returns list ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix shipment info showing for cancelled orders [#2654](https://github.com/bigcommerce/cornerstone/pull/2654)
 - Render backorder prompts on My Account "Your orders" page [#2650](https://github.com/bigcommerce/cornerstone/pull/2650)
 - Gate account orders list "Return Items" link on returns settings (ORDERS-7704) [#2653](https://github.com/bigcommerce/cornerstone/pull/2653)
+- Added new Return list view (ORDERS-7717) [#2664] (https://github.com/bigcommerce/cornerstone/pull/2664) 
 
 ## 6.19.1 (04-09-2026)
 - Update stencil-utils versionto 6.23.0 [#2638](https://github.com/bigcommerce/cornerstone/pull/2638)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix duplicate `id="default_instrument"` on Update Payment Method page [#2661](https://github.com/bigcommerce/cornerstone/pull/2661)
 - Respect `available_to_sell` on PDP so the Sold Out alert is hidden and the Add to Cart button stays enabled for backorderable products, and is disabled when quantity exceeds `available_to_sell` [#2659](https://github.com/bigcommerce/cornerstone/pull/2659)
 - Updated accessibility features [2656](https://github.com/bigcommerce/cornerstone/pull/2656)
+- Adds new guest-return-portal page. [2645](https://github.com/bigcommerce/cornerstone/pull/2645)
 - Update 'Ship to' copy for multi address orders [#2655](https://github.com/bigcommerce/cornerstone/pull/2655)
 - Fixed typo in category page reset-filters live region handler [#2643](https://github.com/bigcommerce/cornerstone/pull/2643)
 - Swap content/data keys in onProductOptionsChanged event detail [#2640](https://github.com/bigcommerce/cornerstone/pull/2640)

--- a/assets/scss/components/stencil/account/_account.scss
+++ b/assets/scss/components/stencil/account/_account.scss
@@ -49,6 +49,32 @@
     }
 }
 
+.account-listItem-summary {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: spacing("single");
+    justify-content: space-between;
+    margin-bottom: spacing("single");
+}
+
+.account-listItem-summary-main {
+    align-items: center;
+    display: flex;
+    flex: 1 1 auto;
+    flex-wrap: wrap;
+    gap: spacing("half");
+    min-width: 0;
+
+    .account-product-title {
+        margin: 0;
+    }
+
+    .account-orderStatus-label {
+        margin: 0;
+    }
+}
+
 .account-listShipping {
     border-bottom: container("border");
     font-weight: fontWeight("bold");
@@ -339,6 +365,21 @@
     line-height: lineHeight("smallest");
     margin: 0 0 spacing("quarter");
     padding: spacing("eighth") spacing("third");
+}
+
+.account-orderStatus-label--open {
+    background-color: color("warning", "light");
+    color: stencilColor("color-textBase");
+}
+
+.account-orderStatus-label--inProgress {
+    background-color: color("success", "light");
+    color: stencilColor("color-textBase");
+}
+
+.account-orderStatus-label--closed {
+    background-color: color("greys", "lighter");
+    color: stencilColor("color-textBase");
 }
 
 .account-orderStatus-action {

--- a/lang/en.json
+++ b/lang/en.json
@@ -457,10 +457,17 @@
             "comments": "Your Comments",
             "submit_request": "Submit Return Request",
             "list": {
+                "last_update":"Last Update",
+                "return_submitted": "Return Submitted",
                 "return_number": "Return #{id}",
-                "product_details": "Returning {num_products}"
+                "product_details": "Returning {num_products}",
+                "return_items": "Return Items",
+                "view_details": "View details"
             },
             "status": {
+                "open":"OPEN",
+                "closed": "CLOSED",
+                "in_progress":"IN PROGRESS",
                 "pending": "Pending",
                 "received": "Received",
                 "authorized": "Authorized",

--- a/templates/components/account/returns-list-v2.html
+++ b/templates/components/account/returns-list-v2.html
@@ -5,7 +5,7 @@
     <li class="account-listItem">
         <div class="account-listItem-summary">
             <div class="account-listItem-summary-main">
-                <h5 class="account-product-title">{{lang 'account.returns.list.return_number' id=orderId}}</h5>
+                <h5 class="account-product-title">{{lang 'account.returns.list.return_number' id=rma}}</h5>
                 {{#if status '===' 'OPEN'}}
                     <h6 class="account-orderStatus-label account-orderStatus-label--open">{{lang 'account.returns.status.open'}}</h6>
                 {{else if status '===' 'IN_PROGRESS'}}

--- a/templates/components/account/returns-list-v2.html
+++ b/templates/components/account/returns-list-v2.html
@@ -1,0 +1,36 @@
+<h3 class="account-heading">{{lang 'account.returns.heading' }}</h3>
+
+<ul class="account-list">
+    {{#each returns}}
+    <li class="account-listItem">
+        <div class="account-listItem-summary">
+            <div class="account-listItem-summary-main">
+                <h5 class="account-product-title">{{lang 'account.returns.list.return_number' id=orderId}}</h5>
+                {{#if status '===' 'OPEN'}}
+                    <h6 class="account-orderStatus-label account-orderStatus-label--open">{{lang 'account.returns.status.open'}}</h6>
+                {{else if status '===' 'IN_PROGRESS'}}
+                    <h6 class="account-orderStatus-label account-orderStatus-label--inProgress">{{lang 'account.returns.status.in_progress'}}</h6>
+                {{else if status '===' 'CLOSED'}}
+                    <h6 class="account-orderStatus-label account-orderStatus-label--closed">{{lang 'account.returns.status.closed'}}</h6>
+               {{/if}}
+            </div>
+            <a class="button button--small" href="#">{{lang 'account.returns.list.view_details'}}</a>
+        </div>
+
+        <div class="account-product-details">
+            <div class="account-product-detail">
+                <h6 class="account-product-detail-heading">{{lang 'account.returns.list.return_submitted' }}</h6>
+                <span>{{moment dateSubmitted format="Do MMM YYYY"}}</span>
+            </div>
+            <div class="account-product-detail">
+                <h6 class="account-product-detail-heading">{{lang 'account.returns.list.last_update' }}</h6>
+                <span>{{#if lastUpdated}}{{moment lastUpdated format="Do MMM YYYY"}}{{else}}{{moment dateSubmitted format="Do MMM YYYY"}}{{/if}}</span>
+            </div>
+            <div class="account-product-detail">
+                <h6 class="account-product-detail-heading">{{lang 'account.returns.list.return_items' }}</h6>
+                <span>{{items.length}}</span>
+            </div>
+        </div>
+    </li>
+    {{/each}}
+</ul>

--- a/templates/pages/account/returns.html
+++ b/templates/pages/account/returns.html
@@ -10,7 +10,7 @@
 
             {{#if settings.returns_v2_enabled}}
 
-                {{#if returns}}
+                {{#if returns.length}}
                     {{> components/account/returns-list-v2 returns=returns}}
                 {{else}}
                     {{> components/common/alert/alert-info (lang 'account.returns.none')}}

--- a/templates/pages/account/returns.html
+++ b/templates/pages/account/returns.html
@@ -7,14 +7,29 @@
 <main class="account account--fixed">
     <div class="account-body">
         <section class="account-content">
-            {{#if customer.returns}}
-                {{> components/account/returns-list returns=customer.returns}}
+
+            {{#if settings.returns_v2_enabled}}
+
+                {{#if returns}}
+                    {{> components/account/returns-list-v2 returns=returns}}
+                {{else}}
+                    {{> components/common/alert/alert-info (lang 'account.returns.none')}}
+                {{/if}}
+
             {{else}}
-                {{> components/common/alert/alert-info (lang 'account.returns.none')}}
+
+                {{#if customer.returns}}
+                    {{> components/account/returns-list returns=customer.returns}}
+                {{else}}
+                    {{> components/common/alert/alert-info (lang 'account.returns.none')}}
+                {{/if}}
+
             {{/if}}
+            
         </section>
     </div>
 </main>
 
 {{/partial}}
 {{> layout/base}}
+

--- a/templates/pages/guest-return-portal.html
+++ b/templates/pages/guest-return-portal.html
@@ -1,0 +1,9 @@
+{{#partial "page"}}
+
+{{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
+
+<h1> Guest Return Portal</h1>
+
+{{/partial}}
+
+{{> layout/base}}


### PR DESCRIPTION
#### What?

Adds the new returns list UI to the returns page when `returns_v2_enabled` is true.

Depends on https://github.com/bigcommerce/storefront/pull/5057 from storefront.

_View Details Link does not work in this PR._

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [ORDERS-7717](https://bigcommercecloud.atlassian.net/browse/ORDERS-7717)

#### Screenshots (if appropriate)

<img width="1886" height="2302" alt="localhost_3000_account php_action=view_returns (2)" src="https://github.com/user-attachments/assets/84b9bf7a-ed26-4b73-99b9-0756407cb1d9" />


[ORDERS-7717]: https://bigcommercecloud.atlassian.net/browse/ORDERS-7717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Account returns rendering now depends on `returns_v2_enabled` and storefront-provided `returns` data; the View details link is non-functional until a follow-up, and the guest portal page is only a stub.
> 
> **Overview**
> When **`settings.returns_v2_enabled`** is on, the account **Returns** page renders a new **`returns-list-v2`** partial from a top-level **`returns`** collection (with empty-state alert), instead of the legacy **`customer.returns`** / **`returns-list`** flow.
> 
> The v2 list shows return **RMA**, **OPEN / IN PROGRESS / CLOSED** badges (new SCSS variants and copy), **submitted** and **last update** dates, **item count**, and a **View details** button that still points to **`#`** (not wired in this PR). Account list summary layout styles were added to support the new row header.
> 
> **`lang/en.json`** gains strings for the v2 list and coarse statuses; **CHANGELOG** notes the list view and a stub **guest return portal** page (`guest-return-portal.html` with placeholder heading only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac768ab1eafe95c1a74a3fde4d1deb74387b4f98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->