### PR TITLE
feat(pdp): polish PDP backorder availability display (BACK-636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
-- Polish PDP backorder availability display: render on-hand stock as "X in stock", drop hardcoded parentheses around the backorder availability prompt, bold the on-hand and backordered quantities, and add a vertical divider between the quantity and the prompt/message
+- Polish PDP backorder availability display: render on-hand stock as "X in stock", drop hardcoded parentheses around the backorder availability prompt, bold the on-hand and backordered quantities, and add a vertical divider between the quantity and the prompt/message [#2670](https://github.com/bigcommerce/cornerstone/pull/2670)
 - Fix bundled item stock section showing title with no content when there is no backorder data or all inventory display settings are disabled [#2668](https://github.com/bigcommerce/cornerstone/pull/2668)
 - Render stock positions for bundled items (pick lists) on the cart page, (change to be left aligned with the quantity adjuster) [#2663](https://github.com/bigcommerce/cornerstone/pull/2663)
 - Fix duplicate `id="default_instrument"` on Update Payment Method page [#2661](https://github.com/bigcommerce/cornerstone/pull/2661)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Polish PDP backorder availability display: render on-hand stock as "X in stock", drop hardcoded parentheses around the backorder availability prompt, bold the on-hand and backordered quantities, and add a vertical divider between the quantity and the prompt/message
 - Fix bundled item stock section showing title with no content when there is no backorder data or all inventory display settings are disabled [#2668](https://github.com/bigcommerce/cornerstone/pull/2668)
 - Render stock positions for bundled items (pick lists) on the cart page, (change to be left aligned with the quantity adjuster) [#2663](https://github.com/bigcommerce/cornerstone/pull/2663)
 - Fix duplicate `id="default_instrument"` on Update Payment Method page [#2661](https://github.com/bigcommerce/cornerstone/pull/2661)

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -256,10 +256,11 @@ export default class ProductDetailsBase {
         const withinSellLimit = availableToSell > 0 ? qty <= availableToSell : true;
 
         if (backordered > 0 && withinSellLimit) {
+            const qtyHtml = `<strong>${backordered}</strong>`;
             const message = this.context.quantityBackorderedMessage
-                ? this.context.quantityBackorderedMessage.replace('__QTY__', backordered)
-                : `${backordered} will be backordered`;
-            viewModel.$backorderedQtyMessage.text(message);
+                ? this.context.quantityBackorderedMessage.replace('__QTY__', qtyHtml)
+                : `${qtyHtml} will be backordered`;
+            viewModel.$backorderedQtyMessage.html(message);
         } else {
             viewModel.$backorderedQtyMessage.text('');
         }
@@ -359,7 +360,7 @@ export default class ProductDetailsBase {
         const promptText = this.context.backorderAvailabilityPrompt;
 
         if (showPrompt && availableToSell > 0 && availableForBackorder > 0 && promptText) {
-            viewModel.$backorderPrompt.text(`(${promptText})`).show();
+            viewModel.$backorderPrompt.text(promptText).show();
         } else {
             viewModel.$backorderPrompt.hide();
         }

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -219,12 +219,16 @@
 // Details - Product backorder message
 // -----------------------------------------------------------------------------
 
-.productView-backorder-availability-prompt {
+.productView-backorder-availability-prompt,
+[data-backorder-message] {
+    border-left: 1px solid stencilColor("color-textSecondary");
+    font-weight: fontWeight("normal");
     margin-left: spacing("half");
+    padding-left: spacing("half");
 }
 
-[data-backorder-message] {
-    margin-left: spacing("half");
+.form-field--stock .form-label--alternate {
+    font-weight: fontWeight("bold");
 }
 
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -726,6 +726,7 @@
     },
     "products": {
         "current_stock": "Current Stock:",
+        "in_stock": "in stock",
         "quantity": "Quantity:",
         "change_product_options": "Change options for {name}",
         "quantity_decrease": "Decrease Quantity of {name}",

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -254,10 +254,10 @@
                 </div>
                 <div class="form-field form-field--stock{{#unless product.stock_level}} u-hiddenVisually{{/unless}}">
                     <label class="form-label form-label--alternate">
-                        {{lang 'products.current_stock'}}
-                        <span data-product-stock>{{product.stock_level}}</span>
+                        <strong data-product-stock>{{product.stock_level}}</strong>
+                        {{lang 'products.in_stock'}}
                         {{#all product.show_backorder_availability_prompt product.available_to_sell product.available_for_backorder}}
-                            <span class="productView-backorder-availability-prompt" data-backorder-prompt>({{product.backorder_availability_prompt}})</span>
+                            <span class="productView-backorder-availability-prompt" data-backorder-prompt>{{product.backorder_availability_prompt}}</span>
                         {{else}}
                             <span class="productView-backorder-availability-prompt" data-backorder-prompt style="display:none;"></span>
                         {{/all}}


### PR DESCRIPTION
#### What?

Polishes the Stencil PDP backorder/on-hand stock display so it matches the intended design (and Catalyst implementation).
<img width="985" height="687" alt="Screenshot 2026-06-02 at 20 19 31" src="https://github.com/user-attachments/assets/ddc62c9a-b056-4858-bf62-e73b79d73bdd" />

Changes:

- **On-hand stock label** — `templates/components/products/product-view.html` now renders the stock count as `<strong>{stock_level}</strong> in stock` instead of `Current Stock: {stock_level}`. The `<span data-product-stock>` was replaced with `<strong data-product-stock>` so the quantity is bold; the surrounding label still picks up `font-weight: bold` from new scoped SCSS for the rest of the row text.
- **New lang key** — Added `products.in_stock` (`"in stock"`) in `lang/en.json`. The old `products.current_stock` key is retained for any other consumers.
- **Backorder availability prompt** — Dropped the hardcoded `(...)` wrapper in both the Handlebars template and `assets/js/theme/common/product-details-base.js` (`updateBackorderAvailabilityPrompt`). The prompt text is now rendered raw.
- **Bolded backordered quantity** — `updateQtyBackorderedMessage` in `product-details-base.js` now wraps the quantity in `<strong>` and writes via `.html()`. The `__QTY__` token substitution in the merchant-provided message keeps working (the bold markup is injected before substitution).
- **Vertical divider + typography** — `assets/scss/components/stencil/productView/_productView.scss`:
  - `.productView-backorder-availability-prompt` and `[data-backorder-message]` now share a `border-left` divider with matching `margin-left`/`padding-left`, replacing the previous plain `margin-left`-only rule. Both elements also explicitly use `font-weight: normal` so the divider/message text doesn't inherit the bold weight from the parent label.
  - Added `.form-field--stock .form-label--alternate { font-weight: bold; }` so the `X in stock` / `X will be backordered` rows render bold, while the prompt/message after the divider stays at normal weight.

The divider naturally hides when there is no prompt/message because those spans are emptied or set to `display: none` by the existing logic.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [BACK-636 — Polish backorder availability display to match intended design](https://bigcommercecloud.atlassian.net/browse/BACK-636)

#### Screenshots (if appropriate)

Before:

> `Current Stock: 0` / `(More available for backorder)` — regular weight, no divider, parentheses around the prompt.

After:

> **0** in stock │ More available for backorder
> **1** will be backordered │ test test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to PDP stock/backorder copy and styles; backordered quantity HTML is built from a numeric value only.
> 
> **Overview**
> Polishes the PDP **backorder / on-hand stock** row so it matches the intended design: **bold quantity**, **"in stock"** copy, and a **divider** before the prompt or backorder message.
> 
> The stock label in `product-view.html` switches from **Current Stock:** `{level}` to **`{level}` in stock** (new `products.in_stock` in `lang/en.json`; `current_stock` is unchanged for other callers). The on-hand count uses `<strong data-product-stock>`. The backorder availability prompt is shown **without** hardcoded parentheses in both the template and `updateBackorderPrompt` in `product-details-base.js`.
> 
> When quantity triggers a backorder line, `updateQtyBackorderedMessage` wraps the count in `<strong>` and uses `.html()` so `__QTY__` in the merchant message can stay bold. SCSS bolds `.form-field--stock` labels, sets **normal** weight on the prompt and `[data-backorder-message]`, and adds a **left border** divider between the main stock text and those segments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc5fb799d401ae77397aeb306007b8b133e814d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->