### PR TITLE
feat(returns): ORDERS-7708 new-return page — render items from order context

### DIFF
--- a/assets/js/theme/add-return-new.js
+++ b/assets/js/theme/add-return-new.js
@@ -21,7 +21,7 @@ export default class AddReturnNew extends PageManager {
                 const quantityInput = document.getElementById(`qty-${itemId}`);
                 // max is set server-side to returnableQuantity → quantity fallback
                 const maxQty = parseInt(quantityInput.max, 10) || 0;
-                let quantity = parseInt(quantityInput.value, 10);
+                let quantity = parseInt(quantityInput.value, 10) || 0;
 
                 if (action === 'inc' && quantity < maxQty) quantity++;
                 else if (action === 'dec' && quantity > 0) quantity--;
@@ -88,7 +88,6 @@ export default class AddReturnNew extends PageManager {
             });
 
             // TODO ORDERS-7715: invoke createReturn Storefront GQL mutation.
-            console.log('createReturn payload', { orderEntityId, additionalNote, items }); // eslint-disable-line no-console
         });
     }
 }

--- a/assets/js/theme/add-return-new.js
+++ b/assets/js/theme/add-return-new.js
@@ -1,4 +1,3 @@
-import { escape } from 'lodash';
 import PageManager from './page-manager';
 
 export default class AddReturnNew extends PageManager {
@@ -6,197 +5,31 @@ export default class AddReturnNew extends PageManager {
         const $form = $('[data-new-return-form]');
         if (!$form.length) return;
 
-        // ---------------------------------------------------------------------------
-        // Hardcoded page data which mirrors the TypeScript returns-ui interface.
-        // Replace with Stencil context when it is available.
-        // ---------------------------------------------------------------------------
-        this.pageData = {
-            order: {
-                id: '101',
-                datePlaced: new Date('2024-01-01'),
-                status: 'Completed',
-                currency: 'AUD',
-                isTaxInclusive: true,
-                shipping: {
-                    address: {
-                        fullName: 'Jane Smith',
-                        address1: '1-3 Smail Street',
-                        city: 'Ultimo',
-                        state: 'NSW',
-                        zip: '2007',
-                        country: 'Australia',
-                    },
-                    method: 'Australia Post',
-                    dateShipped: 'May 15, 2024',
-                    trackingNumber: '7E27315406641',
-                },
-                items: [
-                    {
-                        id: 'item-1',
-                        name: 'Product Name',
-                        variant: 'Blue / Black / Green',
-                        sku: 'SKU-001',
-                        quantity: 1,
-                        returnableQuantity: 1,
-                        thumbnailUrl: '',
-                        totalIncTax: 123.99,
-                        totalExTax: 110.71,
-                    },
-                    {
-                        id: 'item-2',
-                        name: 'Product Name',
-                        variant: 'Blue / Black / Green',
-                        sku: 'SKU-002',
-                        quantity: 1,
-                        returnableQuantity: 1,
-                        thumbnailUrl: '',
-                        totalIncTax: 123.99,
-                        totalExTax: 110.71,
-                    },
-                    {
-                        id: 'item-3',
-                        name: 'Product Name',
-                        variant: 'Blue / Black / Green',
-                        sku: 'SKU-003',
-                        quantity: 1,
-                        returnableQuantity: 1,
-                        thumbnailUrl: '',
-                        totalIncTax: 123.99,
-                        totalExTax: 110.71,
-                    },
-                ],
-            },
-            reasons: [
-                { id: 'reason-1', nameForMerchant: 'Damaged or defective', active: true },
-                { id: 'reason-2', nameForMerchant: 'Wrong item received', active: true },
-                { id: 'reason-3', nameForMerchant: 'Changed my mind', active: true },
-                { id: 'reason-4', nameForMerchant: 'Item not as described', active: true },
-                { id: 'reason-5', nameForMerchant: 'Arrived too late', active: true },
-            ],
-            resolutions: [
-                { resolutionType: 'Refund' },
-                { resolutionType: 'Exchange' },
-                { resolutionType: 'Store Credit' },
-            ],
-        };
-
-        this.renderHeader();
-        this.renderShippingAddress();
-        this.renderShippingMethod();
-        this.renderOrderLineItems();
+        this.bindOrderLineItemEvents();
         this.bindSubmit($form);
     }
 
-    renderHeader() {
-        const { order } = this.pageData;
-        const dateLabel = order.datePlaced.toLocaleDateString('en-AU', { year: 'numeric', month: 'long', day: 'numeric' });
-
-        document.getElementById('return-new-orderId').textContent = order.id;
-        document.getElementById('return-new-statusBadge').textContent = order.status.toUpperCase();
-        document.getElementById('return-new-datePlaced').textContent = `Order date: ${dateLabel}`;
-    }
-
-    renderShippingAddress() {
-        const { address } = this.pageData.order.shipping;
-        const shippingAddressHtml = `<h4>Shipping address</h4>
-            <p>${escape(address.fullName)}</p>
-            <p>${escape(address.address1)}</p>
-            <p>${escape(address.city)}, ${escape(address.state)} ${escape(address.zip)}</p>
-            <p>${escape(address.country)}</p>`;
-
-        document.getElementById('return-new-shippingAddress').innerHTML = shippingAddressHtml;
-    }
-
-    renderShippingMethod() {
-        const { shipping } = this.pageData.order;
-        const shippingMethodHtml = `<h4>Shipping method</h4>
-            <p>${escape(shipping.method)}</p>
-            <p>Shipped on ${escape(shipping.dateShipped)}</p>
-            <p>${escape(shipping.trackingNumber)}</p>`;
-
-        document.getElementById('return-new-shippingMethod').innerHTML = shippingMethodHtml;
-    }
-
-    renderOrderLineItems() {
-        const { order, reasons, resolutions } = this.pageData;
-
-        const resolutionOptions = [
-            '<option value="">Select a return request</option>',
-            ...resolutions.map(resolution => {
-                const optionValue = this.isCustomResolution(resolution) ? escape(resolution.id) : escape(resolution.resolutionType);
-                const optionLabel = this.isCustomResolution(resolution) ? escape(resolution.nameForMerchant) : escape(resolution.resolutionType);
-                return `<option value="${optionValue}">${optionLabel}</option>`;
-            }),
-        ].join('');
-
-        const reasonOptions = [
-            '<option value="">Select a return reason</option>',
-            ...reasons
-                .filter(reason => reason.active)
-                .map(reason => `<option value="${escape(reason.id)}">${escape(reason.nameForMerchant)}</option>`),
-        ].join('');
-
-        const orderLineItemsHtml = order.items.map(item => {
-            const price = new Intl.NumberFormat('en-AU', { style: 'currency', currency: order.currency }).format(item.totalIncTax);
-            const thumbnailHtml = item.thumbnailUrl
-                ? `<img class="newReturn-orderLineItemThumbnail" src="${escape(item.thumbnailUrl)}" alt="${escape(item.name)}">`
-                : '<div class="newReturn-orderLineItemThumbnail--placeholder">No image</div>';
-
-            return `
-                <div class="newReturn-orderLineItem" data-item-id="${escape(item.id)}">
-                    ${thumbnailHtml}
-                    <div class="newReturn-orderLineItemInfo">
-                        <p class="newReturn-orderLineItemName">${escape(item.name)}</p>
-                        <p class="newReturn-orderLineItemVariant">${escape(item.variant)}</p>
-                        <p class="newReturn-orderLineItemPrice">${price} x ${item.quantity}</p>
-                    </div>
-                    <div class="newReturn-orderLineItemControls">
-                        <div class="form-increment">
-                            <button class="button button--icon" type="button"
-                                    data-action="dec" data-item-id="${escape(item.id)}" disabled>
-                                <span class="is-srOnly">Decrease quantity</span>
-                                <i class="icon" aria-hidden="true"><svg><use href="#icon-keyboard-arrow-down"></use></svg></i>
-                            </button>
-                            <input class="form-input form-input--incrementTotal"
-                                   id="qty-${escape(item.id)}"
-                                   type="tel" value="0" min="0" max="${item.returnableQuantity}"
-                                   pattern="[0-9]*" aria-label="Quantity" readonly>
-                            <button class="button button--icon" type="button"
-                                    data-action="inc" data-item-id="${escape(item.id)}"
-                                    ${item.returnableQuantity === 0 ? 'disabled' : ''}>
-                                <span class="is-srOnly">Increase quantity</span>
-                                <i class="icon" aria-hidden="true"><svg><use href="#icon-keyboard-arrow-up"></use></svg></i>
-                            </button>
-                        </div>
-                        <select class="newReturn-select" id="resolution-${escape(item.id)}" aria-label="Resolution dropdown">
-                            ${resolutionOptions}
-                        </select>
-                        <select class="newReturn-select" id="reason-${escape(item.id)}" aria-label="Return reason">
-                            ${reasonOptions}
-                        </select>
-                    </div>
-                </div>`;
-        }).join('');
-
-        document.getElementById('return-new-itemsList').innerHTML = orderLineItemsHtml;
-        this.bindOrderLineItemEvents();
-    }
-
     bindOrderLineItemEvents() {
-        document.querySelectorAll('.form-increment .button--icon').forEach(button => {
+        document.querySelectorAll('.newReturn-stepperBtn').forEach(button => {
             button.addEventListener('click', () => {
-                const itemId = button.getAttribute('data-item-id');
+                // Derive itemId from the parent row — buttons do not carry data-item-id,
+                // so the [data-item-id] selector stays scoped to the row container only.
+                const row = button.closest('.newReturn-orderLineItem');
+                const itemId = row?.dataset?.itemId;
+                if (!itemId) return;
                 const action = button.getAttribute('data-action');
-                const item = this.pageData.order.items.find(orderLineItem => orderLineItem.id === itemId);
                 const quantityInput = document.getElementById(`qty-${itemId}`);
+                // max is set server-side to returnableQuantity → quantity fallback
+                const maxQty = parseInt(quantityInput.max, 10) || 0;
                 let quantity = parseInt(quantityInput.value, 10);
 
-                if (action === 'inc' && quantity < item.returnableQuantity) quantity++;
+                if (action === 'inc' && quantity < maxQty) quantity++;
                 else if (action === 'dec' && quantity > 0) quantity--;
 
                 quantityInput.value = quantity;
-                document.querySelector(`[data-action="dec"][data-item-id="${itemId}"]`).disabled = quantity === 0;
-                document.querySelector(`[data-action="inc"][data-item-id="${itemId}"]`).disabled = quantity >= item.returnableQuantity;
+                const stepper = button.closest('.newReturn-stepper');
+                stepper.querySelector('[data-action="dec"]').disabled = quantity === 0;
+                stepper.querySelector('[data-action="inc"]').disabled = quantity >= maxQty;
 
                 this.updateSubmitState();
             });
@@ -205,41 +38,57 @@ export default class AddReturnNew extends PageManager {
         document.querySelectorAll('.newReturn-select').forEach(selectElement => {
             selectElement.addEventListener('change', () => this.updateSubmitState());
         });
+
+        // Disable + button on load for any item where max=0 (non-returnable)
+        document.querySelectorAll('.newReturn-stepperInput').forEach(input => {
+            const maxQty = parseInt(input.max, 10) || 0;
+            const incBtn = input.closest('.newReturn-stepper')?.querySelector('[data-action="inc"]');
+            if (incBtn && maxQty === 0) incBtn.disabled = true;
+        });
     }
 
     updateSubmitState() {
-        const selectedItems = this.pageData.order.items.filter(item => parseInt(document.getElementById(`qty-${item.id}`).value, 10) > 0);
-
-        const isValid = selectedItems.length > 0 && selectedItems.every(item => (
-            document.getElementById(`resolution-${item.id}`).value
-            && document.getElementById(`reason-${item.id}`).value
-        ));
+        const selectedItems = this.getSelectedItems();
+        const isValid = selectedItems.length > 0 && selectedItems.every(itemRow => {
+            const itemId = itemRow.dataset?.itemId;
+            if (!itemId) return false;
+            const resolutionEl = document.getElementById(`resolution-${itemId}`);
+            const reasonEl = document.getElementById(`reason-${itemId}`);
+            return resolutionEl && resolutionEl.value && reasonEl && reasonEl.value;
+        });
 
         document.getElementById('return-new-submitBtn').disabled = !isValid;
+    }
+
+    // Returns only row containers (not buttons) with a non-zero quantity selected.
+    getSelectedItems() {
+        return [...document.querySelectorAll('.newReturn-orderLineItem')].filter(itemRow => {
+            const itemId = itemRow.dataset?.itemId;
+            if (!itemId) return false;
+            const qtyInput = document.getElementById(`qty-${itemId}`);
+            return qtyInput && parseInt(qtyInput.value, 10) > 0;
+        });
     }
 
     bindSubmit($form) {
         $form.on('submit', event => {
             event.preventDefault();
 
-            const selectedItems = this.pageData.order.items.filter(item => parseInt(document.getElementById(`qty-${item.id}`).value, 10) > 0);
+            const orderEntityId = parseInt(this.context.order?.id, 10);
+            const additionalNote = document.querySelector('[data-new-return-note]')?.value || '';
+            const items = this.getSelectedItems().flatMap(itemRow => {
+                const itemId = itemRow.dataset?.itemId;
+                if (!itemId) return [];
+                return [{
+                    lineItemEntityId: parseInt(itemId, 10),
+                    quantity: parseInt(document.getElementById(`qty-${itemId}`)?.value, 10),
+                    resolution: document.getElementById(`resolution-${itemId}`)?.value,
+                    reasonEntityId: document.getElementById(`reason-${itemId}`)?.value,
+                }];
+            });
 
-            const newReturn = {
-                orderId: this.pageData.order.id,
-                items: selectedItems.map(item => ({
-                    id: item.id,
-                    quantity: parseInt(document.getElementById(`qty-${item.id}`).value, 10),
-                    reasonId: document.getElementById(`reason-${item.id}`).value,
-                    resolution: document.getElementById(`resolution-${item.id}`).value,
-                })),
-            };
-
-            // TODO: wire up API call when available
-            console.log('Submitting return:', JSON.stringify(newReturn, null, 2));
+            // TODO ORDERS-7715: invoke createReturn Storefront GQL mutation.
+            console.log('createReturn payload', { orderEntityId, additionalNote, items }); // eslint-disable-line no-console
         });
-    }
-
-    isCustomResolution(resolution) {
-        return 'id' in resolution;
     }
 }

--- a/assets/scss/components/stencil/addReturn/_addReturn.scss
+++ b/assets/scss/components/stencil/addReturn/_addReturn.scss
@@ -1,10 +1,6 @@
 // =============================================================================
 // ADD RETURN REQUEST (CSS)
 // =============================================================================
-//
-// Styles shared by both the legacy add-return page (.account--addReturn)
-// and the new add-return-new page (.newReturn).
-// =============================================================================
 
 
 .account--addReturn {
@@ -228,44 +224,20 @@
 }
 
 
-.newReturn-shippingGrid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: remCalc(32px);
-}
-
-.newReturn-shippingSection {
-
-    h4 {
-        font-size: fontSize("smallest");
-        font-weight: fontWeight("semibold");
-        color: color("link");
-        margin: 0 0 spacing("quarter");
-    }
-
-    p,
-    a {
-        font-size: remCalc(13px);
-        margin: remCalc(2px) 0;
-        text-decoration: none;
-    }
-
-    p {
-        color: color("greys", "dark");
-    }
-}
-
-
 .newReturn-orderLineItem {
     display: flex;
-    align-items: center;
+    align-items: flex-start; // controls column is tallest when stacked (mobile/tablet)
     gap: remCalc(16px);
     padding: remCalc(16px) 0;
-    border-bottom: container("border");
 
-    &:last-child {
-        border-bottom: 0;
+    @include breakpoint("large") {
+        align-items: center; // desktop: everything inline so vertical-center is fine
     }
+}
+
+.newReturn-orderLineItemThumbnailWrapper {
+    flex-shrink: 0;
+    line-height: 0; // collapse inline whitespace around the img
 }
 
 .newReturn-orderLineItemThumbnail {
@@ -275,19 +247,6 @@
     border-radius: remCalc(6px);
     flex-shrink: 0;
     background: color("greys", "lighter");
-}
-
-.newReturn-orderLineItemThumbnail--placeholder {
-    width: remCalc(72px);
-    height: remCalc(72px);
-    border-radius: remCalc(6px);
-    flex-shrink: 0;
-    background: color("greys", "light");
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: color("greys", "medium");
-    font-size: remCalc(11px);
 }
 
 .newReturn-orderLineItemInfo {
@@ -313,28 +272,79 @@
     margin: 0;
 }
 
+// Per-item controls cluster: stepper + resolution-select + reason-select.
+// Below large breakpoint they stack vertically (mobile + tablet); on large they
+// sit inline as in the Figma desktop frame.
 .newReturn-orderLineItemControls {
     display: flex;
-    align-items: center;
-    gap: spacing("half");
+    flex-direction: column;
+    align-items: stretch;
+    gap: spacing("quarter");
     flex-shrink: 0;
+    width: remCalc(180px);
 
-    //Override layout here so the counter sits in a horizontal row
-    // without touching the shared component.
-    .form-increment {
-        display: flex;
+    @include breakpoint("large") {
+        flex-direction: row;
         align-items: center;
-
-    }
-
-    .form-input--incrementTotal {
-        height: remCalc(36px);
-        line-height: remCalc(36px);
-        vertical-align: middle;
+        gap: spacing("half");
+        width: auto;
     }
 }
 
+.newReturn-stepper {
+    display: inline-flex;
+    align-items: center;
+    height: remCalc(36px);
+    border: remCalc(1.5px) solid color("greys", "medium");
+    border-radius: remCalc(6px);
+    overflow: hidden;
+    flex-shrink: 0;
+    align-self: flex-start; // keep compact when stacked; selects stretch instead
+
+    @include breakpoint("large") {
+        align-self: auto;
+    }
+}
+
+.newReturn-stepperBtn {
+    background: none;
+    border: none;
+    width: remCalc(32px);
+    height: 100%;
+    font-size: remCalc(18px);
+    line-height: 1;
+    cursor: pointer;
+    color: color("greys", "dark");
+    padding: 0;
+
+    &:disabled {
+        color: color("greys", "light");
+        cursor: not-allowed;
+    }
+
+    &:focus:not(:focus-visible) {
+        outline: none !important;
+    }
+
+    &:hover:not(:disabled) {
+        background-color: color("greys", "lighter");
+    }
+}
+
+.newReturn-stepperInput {
+    width: remCalc(40px);
+    height: 100%;
+    border: none;
+    text-align: center;
+    font-size: remCalc(14px);
+    padding: 0;
+    outline: none;
+    background: transparent;
+    color: color("greys", "dark");
+}
+
 .newReturn-select {
+    width: 100%; // full width when stacked under stepper on mobile/tablet
     height: remCalc(36px);
     padding: 0 remCalc(28px) 0 spacing("quarter") * 1.67;
     border: remCalc(1.5px) solid color("greys", "medium");
@@ -346,7 +356,11 @@
     background-size: remCalc(10px);
     appearance: none;
     cursor: pointer;
-    min-width: remCalc(180px);
+
+    @include breakpoint("large") {
+        width: auto;
+        min-width: remCalc(180px);
+    }
 
     &:disabled {
         background-color: color("greys", "lighter");
@@ -356,31 +370,18 @@
     }
 }
 
-.newReturn-submitRow {
-    display: flex;
-    justify-content: flex-end;
-    margin-top: spacing("half");
-}
+// Right-aligned bottom column holding the additional-note textarea + submit button.
+// Mirrors the controls column width on tablet+; collapses to full width on mobile.
+.newReturn-footer {
+    margin-top: spacing("single");
 
-.newReturn-submitBtn {
-    width: 100%;
-    max-width: remCalc(520px);
-    padding: remCalc(14px);
-    background: color("greys", "darkest");
-    color: color("whites", "bright");
-    border: 0;
-    border-radius: remCalc(8px);
-    font-size: remCalc(15px);
-    font-weight: fontWeight("semibold");
-    cursor: pointer;
-    transition: background 0.2s;
-
-    &:hover {
-        background: color("greys", "dark");
+    @include breakpoint("medium") {
+        width: 50%;
+        margin-left: auto;
     }
 
-    &:disabled {
-        background: color("greys", "medium");
-        cursor: not-allowed;
+    .form-actions {
+        text-align: right;
     }
 }
+

--- a/lang/en.json
+++ b/lang/en.json
@@ -456,6 +456,9 @@
             "action": "Return Action",
             "comments": "Your Comments",
             "submit_request": "Submit Return Request",
+            "additional_note": "Additional note",
+            "additional_note_placeholder": "Please describe any additional details of this return request.",
+            "submit": "Submit Return",
             "list": {
                 "return_number": "Return #{id}",
                 "product_details": "Returning {num_products}"

--- a/templates/pages/account/add-return-new.html
+++ b/templates/pages/account/add-return-new.html
@@ -1,44 +1,114 @@
-{{#partial "page"}}
-
-{{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
-{{> components/account/navigation account_page='returns'}}
-
+{{~inject 'order' orders.[0]}}
 <main class="newReturn">
+
+    {{#with orders.[0]}}
 
     <div class="newReturn-header">
         <div class="newReturn-titleGroup">
-            <h1 class="newReturn-title">Request Return for Order #<span id="return-new-orderId"></span></h1>
-            <span class="newReturn-statusBadge" id="return-new-statusBadge"></span>
+            <h1 class="newReturn-title">{{lang 'account.returns.from_order' id=id}}</h1>
+            {{#if status}}<span class="newReturn-statusBadge">{{status}}</span>{{/if}}
         </div>
         <div class="newReturn-headerActions">
-            <a href="{{urls.account.orders.all}}" class="newReturn-btnBack">Back</a>
+            <a href="{{../urls.account.orders.all}}" class="newReturn-btnBack">{{lang 'account.orders.return.back_button'}}</a>
             <a href="/return-policy" class="newReturn-btnPolicy">View return policy &rarr;</a>
         </div>
     </div>
-    <p class="newReturn-orderDate" id="return-new-datePlaced"></p>
+    {{#if date}}<p class="newReturn-orderDate">{{date}}</p>{{/if}}
 
     <hr class="newReturn-divider">
 
-    <div class="newReturn-shippingGrid">
-        <div class="newReturn-shippingSection" id="return-new-shippingAddress"></div>
-        <div class="newReturn-shippingSection" id="return-new-shippingMethod"></div>
-    </div>
+    <form data-new-return-form data-success-url="{{../urls.account.orders.all}}">
 
-    <hr class="newReturn-divider">
+        {{#each items}}
+            <div class="newReturn-orderLineItem" data-item-id="{{id}}">
 
-    <form data-new-return-form>
+                <div class="newReturn-orderLineItemThumbnailWrapper">
+                    {{> components/common/responsive-img
+                        image=image
+                        class="newReturn-orderLineItemThumbnail"
+                        fallback_size=../../theme_settings.productthumb_size
+                        lazyload=../../theme_settings.lazyload_mode
+                        default_image=../../theme_settings.default_image_product
+                    }}
+                </div>
 
-        <div id="return-new-itemsList"></div>
+                <div class="newReturn-orderLineItemInfo">
+                    <p class="newReturn-orderLineItemName">{{name}}</p>
+                    {{#if productAttributesList}}
+                        <p class="newReturn-orderLineItemVariant">
+                            {{#each productAttributesList}}{{name}}: {{{sanitize value}}}{{#unless @last}} &middot; {{/unless}}{{/each}}
+                        </p>
+                    {{/if}}
+                    {{!-- TODO ORDERS-7764: replace cross-ref with {{price.formatted}} directly on item once dedicated returns service includes item price --}}
+                    {{#each ../../forms.return.order_products}}
+                        {{#if id '==' ../id}}
+                            <p class="newReturn-orderLineItemPrice">{{price.formatted}} &times; {{../quantity}}</p>
+                        {{/if}}
+                    {{/each}}
+                </div>
 
-        <div class="newReturn-submitRow">
-            <button class="newReturn-submitBtn" id="return-new-submitBtn" type="submit" disabled>
-                Submit Return
-            </button>
+                <div class="newReturn-orderLineItemControls">
+                    <div class="newReturn-stepper">
+                        <button class="newReturn-stepperBtn" type="button"
+                                data-action="dec" disabled
+                                aria-label="Decrease quantity">&#8722;</button>
+                        {{!-- TODO ORDERS-7764: replace max={{quantity}} with returnableQuantity once dedicated returns service provides it --}}
+                        <input class="newReturn-stepperInput"
+                               id="qty-{{id}}"
+                               type="tel" value="0" min="0" max="{{quantity}}"
+                               pattern="[0-9]*" aria-label="Quantity" readonly>
+                        <button class="newReturn-stepperBtn" type="button"
+                                data-action="inc"
+                                aria-label="Increase quantity">&#43;</button>
+                    </div>
+                    <select class="newReturn-select" id="resolution-{{id}}" aria-label="Resolution dropdown">
+                        <option value="">Select a return request</option>
+                        <option value="Refund">Refund</option>
+                        <option value="Exchange">Exchange</option>
+                        <option value="Store Credit">Store Credit</option>
+                    </select>
+                    <select class="newReturn-select" id="reason-{{id}}" aria-label="Return reason">
+                        <option value="">Select a return reason</option>
+                        <option value="reason-1">Damaged or defective</option>
+                        <option value="reason-2">Wrong item received</option>
+                        <option value="reason-3">Changed my mind</option>
+                        <option value="reason-4">Item not as described</option>
+                        <option value="reason-5">Arrived too late</option>
+                    </select>
+                </div>
+            </div>
+        {{/each}}
+
+        <hr class="newReturn-divider">
+
+        <div id="return-new-error" class="alertBox alertBox--error" style="display:none" role="alert">
+            <p class="alertBox-message" data-return-error-message></p>
+        </div>
+
+        <div class="newReturn-footer">
+            <div class="form-field">
+                <label for="newReturn-additionalNote" class="form-label">
+                    {{lang 'account.returns.additional_note'}}
+                </label>
+                <textarea class="form-input"
+                          id="newReturn-additionalNote"
+                          name="additional_note"
+                          rows="4"
+                          data-new-return-note
+                          placeholder="{{lang 'account.returns.additional_note_placeholder'}}"></textarea>
+            </div>
+
+            <div class="form-actions">
+                <input class="button button--primary"
+                       id="return-new-submitBtn"
+                       type="submit"
+                       value="{{lang 'account.returns.submit'}}"
+                       disabled>
+            </div>
         </div>
 
     </form>
 
-</main>
+    {{/with}}
 
-{{/partial}}
-{{> layout/base}}
+</main>

--- a/templates/pages/account/add-return.html
+++ b/templates/pages/account/add-return.html
@@ -1,106 +1,118 @@
 {{#partial "page"}}
 
-{{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
-<h1 class="page-heading">{{lang 'account.returns.new_return' }}</h1>
-{{> components/account/navigation account_page='returns'}}
+{{#if settings.returns_v2_enabled}}
 
-<main class="account account--fixed account--addReturn">
-    <div class="account-body">
-        <section class="account-content">
+    {{!-- New returns portal (ORDERS-7708) --}}
+    {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
+    {{> components/account/navigation account_page='returns'}}
+    {{> pages/account/add-return-new}}
 
-            <h3 class="account-heading">{{lang 'account.returns.from_order' id=forms.return.order_id}}</h3>
+{{else}}
 
-            {{#if forms.return.order_products.length}}
-                <form
-                    action="{{urls.account.orders.save_new_return}}"
-                    class="form"
-                    method="post"
-                    data-account-return-form-error="{{lang 'account.returns.error_no_qty'}}"
-                    data-account-return-form
-                >
-                    <fieldset class="form-fieldset">
-                        <input type="hidden" name="order_id" value="{{forms.return.order_id}}">
-                        <table class="table table--line">
-                            <thead class="table-thead">
-                                <tr>
-                                    <th class="return-itemName">{{lang 'account.orders.return.order_item'}}</th>
-                                    <th class="return-itemPrice">{{lang 'account.orders.return.item_price'}}</th>
-                                    <th class="return-itemQuantity">{{lang 'account.orders.return.quantity'}}</th>
-                                </tr>
-                            </thead>
-                            <tbody class="table-tbody">
-                                {{#each forms.return.order_products}}
+    {{!-- Legacy returns form — preserved for backwards compatibility --}}
+    {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
+    <h1 class="page-heading">{{lang 'account.returns.new_return' }}</h1>
+    {{> components/account/navigation account_page='returns'}}
+
+    <main class="account account--fixed account--addReturn">
+        <div class="account-body">
+            <section class="account-content">
+
+                <h3 class="account-heading">{{lang 'account.returns.from_order' id=forms.return.order_id}}</h3>
+
+                {{#if forms.return.order_products.length}}
+                    <form
+                        action="{{urls.account.orders.save_new_return}}"
+                        class="form"
+                        method="post"
+                        data-account-return-form-error="{{lang 'account.returns.error_no_qty'}}"
+                        data-account-return-form
+                    >
+                        <fieldset class="form-fieldset">
+                            <input type="hidden" name="order_id" value="{{forms.return.order_id}}">
+                            <table class="table table--line">
+                                <thead class="table-thead">
                                     <tr>
-                                        <td class="return-itemName">
-                                            <span class="return-itemTitle">{{name}}</span>
-                                            {{#if options}}
-                                            <dl class="definitionList">
-                                                {{#each options}}
-                                                <dt class="definitionList-label">{{name}}:</dt>
-                                                <dd class="definitionList-description">{{{sanitize value}}}</dd>
-                                                {{/each}}
-                                            </dl>
-                                            {{/if}}
-                                        </td>
-                                        <td class="return-itemPrice">{{price.formatted}}</td>
-                                        <td class="return-itemQuantity">
-                                            <label class="form-label">{{lang 'account.orders.return.quantity'}}:</label>
-                                            <select class="form-select form-select--small form-select--short" name="return_qty[{{id}}]">
-                                                {{#for 0 quantity}}
-                                                    <option value="{{$index}}">{{$index}}</option>
-                                                {{/for}}
-                                            </select>
-                                        </td>
+                                        <th class="return-itemName">{{lang 'account.orders.return.order_item'}}</th>
+                                        <th class="return-itemPrice">{{lang 'account.orders.return.item_price'}}</th>
+                                        <th class="return-itemQuantity">{{lang 'account.orders.return.quantity'}}</th>
                                     </tr>
-                                {{/each}}
-                            </tbody>
-                        </table>
-                    </fieldset>
-                    <div class="account--addReturn-row">
-                        <fieldset class="form-fieldset account--addReturn-column">
-                            <div class="form-field">
-                                <label for="return_reason" class="form-label">
-                                    {{lang 'account.orders.return.reason'}}
-                                    <small>{{lang 'common.required'}}</small>
-                                </label>
-                                <select name="return_reason" id="return_reason" class="form-select">
-                                    {{#each forms.return.reasons}}
-                                        <option value="{{this}}">{{this}}</option>
+                                </thead>
+                                <tbody class="table-tbody">
+                                    {{#each forms.return.order_products}}
+                                        <tr>
+                                            <td class="return-itemName">
+                                                <span class="return-itemTitle">{{name}}</span>
+                                                {{#if options}}
+                                                <dl class="definitionList">
+                                                    {{#each options}}
+                                                    <dt class="definitionList-label">{{name}}:</dt>
+                                                    <dd class="definitionList-description">{{{sanitize value}}}</dd>
+                                                    {{/each}}
+                                                </dl>
+                                                {{/if}}
+                                            </td>
+                                            <td class="return-itemPrice">{{price.formatted}}</td>
+                                            <td class="return-itemQuantity">
+                                                <label class="form-label">{{lang 'account.orders.return.quantity'}}:</label>
+                                                <select class="form-select form-select--small form-select--short" name="return_qty[{{id}}]">
+                                                    {{#for 0 quantity}}
+                                                        <option value="{{$index}}">{{$index}}</option>
+                                                    {{/for}}
+                                                </select>
+                                            </td>
+                                        </tr>
                                     {{/each}}
-                                </select>
-                            </div>
-                            <div class="form-field">
-                                <label for="return_action" class="form-label">
-                                    {{lang 'account.orders.return.action'}}
-                                </label>
-                                <select name="return_action" id="return_action" class="form-select">
-                                    {{#each forms.return.actions}}
-                                        <option value="{{this}}">{{this}}</option>
-                                    {{/each}}
-                                </select>
-                            </div>
+                                </tbody>
+                            </table>
                         </fieldset>
-                        <fieldset class="form-fieldset account--addReturn-column">
-                            <div class="form-field">
-                                <label for="return_comments" class="form-label">
-                                    {{lang 'account.orders.return.comments'}}
-                                </label>
-                                <textarea class="form-input" rows="8" name="return_comments" id="return_comments"></textarea>
-                            </div>
-                        </fieldset>
-                    </div>
-                    <div class="form-actions">
-                        <input class="button button--primary" type="submit" value="{{lang 'account.returns.submit_request'}}" />
-                    </div>
-                </form>
-            {{else}}
-                <p>{{lang 'account.orders.return.already_returned'}}</p>
-                <a href="{{urls.account.orders.all}}" class="button">{{lang 'account.orders.return.back_button'}}</a>
-            {{/if}}
+                        <div class="account--addReturn-row">
+                            <fieldset class="form-fieldset account--addReturn-column">
+                                <div class="form-field">
+                                    <label for="return_reason" class="form-label">
+                                        {{lang 'account.orders.return.reason'}}
+                                        <small>{{lang 'common.required'}}</small>
+                                    </label>
+                                    <select name="return_reason" id="return_reason" class="form-select">
+                                        {{#each forms.return.reasons}}
+                                            <option value="{{this}}">{{this}}</option>
+                                        {{/each}}
+                                    </select>
+                                </div>
+                                <div class="form-field">
+                                    <label for="return_action" class="form-label">
+                                        {{lang 'account.orders.return.action'}}
+                                    </label>
+                                    <select name="return_action" id="return_action" class="form-select">
+                                        {{#each forms.return.actions}}
+                                            <option value="{{this}}">{{this}}</option>
+                                        {{/each}}
+                                    </select>
+                                </div>
+                            </fieldset>
+                            <fieldset class="form-fieldset account--addReturn-column">
+                                <div class="form-field">
+                                    <label for="return_comments" class="form-label">
+                                        {{lang 'account.orders.return.comments'}}
+                                    </label>
+                                    <textarea class="form-input" rows="8" name="return_comments" id="return_comments"></textarea>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="form-actions">
+                            <input class="button button--primary" type="submit" value="{{lang 'account.returns.submit_request'}}" />
+                        </div>
+                    </form>
+                {{else}}
+                    <p>{{lang 'account.orders.return.already_returned'}}</p>
+                    <a href="{{urls.account.orders.all}}" class="button">{{lang 'account.orders.return.back_button'}}</a>
+                {{/if}}
 
-        </section>
-    </div>
-</main>
+            </section>
+        </div>
+    </main>
+
+{{/if}}
 
 {{/partial}}
 {{> layout/base}}


### PR DESCRIPTION
ORDERS-7708 new-return page — render items from order context, stepper qty controls, responsive layout, gate behind returns_v2_enabled flag

#### What?
Render items on add-return-new.html from order context. Support stepper qty controls, responsive layout, gate behind returns_v2_enabled flag


#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation
[ORDERS-7708](https://bigcommercecloud.atlassian.net/browse/ORDERS-7708)
Related PR on Storefront: https://github.com/bigcommerce/storefront/pull/5104/

### Screenshots (if appropriate)

## Testing
All pages load fine:

###Orders listing page:
<img width="1363" height="981" alt="image" src="https://github.com/user-attachments/assets/d7ffd35e-f0b1-45ac-a546-a37026f5da47" />


###Order details page: 
<img width="1366" height="1121" alt="image" src="https://github.com/user-attachments/assets/261d90ba-4bb9-4851-8137-727832173dd9" />

###Add returns page:

#### When both flags(legacy `returns_enabled` and new `returns_v2_enabled`) off:
Orders list and Order details page don't show returns items and new_return route redirects to orders list page:
<img width="1364" height="882" alt="image" src="https://github.com/user-attachments/assets/d3050c10-39ed-40a4-9bed-2c896cf3751a" />
<img width="1367" height="1076" alt="image" src="https://github.com/user-attachments/assets/05afbda6-88b9-437c-afff-9c57c9c2ff14" />

#### Existing add Return page (when only legacy returns_enabled):
<img width="1366" height="1095" alt="image" src="https://github.com/user-attachments/assets/df3fd565-e870-464e-a600-d5cfdd2c6cc6" />

#### Add return page when only new flag `returns_v2_enabled` enabled:
Redirects to orders list page. Currently BC app doesn't support redirection when legacy returns is disabled. We need to fix this as part of ORDERS-7764

#### Add Return page with new content(when returns_v2_enabled or both enabled):
<img width="1365" height="1084" alt="image" src="https://github.com/user-attachments/assets/65be30dc-f6c2-4ccd-897f-97a0144eff30" />



[ORDERS-7708]: https://bigcommercecloud.atlassian.net/browse/ORDERS-7708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ