### PR TITLE
fix(account): BACK-699 refine backorder layout and colors on order details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Refine backorder display on the account order details page: top-align all product row cells (checkbox, image, body) so rows stay readable with or without backorder text, remove the extra vertical gap between backorder rows, and use `#757575` for all backorder text (qty ready to ship, qty backordered, backorder message, and shipping expectation message)
 - Make the cart Shipping row label span the full width of the totals row so the shipping expectation prompt is no longer constrained to the narrow label column
 - Respect `unlimited_backorder` on PDP so the backorder quantity message and availability prompt render, and the Add to Cart quantity cap is lifted for products with unlimited backorder
 - Keep PDP "N will be backordered" message visible when the requested quantity exceeds `available_to_sell` (still clamped by `available_for_backorder`), so shoppers see why the qty was clamped alongside the "maximum purchasable quantity" error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
-- Refine backorder display on the account order details page: top-align all product row cells (checkbox, image, body) so rows stay readable with or without backorder text, remove the extra vertical gap between backorder rows, and use `#757575` for all backorder text (qty ready to ship, qty backordered, backorder message, and shipping expectation message)
+- Refine backorder layout and colors on the account order details page [#2677](https://github.com/bigcommerce/cornerstone/pull/2677)
 - Make the cart Shipping row label span the full width of the totals row so the shipping expectation prompt is no longer constrained to the narrow label column
 - Respect `unlimited_backorder` on PDP so the backorder quantity message and availability prompt render, and the Add to Cart quantity cap is lifted for products with unlimited backorder
 - Keep PDP "N will be backordered" message visible when the requested quantity exceeds `available_to_sell` (still clamped by `available_for_backorder`), so shoppers see why the qty was clamped alongside the "maximum purchasable quantity" error

--- a/assets/scss/components/stencil/account/_account.scss
+++ b/assets/scss/components/stencil/account/_account.scss
@@ -150,16 +150,13 @@
 }
 
 .account-product-backorder-prompts {
+    color: #757575;
     font-size: fontSize("smaller");
-    margin-bottom: spacing("quarter");
-
-    &:last-of-type {
-        margin-bottom: 0;
-    }
+    margin-bottom: 0;
 }
 
 .account-order-backorder-expectation {
-    color: color("greys", "light");
+    color: #757575;
     font-size: fontSize("smaller");
     margin-bottom: 0;
     margin-top: spacing("base");
@@ -225,7 +222,7 @@
     .account-product-checkItem {
         display: table-cell;
         position: relative;
-        vertical-align: middle;
+        vertical-align: top;
         width: 2rem;
 
         @include breakpoint("large") {
@@ -243,6 +240,7 @@
     .account-product-figure,
     .account-product-body {
         display: table-cell;
+        vertical-align: top;
     }
 
     .account-product-figure {
@@ -256,7 +254,6 @@
 
     .account-product-body {
         padding-left: 2rem;
-        vertical-align: middle;
 
         @include breakpoint("large") {
             padding-left: 0;

--- a/assets/scss/components/stencil/account/_account.scss
+++ b/assets/scss/components/stencil/account/_account.scss
@@ -2,6 +2,10 @@
 // ACCOUNT (CSS)
 // =============================================================================
 
+// Backorder copy colour (BACK-699). No Citadel greys token matches this value,
+// so the design-specified hex is kept as a single named local variable.
+$account-backorder-textColor: #757575;
+
 
 // Account navigation
 // -----------------------------------------------------------------------------
@@ -150,13 +154,13 @@
 }
 
 .account-product-backorder-prompts {
-    color: #757575;
+    color: $account-backorder-textColor;
     font-size: fontSize("smaller");
     margin-bottom: 0;
 }
 
 .account-order-backorder-expectation {
-    color: #757575;
+    color: $account-backorder-textColor;
     font-size: fontSize("smaller");
     margin-bottom: 0;
     margin-top: spacing("base");


### PR DESCRIPTION
#### What?

Refines the backorder display on the **account → order details** page (`templates/components/account/order-contents.html` + `templates/pages/account/orders/details.html`), addressing the font/layout issues called out in BACK-699. All changes are in `assets/scss/components/stencil/account/_account.scss`.

- **Top-align all cells in a product row.** `.account-product--alignMiddle` lays the checkbox, image figure, and body out as table cells. Previously the checkbox and body were `vertical-align: middle` while the image figure fell back to the default baseline, so the image never lined up with the rest — and once backorder text grew the row height, the misalignment made rows hard to read. All three cells (`.account-product-checkItem`, `.account-product-figure`, `.account-product-body`) are now `vertical-align: top`, so every cell top-aligns regardless of simple/complex product or whether backorder text is present.
- **Remove the extra vertical gap between backorder rows.** `.account-product-backorder-prompts` dropped its `margin-bottom: spacing("quarter")` (and the now-redundant `:last-of-type` reset) in favour of `margin-bottom: 0`, so "ready to ship / will be backordered / backorder message" read as one tight group instead of a confusingly loose stack.
- **Unify backorder text colour to `#757575`.** Added the colour to `.account-product-backorder-prompts` (was inheriting the too-dark body text) and changed `.account-order-backorder-expectation` from `color("greys", "light")` (`#e1e6eb`, too light) to `#757575`. This now covers qty ready to ship, qty backordered, the backorder message, and the shipping expectation message — all per the ticket's spec colour.

`#757575` is not an existing Citadel grey token (nearest are `#798289` / `#acb3be`), so the literal hex from the ticket is used in both rules.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [BACK-699 — [Stencil My account] Font and layout refinement needed](https://bigcommercecloud.atlassian.net/browse/BACK-699)

#### Screenshots (if appropriate)

<img width="576" height="760" alt="BACK-699-before-after" src="https://github.com/user-attachments/assets/9d3241f1-2375-4079-ae2e-d1ee94b35dee" />


<!-- Drag BACK-699-before-after.png here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only SCSS on the account order details page; no logic, templates, or data handling changes in this diff.
> 
> **Overview**
> **BACK-699** polishes how backorder information looks on **My Account → order details** via `_account.scss` only (plus a Draft **CHANGELOG** entry).
> 
> Backorder-related text (per-line prompts and the order-level shipping expectation) now shares **`#757575`** through a local `$account-backorder-textColor` variable, replacing inherited body color and the previous too-light grey on the expectation line. **`.account-product-backorder-prompts`** no longer adds quarter-spacing between lines so multiple prompts read as one block.
> 
> **`.account-product--alignMiddle`** table cells (checkbox, image, body) are switched from middle/baseline alignment to **`vertical-align: top`**, so taller rows with backorder copy stay aligned at the top.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa13e1b33a3990cb4b4b0319c1cbd09930e6ba28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->