### PR TITLE
feat(orders): ORDERS-7731 add template for create return page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Add new create-return page [#2669](https://github.com/bigcommerce/cornerstone/pull/2669) 
 - Fix duplicate `id="default_instrument"` on Update Payment Method page [#2661](https://github.com/bigcommerce/cornerstone/pull/2661)
 - Respect `available_to_sell` on PDP so the Sold Out alert is hidden and the Add to Cart button stays enabled for backorderable products, and is disabled when quantity exceeds `available_to_sell` [#2659](https://github.com/bigcommerce/cornerstone/pull/2659)
 - Updated accessibility features [2656](https://github.com/bigcommerce/cornerstone/pull/2656)

--- a/templates/pages/create-return.html
+++ b/templates/pages/create-return.html
@@ -1,0 +1,9 @@
+{{#partial "page"}}
+
+{{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
+
+<h1>Create Return</h1>
+
+{{/partial}}
+
+{{> layout/base}}


### PR DESCRIPTION
#### What?

This PR adds a new create return page template.

See related PRs:
- https://github.com/bigcommerce/bigcommerce/pull/68447
- https://github.com/bigcommerce/storefront/pull/5127

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- ORDERS-7731

#### Screenshots (if appropriate)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only a placeholder template and changelog line; no business logic, auth, or checkout behavior changes.
> 
> **Overview**
> Introduces a new storefront page template **`create-return.html`** as a scaffold for the returns v2 “create return” flow (ORDERS-7331), wired through the standard **`layout/base`** partial with breadcrumbs and a **Create Return** heading only—no forms, JS, or styling yet.
> 
> Documents the change in **`CHANGELOG.md`** under Draft.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e79ca2d4024ea2b829a6133ab2e2d086e8b0bd2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->