### PR TITLE
fix(backorders): BACK-674 keep PDP backorder row visible when qty exceeds available_to_sell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Keep PDP "N will be backordered" message visible when the requested quantity exceeds `available_to_sell` (still clamped by `available_for_backorder`), so shoppers see why the qty was clamped alongside the "maximum purchasable quantity" error
 - Render backorder prompt for picklist products on PDP [#2662](https://github.com/bigcommerce/cornerstone/pull/2662)
 - Fix bundled item stock section showing title with no content when there is no backorder data or all inventory display settings are disabled [#2668](https://github.com/bigcommerce/cornerstone/pull/2668)
 - Render stock positions for bundled items (pick lists) on the cart page, (change to be left aligned with the quantity adjuster) [#2663](https://github.com/bigcommerce/cornerstone/pull/2663)

--- a/assets/js/test-unit/theme/common/picklist-backorder.spec.js
+++ b/assets/js/test-unit/theme/common/picklist-backorder.spec.js
@@ -445,7 +445,7 @@ describe('PicklistBackorder', () => {
             expect($list.css('display')).toBe('none');
         });
 
-        it('skips a selection when requested qty exceeds the linked product available_to_sell', () => {
+        it('still renders the backorder line when requested qty exceeds available_to_sell (clamped by available_for_backorder)', () => {
             $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
             const renderer = new PicklistBackorder($scope, context);
 
@@ -458,7 +458,9 @@ describe('PicklistBackorder', () => {
                 })],
             }, 10);
 
-            expect($('[data-picklist-backorder-list] li', $scope).length).toBe(0);
+            const $items = $('[data-picklist-backorder-list] li', $scope);
+            expect($items.length).toBe(1);
+            expect($items.eq(0).text()).toContain('5 will be backordered');
         });
 
         it('renders the line when requested qty is within the linked product available_to_sell', () => {

--- a/assets/js/theme/common/picklist-backorder.js
+++ b/assets/js/theme/common/picklist-backorder.js
@@ -50,11 +50,6 @@ export default class PicklistBackorder {
             if (detail.purchasable === false) return;
 
             const unlimited = detail.unlimited_backorder === true;
-            const availableToSell = parseInt(detail.available_to_sell, 10) || 0;
-            const withinSellLimit = unlimited
-                || (availableToSell > 0 ? requestedQty <= availableToSell : true);
-            if (!withinSellLimit) return;
-
             const onHand = parseInt(detail.available_on_hand, 10) || 0;
             const afb = unlimited
                 ? Infinity

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -253,11 +253,9 @@ export default class ProductDetailsBase {
         }
 
         const availableForBackorder = parseInt(this.context.availableForBackorder, 10) || 0;
-        const availableToSell = parseInt(this.context.availableToSell, 10) || 0;
         const backordered = Math.max(0, Math.min(qty - onHand, availableForBackorder));
-        const withinSellLimit = availableToSell > 0 ? qty <= availableToSell : true;
 
-        if (backordered > 0 && withinSellLimit) {
+        if (backordered > 0) {
             const message = this.context.quantityBackorderedMessage
                 ? this.context.quantityBackorderedMessage.replace('__QTY__', backordered)
                 : `${backordered} will be backordered`;


### PR DESCRIPTION
#### What?

https://github.com/user-attachments/assets/38bf26f1-4b0f-4b49-a37f-582e1fd22895


When a shopper on the storefront PDP enters a quantity that exceeds `available_to_sell`, the PDP already surfaces the existing **"The maximum purchasable quantity is N"** error on the Add to Cart button. Previously, the **"N will be backordered"** row was *also* hidden in this state — leaving the shopper without any explanation of how many of the requested qty would be backordered or why the qty was clamped.

This change drops the within-sell-limit gate in both the main-product and picklist backorder quantity calculations. The backordered line now renders whenever `backordered > 0`, still clamped by `available_for_backorder` for non-unlimited products, independent of whether the requested qty is within the sell limit.

**Files changed:**

- `assets/js/theme/common/product-details-base.js` — `updateQtyBackorderedMessage`: removed the `withinSellLimit` gate. The row now renders whenever `backordered > 0`.
- `assets/js/theme/common/picklist-backorder.js` — `buildLines`: removed the `withinSellLimit` early-return so each picklist line continues to render when the main qty exceeds that sub-product's ATS (still clamped by its `available_for_backorder`).
- `assets/js/test-unit/theme/common/picklist-backorder.spec.js` — updated the "skip when qty exceeds ATS" test to assert the line now renders with the clamped backorder count instead. All 27 tests pass.
- `CHANGELOG.md` — Draft entry added.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [BACK-674](https://bigcommercecloud.atlassian.net/browse/BACK-674)

Note: independent of [BACK-637](https://bigcommercecloud.atlassian.net/browse/BACK-637) / PR #2671 (unlimited_backorder support). Both target the same gate and may produce a small merge conflict depending on merge order; either can merge first.

#### Screenshots (if appropriate)

N/A — UI behavior change verified by setting qty above ATS on a backorderable product and confirming both the "maximum purchasable quantity" error and the "N will be backordered" row are visible together.

#### Test plan

- [ ] On a storefront with a product that has a numeric backorder limit (e.g. on-hand = 2, available_for_backorder = 5, available_to_sell = 7): enter qty = 10 on the PDP. Expect both "The maximum purchasable quantity is 7" on the Add to Cart button **and** "5 will be backordered" in the backorder row to be visible at the same time.
- [ ] Same scenario for a complex product with picklist options: enter qty above a sub-product's ATS. Expect the picklist line "Option Name: N will be backordered" to remain visible alongside the cart-level error.
- [ ] Regression check: when qty is within ATS, the backorder row continues to render correctly (still clamped by `available_for_backorder`).
- [ ] Regression check: when on-hand covers requested qty (no backorder needed), the backorder row is hidden as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BACK-674]: https://bigcommercecloud.atlassian.net/browse/BACK-674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Storefront-only display logic for backorder messaging; add-to-cart limits for available_to_sell are unchanged.
> 
> **Overview**
> When shoppers enter a quantity above **`available_to_sell`** on the PDP, the theme still shows the **maximum purchasable quantity** error on Add to Cart (unchanged). This PR stops hiding the **"N will be backordered"** row in that situation.
> 
> **Main product:** `updateQtyBackorderedMessage` no longer requires qty to be within the sell limit; the backorder message appears whenever the computed backorder count is **> 0**, still capped by **`available_for_backorder`**.
> 
> **Picklist options:** `PicklistBackorder.buildLines` drops the same sell-limit early return so bundled picklist lines stay visible when main qty exceeds a sub-product's ATS, with the same backorder clamping.
> 
> Unit test and **CHANGELOG** draft updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0850c89e0b4f9bdbde6d7644e68e421c5a65066d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->