### PR TITLE
fix(backorders): BACK-637 respect unlimited_backorder on PDP for simple and complex products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Respect `unlimited_backorder` on PDP so the backorder quantity message and availability prompt render, and the Add to Cart quantity cap is lifted for products with unlimited backorder
 - Render backorder prompt for picklist products on PDP [#2662](https://github.com/bigcommerce/cornerstone/pull/2662)
 - Fix bundled item stock section showing title with no content when there is no backorder data or all inventory display settings are disabled [#2668](https://github.com/bigcommerce/cornerstone/pull/2668)
 - Render stock positions for bundled items (pick lists) on the cart page, (change to be left aligned with the quantity adjuster) [#2663](https://github.com/bigcommerce/cornerstone/pull/2663)

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -252,10 +252,13 @@ export default class ProductDetailsBase {
             onHand = stockFromDom;
         }
 
-        const availableForBackorder = parseInt(this.context.availableForBackorder, 10) || 0;
+        const unlimited = this.context.unlimitedBackorder === true;
+        const availableForBackorder = unlimited
+            ? Infinity
+            : parseInt(this.context.availableForBackorder, 10) || 0;
         const availableToSell = parseInt(this.context.availableToSell, 10) || 0;
         const backordered = Math.max(0, Math.min(qty - onHand, availableForBackorder));
-        const withinSellLimit = availableToSell > 0 ? qty <= availableToSell : true;
+        const withinSellLimit = unlimited || (availableToSell > 0 ? qty <= availableToSell : true);
 
         if (backordered > 0 && withinSellLimit) {
             const message = this.context.quantityBackorderedMessage
@@ -306,7 +309,10 @@ export default class ProductDetailsBase {
 
     updateAddToCartForQty(qty, passedViewModel) {
         const viewModel = passedViewModel || this.getViewModel(this.$scope);
-        const availableToSell = parseInt(this.context.availableToSell, 10) || 0;
+        const unlimited = this.context.unlimitedBackorder === true;
+        const availableToSell = unlimited
+            ? Infinity
+            : parseInt(this.context.availableToSell, 10) || 0;
 
         if (availableToSell <= 0) return;
 
@@ -347,6 +353,9 @@ export default class ProductDetailsBase {
         if (typeof data.backorder_availability_prompt === 'string') {
             this.context.backorderAvailabilityPrompt = data.backorder_availability_prompt;
         }
+        if (typeof data.unlimited_backorder === 'boolean') {
+            this.context.unlimitedBackorder = data.unlimited_backorder;
+        }
         this.context.backorderMessageId = data.backorder_message_id ?? null;
     }
 
@@ -356,8 +365,13 @@ export default class ProductDetailsBase {
         if (!viewModel.$backorderPrompt.length) return;
 
         const showPrompt = this.context.showBackorderAvailabilityPrompt;
-        const availableForBackorder = parseInt(this.context.availableForBackorder, 10) || 0;
-        const availableToSell = parseInt(this.context.availableToSell, 10) || 0;
+        const unlimited = this.context.unlimitedBackorder === true;
+        const availableForBackorder = unlimited
+            ? Infinity
+            : parseInt(this.context.availableForBackorder, 10) || 0;
+        const availableToSell = unlimited
+            ? Infinity
+            : parseInt(this.context.availableToSell, 10) || 0;
         const promptText = this.context.backorderAvailabilityPrompt;
 
         if (showPrompt && availableToSell > 0 && availableForBackorder > 0 && promptText) {

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -2,6 +2,7 @@
 {{inject 'availableOnHand' product.available_on_hand}}
 {{inject 'availableForBackorder' product.available_for_backorder}}
 {{inject 'availableToSell' product.available_to_sell}}
+{{inject 'unlimitedBackorder' product.unlimited_backorder}}
 {{inject 'showQuantityOnBackorder' product.show_quantity_on_backorder}}
 {{inject 'showBackorderAvailabilityPrompt' product.show_backorder_availability_prompt}}
 {{inject 'backorderAvailabilityPrompt' product.backorder_availability_prompt}}


### PR DESCRIPTION
#### What?


https://github.com/user-attachments/assets/ff158578-4602-45a9-83fa-cd8ca4ddb3f0



Fixes PDP backorder rendering when a product is configured with **unlimited backorder**. Previously, both simple and complex products on the storefront PDP ignored `unlimited_backorder = true` and clamped calculations by `available_for_backorder` / `available_to_sell`, which caused:

- **Complex product:** when shopper qty exceeds on-hand, the backorder availability prompt, "N will be backordered" message, and backorder message did not render — but the qty could still be added to cart.
- **Simple product:** when shopper qty exceeds on-hand, the PDP showed a "max purchasable is X" error with a disabled Add to Cart button, even though cart and checkout accept the unlimited backorder qty.

This change mirrors the picklist (complex product) logic in `picklist-backorder.js`: when `unlimited_backorder === true`, the `available_for_backorder` and `available_to_sell` caps are treated as `Infinity`, so the backorder UI renders correctly and the Add to Cart cap is lifted.

**Files changed:**

- `templates/components/products/product-view.html` — inject `unlimitedBackorder` from `product.unlimited_backorder` into the JS context.
- `assets/js/theme/common/product-details-base.js`:
  - `updateBackorderContext` — pick up `data.unlimited_backorder` from the `/remote/v1/product-attributes/{id}` variant-change response so the flag updates when the shopper switches variants.
  - `updateQtyBackorderedMessage` — when unlimited, drop the `available_for_backorder` clamp on the backordered quantity and treat `withinSellLimit` as always true so the "N will be backordered" message renders.
  - `updateAddToCartForQty` — when unlimited, treat `availableToSell` as `Infinity` so the qty cap and "max purchasable" message are not applied.
  - `updateBackorderPrompt` — when unlimited, treat `availableForBackorder` / `availableToSell` as `Infinity` so the backorder availability prompt is shown.
- `CHANGELOG.md` — Draft entry added.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [BACK-637](https://bigcommercecloud.atlassian.net/browse/BACK-637)

#### Screenshots (if appropriate)

N/A — UI behavior change verified by selecting a qty above on-hand on a product configured with unlimited backorder.

#### Test plan

- [ ] On a storefront with a **simple** product configured with `unlimited_backorder = true`: select a qty above on-hand stock on the PDP. Expect the backorder availability prompt, the "N will be backordered" message, and the backorder message to render. Add to Cart stays enabled and no "max purchasable" error is shown.
- [ ] On a storefront with a **complex** (variant) product configured with `unlimited_backorder = true`: select a variant, set qty above on-hand. Expect the same backorder UI to render. Switch to a variant without unlimited backorder and confirm the normal caps reapply.
- [ ] Regression check: product with finite `available_for_backorder` and `available_to_sell` still renders the existing capped backorder message and disables Add to Cart when qty exceeds ATS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BACK-637]: https://bigcommercecloud.atlassian.net/browse/BACK-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PDP purchase and backorder messaging logic; mis-handling could allow over-ordering or hide limits for finite backorder products, but scope is limited to the new flag and mirrors existing picklist behavior.
> 
> **Overview**
> **Respects `unlimited_backorder` on the PDP** so storefront behavior matches cart/checkout when a product allows unlimited backorder.
> 
> `product-view.html` now injects `unlimitedBackorder` into the JS context. In `product-details-base.js`, when that flag is true, `available_for_backorder` and `available_to_sell` are treated as unbounded (`Infinity`) for backorder qty messaging, the availability prompt, and Add to Cart quantity limits. `updateBackorderContext` also reads `unlimited_backorder` from variant/product-attribute API responses so the flag stays correct after option changes.
> 
> Draft **CHANGELOG** entry documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 874349b84dc6de4ed4fd06e4d41311be71ff2e0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->