### PR TITLE
PI-5196: Add global regions for payment promotional banners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Add global regions for payment promotional banners so Affirm, PayPal and other payment promo banners render on custom product/category/cart/home templates (PI-5196)
 - Fix duplicate `id="default_instrument"` on Update Payment Method page [#2661](https://github.com/bigcommerce/cornerstone/pull/2661)
 - Respect `available_to_sell` on PDP so the Sold Out alert is hidden and the Add to Cart button stays enabled for backorderable products, and is disabled when quantity exceeds `available_to_sell` [#2659](https://github.com/bigcommerce/cornerstone/pull/2659)
 - Updated accessibility features [2656](https://github.com/bigcommerce/cornerstone/pull/2656)

--- a/templates/components/common/body.html
+++ b/templates/components/common/body.html
@@ -3,6 +3,7 @@
     <div class="container">
         {{#block "page"}} {{/block}}
     </div>
+    {{> components/common/payment-banners-global}}
     {{> components/common/modal/modal}}
     {{> components/common/alert/alert-modal}}
 </div>

--- a/templates/components/common/payment-banners-global.html
+++ b/templates/components/common/payment-banners-global.html
@@ -1,0 +1,11 @@
+{{!--
+    Global regions for payment provider promotional banners (Affirm, PayPal, etc.).
+    Rendered via layout/base.html on every storefront page so banners work
+    regardless of which template (default or custom) the page uses.
+    See PI-5196.
+--}}
+{{{region name="product_below_price--global"}}}
+{{{region name="category_below_content--global"}}}
+{{{region name="cart_below_totals--global"}}}
+{{{region name="cart_header_bottom--global"}}}
+{{{region name="home_header_bottom--global"}}}


### PR DESCRIPTION
#### What?

Adds a partial that declares five new global regions used by payment promotional banners (Affirm, PayPal, Zip/Quadpay, BraintreePayPalCredit, BigCommercePayments, Opy):

- `product_below_price--global`
- `category_below_content--global`
- `cart_below_totals--global`
- `cart_header_bottom--global`
- `home_header_bottom--global`

The partial is included from `templates/components/common/body.html`, which renders through `layout/base.html` on every storefront page (default AND custom templates). This lets the BigCommerce platform create one global placement per banner instead of per-template placements and fixes the long-standing bug (PI-4999) where promo banners stop rendering when a merchant switches a product to a custom template file.

Existing per-template regions (`product_below_price` in `product-view.html`, `cart_below_totals` in `cart.html`, etc.) are left untouched so existing placements continue to render during the coexistence window. Each payment provider's widget JS deduplicates when both legacy and global placements are present.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- Jira: [PI-5196](https://bigcommercecloud.atlassian.net/browse/PI-5196)
- Companion BigCommerce monolith PR: https://github.com/bigcommerce/bigcommerce/pull/68364
- Original bug: [PI-4999](https://bigcommercecloud.atlassian.net/browse/PI-4999)

#### Screenshots (if appropriate)

N/A — purely template additions; no visual changes on the default Cornerstone storefront. Banners render in the new regions only when the platform-side feature flag `PI-5196.global_payment_banner_placement` is on for the store.

[PI-5196]: https://bigcommercecloud.atlassian.net/browse/PI-5196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ