### PR TITLE
fix(checkout): On the cart page, fix bundled item stock section showing title with no content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
-- Fix bundled item stock section showing title with no content when there is no backorder data or all inventory display settings are disabled [#2663](https://github.com/bigcommerce/cornerstone/pull/2663)
+- Fix bundled item stock section showing title with no content when there is no backorder data or all inventory display settings are disabled [#2668](https://github.com/bigcommerce/cornerstone/pull/2668)
 - Render stock positions for bundled items (pick lists) on the cart page, (change to be left aligned with the quantity adjuster) [#2663](https://github.com/bigcommerce/cornerstone/pull/2663)
 - Fix duplicate `id="default_instrument"` on Update Payment Method page [#2661](https://github.com/bigcommerce/cornerstone/pull/2661)
 - Respect `available_to_sell` on PDP so the Sold Out alert is hidden and the Add to Cart button stays enabled for backorderable products, and is disabled when quantity exceeds `available_to_sell` [#2659](https://github.com/bigcommerce/cornerstone/pull/2659)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Fix bundled item stock section showing title with no content when there is no backorder data or all inventory display settings are disabled [#2663](https://github.com/bigcommerce/cornerstone/pull/2663)
 - Render stock positions for bundled items (pick lists) on the cart page, (change to be left aligned with the quantity adjuster) [#2663](https://github.com/bigcommerce/cornerstone/pull/2663)
 - Fix duplicate `id="default_instrument"` on Update Payment Method page [#2661](https://github.com/bigcommerce/cornerstone/pull/2661)
 - Respect `available_to_sell` on PDP so the Sold Out alert is hidden and the Add to Cart button stays enabled for backorderable products, and is disabled when quantity exceeds `available_to_sell` [#2659](https://github.com/bigcommerce/cornerstone/pull/2659)

--- a/templates/components/cart/content.html
+++ b/templates/components/cart/content.html
@@ -155,24 +155,23 @@
                         {{/if}}
                         {{#each options}}
                             {{#if linked_bundled_item}}
-                                <div class="cart-item-option-stock">
-                                    <p class="cart-item-backorder-message"><strong>{{name}}:</strong></p>
-                                    {{#if ../../cart.inventory_settings.show_quantity_on_hand}}
-                                        {{#all linked_bundled_item.stock_position.quantity_on_hand linked_bundled_item.stock_position.quantity_backordered}}
+                                {{#all ../../cart.inventory_settings.show_quantity_on_hand linked_bundled_item.stock_position.quantity_on_hand linked_bundled_item.stock_position.quantity_backordered}}{{assignVar "showOnHandQty" 1}}{{else}}{{assignVar "showOnHandQty" 0}}{{/all}}
+                                {{#all ../../cart.inventory_settings.show_quantity_on_backorder linked_bundled_item.stock_position.quantity_backordered}}{{assignVar "showBackorderedQty" 1}}{{else}}{{assignVar "showBackorderedQty" 0}}{{/all}}
+                                {{#all ../../cart.inventory_settings.show_backorder_message linked_bundled_item.stock_position.backorder_message}}{{assignVar "showBackorderMessage" 1}}{{else}}{{assignVar "showBackorderMessage" 0}}{{/all}}
+                                {{#or (getVar "showOnHandQty") (getVar "showBackorderedQty") (getVar "showBackorderMessage")}}
+                                    <div class="cart-item-option-stock">
+                                        <p class="cart-item-backorder-message"><strong>{{name}}:</strong></p>
+                                        {{#if (getVar "showOnHandQty")}}
                                             <p class="cart-item-backorder-message">{{lang 'products.quantity_on_hand' quantity=linked_bundled_item.stock_position.quantity_on_hand}}</p>
-                                        {{/all}}
-                                    {{/if}}
-                                    {{#if ../../cart.inventory_settings.show_quantity_on_backorder}}
-                                        {{#if linked_bundled_item.stock_position.quantity_backordered}}
+                                        {{/if}}
+                                        {{#if (getVar "showBackorderedQty")}}
                                             <p class="cart-item-backorder-message">{{lang 'products.quantity_backordered' quantity=linked_bundled_item.stock_position.quantity_backordered}}</p>
                                         {{/if}}
-                                    {{/if}}
-                                    {{#if ../../cart.inventory_settings.show_backorder_message}}
-                                        {{#if linked_bundled_item.stock_position.backorder_message}}
+                                        {{#if (getVar "showBackorderMessage")}}
                                             <p class="cart-item-backorder-message">{{linked_bundled_item.stock_position.backorder_message}}</p>
                                         {{/if}}
-                                    {{/if}}
-                                </div>
+                                    </div>
+                                {{/or}}
                             {{/if}}
                         {{/each}}
                     {{/if}}


### PR DESCRIPTION
#### What?

I just merged a PR: https://github.com/bigcommerce/cornerstone/pull/2663 but found a display bug: 
The bundled item section heading (e.g. "bundle1:") was rendered even when no stock data would be displayed, leaving a floating label with no content beneath it

<img width="2000" height="497" alt="image" src="https://github.com/user-attachments/assets/96b8f71e-52fd-4d8a-8195-4612f4afe643" />

So this PR is to fix that bug.

Details:

For each bundled item, uses `assignVar`/`getVar` to pre-compute three boolean display flags:
  - `showOnHandQty` — `show_quantity_on_hand` + `quantity_on_hand` + `quantity_backordered` all truthy
  - `showBackorderedQty` — `show_quantity_on_backorder` + `quantity_backordered` both truthy
  - `showBackorderMessage` — `show_backorder_message` + `backorder_message` both truthy
- **the entire stock section (including the item name label) is guarded by `{{#or (getVar ...) ...}}` so the title only renders when at least one condition is met (at least one field is displayed)**

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [PR to introduce backorder prompts on bundled items](https://github.com/bigcommerce/cornerstone/pull/2663)
- ...

#### Screenshots (if appropriate)

**If no backorder prompts to show for bundled item**

before fix: 

<img width="2000" height="497" alt="image" src="https://github.com/user-attachments/assets/96b8f71e-52fd-4d8a-8195-4612f4afe643" />

🔴 picklist item title is displayed when no backorder prompts displayed

after fix:

<img width="2470" height="1444" alt="image" src="https://github.com/user-attachments/assets/f7bf33d3-b6d1-4f66-bf69-a4b0f93f6712" />

✅ picklist item tile is NOT displayed when no backorder prompts displayed

**if sth to show for the bundled item**

before and after fix its the same:

<img width="2430" height="1548" alt="image" src="https://github.com/user-attachments/assets/9b84e8bc-6d9b-46d5-aff5-29e84a9000ca" />


