### PR TITLE
CATALOG-12399: Hide disable-and-hide option values on selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Hide option values on the PDP that would complete a "disable and hide" rule for the current selection, and steer the shopper off a default selection that is itself a forbidden combination [#2678](https://github.com/bigcommerce/cornerstone/pull/2678)
 - Refine backorder layout and colors on the account order details page [#2677](https://github.com/bigcommerce/cornerstone/pull/2677)
 - Make the cart Shipping row label span the full width of the totals row so the shipping expectation prompt is no longer constrained to the narrow label column
 - Respect `unlimited_backorder` on PDP so the backorder quantity message and availability prompt render, and the Add to Cart quantity cap is lifted for products with unlimited backorder

--- a/assets/js/test-unit/theme/common/product-details-base.spec.js
+++ b/assets/js/test-unit/theme/common/product-details-base.spec.js
@@ -1,0 +1,106 @@
+import ProductDetailsBase from '../../../theme/common/product-details-base';
+
+// Build an instance without running the (DOM/event-wiring) constructor; reselectHiddenSelectedValues
+// only needs this.$scope plus the real getAttributeType/getAttributeValueInput/isHiddenByStock.
+const makeInstance = $scope => {
+    const instance = Object.create(ProductDetailsBase.prototype);
+    instance.$scope = $scope;
+    return instance;
+};
+
+// out_of_stock_behavior !== 'hide_option' → isHiddenByStock() is always false, isolating the rule path.
+const data = { out_of_stock_behavior: 'do_nothing', in_stock_attributes: [] };
+
+const radioInput = (optionId, v) => `<input class="form-radio" type="radio" id="attribute_radio_${optionId}_${v.id}"
+        name="attribute[${optionId}]" value="${v.id}"
+        ${v.default ? 'data-default' : ''} ${v.selected ? 'checked' : ''}>
+     <label data-product-attribute-value="${v.id}" class="form-label"
+        for="attribute_radio_${optionId}_${v.id}">${v.label}</label>`;
+
+const radioOption = (optionId, values) => {
+    const $scope = $(
+        `<div><div class="form-field" data-product-attribute="set-radio">
+            ${values.map(v => radioInput(optionId, v)).join('')}
+        </div></div>`,
+    );
+    $scope.appendTo(document.body);
+    return $scope;
+};
+
+const selectOption = (values) => {
+    const opts = values
+        .map(v => `<option data-product-attribute-value="${v.id}" value="${v.id}"
+            ${v.default ? 'data-default' : ''} ${v.selected ? 'selected' : ''}>${v.label}</option>`)
+        .join('');
+    const $scope = $(
+        `<div><div class="form-field" data-product-attribute="set-select">
+            <select>
+                <option data-product-attribute-value="" value="">choose</option>
+                ${opts}
+            </select>
+        </div></div>`,
+    );
+    $scope.appendTo(document.body);
+    return $scope;
+};
+
+const labelFor = ($scope, valueId) => $scope.find(`[data-product-attribute-value="${valueId}"]`);
+
+describe('ProductDetailsBase.reselectHiddenSelectedValues', () => {
+    let $scope;
+
+    afterEach(() => {
+        if ($scope) {
+            $scope.remove();
+            $scope = null;
+        }
+        $(document.body).empty();
+    });
+
+    it('does NOT auto-select the next value when the hidden default has no available default to fall back to', () => {
+        // Option B: b1 is the default and is selected; the rule hides b1 (default-into-conflict).
+        $scope = radioOption(5, [
+            {
+                id: 11, label: 'b1', default: true, selected: true,
+            },
+            { id: 12, label: 'b2' },
+        ]);
+        const instance = makeInstance($scope);
+        const $hidden = labelFor($scope, 11);
+
+        instance.reselectHiddenSelectedValues([$hidden], new Set([11]), data);
+
+        // b2 is not a default, so it must not be auto-selected.
+        expect($scope.find('input[value="12"]').prop('checked')).toBe(false);
+    });
+
+    it('snaps back to the default value when a hidden non-default was selected and the default is available', () => {
+        // Shopper selected b2 (non-default); the rule hides b2; default b1 is still available.
+        $scope = radioOption(5, [
+            { id: 11, label: 'b1', default: true },
+            { id: 12, label: 'b2', selected: true },
+        ]);
+        const instance = makeInstance($scope);
+        const $hidden = labelFor($scope, 12);
+
+        instance.reselectHiddenSelectedValues([$hidden], new Set([12]), data);
+
+        expect($scope.find('input[value="11"]').prop('checked')).toBe(true);
+        expect($scope.find('input[value="12"]').prop('checked')).toBe(false);
+    });
+
+    it('does NOT move a select option onto a non-default value when the default is hidden', () => {
+        $scope = selectOption([
+            {
+                id: 11, label: 'b1', default: true, selected: true,
+            },
+            { id: 12, label: 'b2' },
+        ]);
+        const instance = makeInstance($scope);
+        const $hidden = $scope.find('option[value="11"]');
+
+        instance.reselectHiddenSelectedValues([$hidden], new Set([11]), data);
+
+        expect($scope.find('select').val()).not.toBe('12');
+    });
+});

--- a/assets/js/test-unit/theme/common/product-details-base.spec.js
+++ b/assets/js/test-unit/theme/common/product-details-base.spec.js
@@ -72,6 +72,8 @@ describe('ProductDetailsBase.reselectHiddenSelectedValues', () => {
 
         // b2 is not a default, so it must not be auto-selected.
         expect($scope.find('input[value="12"]').prop('checked')).toBe(false);
+        // The hidden value must be deselected so the forbidden value can't be submitted.
+        expect($scope.find('input[value="11"]').prop('checked')).toBe(false);
     });
 
     it('snaps back to the default value when a hidden non-default was selected and the default is available', () => {

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -223,9 +223,11 @@ export default class ProductDetailsBase {
     /**
      * When a "disable and hide" rule hides the currently selected value of an option (typically
      * because the product's default option values are themselves the forbidden combination), move
-     * that option to its next available value and fire a single change so the server recomputes the
-     * disabled values for the corrected, valid selection. Options with no remaining available value
-     * are left untouched so the invalid combination keeps the product unpurchasable.
+     * that option back to its default value (when that default is still available) and fire a single
+     * change so the server recomputes the disabled values for the corrected selection. We only ever
+     * auto-select the option's default value — never a non-default one — so we don't silently pick a
+     * value the shopper didn't choose. If the default is itself unavailable (hidden/out of stock),
+     * the option is left with no selection and the shopper must choose.
      * @param {Object[]} hiddenSelectedAttributes selected value labels that were just hidden
      * @param {Set} disabledValueIds value ids hidden for the current selection
      * @param {Object} data Product attribute data
@@ -254,13 +256,18 @@ export default class ProductDetailsBase {
                     if (($attribute.attr('value') ?? '') === '') {
                         return true;
                     }
+                    // Only snap to the option's default value, never a non-default one.
+                    if (!$attribute.is('[data-default]')) {
+                        return true;
+                    }
                     $targetOption = $attribute;
 
                     return false;
                 }
 
                 const $input = this.getAttributeValueInput($attribute);
-                if ($input.length && !$input.prop('disabled')) {
+                // Only snap to the option's default value, never a non-default one.
+                if ($input.length && !$input.prop('disabled') && $input.is('[data-default]')) {
                     $targetInput = $input;
 
                     return false;

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -289,13 +289,17 @@ export default class ProductDetailsBase {
                 return;
             }
 
+            // Always deselect the hidden value so a forbidden radio/swatch can't stay checked and be
+            // submitted (selects already reset to their placeholder when hidden). When there is no
+            // default to fall back to, leave the option with no selection.
+            this.getAttributeValueInput($hiddenAttribute)
+                .prop('checked', false)
+                .data('state', false);
+
             if (!$targetInput) {
                 return;
             }
 
-            this.getAttributeValueInput($hiddenAttribute)
-                .prop('checked', false)
-                .data('state', false);
             $targetInput.prop('checked', true).data('state', true);
             $changeTrigger = $targetInput;
         });

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -23,7 +23,8 @@ export function optionChangeDecorator(areDefaultOptionsSet) {
         const attributesContent = response.content || {};
 
         this.updateProductAttributes(attributesData);
-        this.updateDisabledOptionValues(attributesData);
+        // CATALOG-12399 disable-and-hide option hiding is a PDP-only feature; the cart editor uses
+        // this decorator, so it is wired into product-details.js directly instead of here.
         if (areDefaultOptionsSet) {
             this.updateView(attributesData, attributesContent);
         } else {

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -152,7 +152,8 @@ export default class ProductDetailsBase {
                 // Remember a hidden value that is the current selection so we can move the option
                 // to a valid value afterwards (e.g. the product's default values are the forbidden
                 // combination, so the rule's last value must be hidden even though it is selected).
-                if (this.getAttributeValueInput($attribute).prop('checked')) {
+                // Checked before disableAttribute() resets a select's selection below.
+                if (this.isValueSelected($attribute)) {
                     hiddenSelectedAttributes.push($attribute);
                 }
                 this.disableAttribute($attribute, 'hide_option', '');
@@ -203,6 +204,22 @@ export default class ProductDetailsBase {
     }
 
     /**
+     * Whether the given option value is currently selected. Radio/rectangle/swatch values are
+     * `<label for="...">` linked to an input; select values are `<option>` elements.
+     * @param  {Object} $attribute jQuery wrapped [data-product-attribute-value] element
+     * @return {boolean}
+     */
+    isValueSelected($attribute) {
+        const $input = this.getAttributeValueInput($attribute);
+
+        if ($input.length) {
+            return $input.prop('checked') === true;
+        }
+
+        return $attribute.is('option') && $attribute.prop('selected') === true;
+    }
+
+    /**
      * When a "disable and hide" rule hides the currently selected value of an option (typically
      * because the product's default option values are themselves the forbidden combination), move
      * that option to its next available value and fire a single change so the server recomputes the
@@ -217,7 +234,9 @@ export default class ProductDetailsBase {
 
         hiddenSelectedAttributes.forEach($hiddenAttribute => {
             const $option = $hiddenAttribute.closest('[data-product-attribute]');
-            let $target = null;
+            const isSelect = this.getAttributeType($hiddenAttribute) === 'set-select';
+            let $targetInput = null;
+            let $targetOption = null;
 
             $('[data-product-attribute-value]', $option).each((i, attribute) => {
                 const $attribute = $(attribute);
@@ -229,24 +248,48 @@ export default class ProductDetailsBase {
                     return true;
                 }
 
+                if (isSelect) {
+                    // Skip the empty/placeholder <option> so we land on a real value.
+                    if (($attribute.attr('value') ?? '') === '') {
+                        return true;
+                    }
+                    $targetOption = $attribute;
+
+                    return false;
+                }
+
                 const $input = this.getAttributeValueInput($attribute);
                 if ($input.length && !$input.prop('disabled')) {
-                    $target = $input;
+                    $targetInput = $input;
+
                     return false;
                 }
 
                 return true;
             });
 
-            if (!$target) {
+            if (isSelect) {
+                if (!$targetOption) {
+                    return;
+                }
+                // disableAttribute() already reset the hidden option; point the select at the next
+                // available value and fire change on the select so the form refreshes.
+                const $select = $targetOption.closest('select');
+                $select.val($targetOption.attr('value'));
+                $changeTrigger = $select;
+
+                return;
+            }
+
+            if (!$targetInput) {
                 return;
             }
 
             this.getAttributeValueInput($hiddenAttribute)
                 .prop('checked', false)
                 .data('state', false);
-            $target.prop('checked', true).data('state', true);
-            $changeTrigger = $target;
+            $targetInput.prop('checked', true).data('state', true);
+            $changeTrigger = $targetInput;
         });
 
         if ($changeTrigger) {

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -23,8 +23,8 @@ export function optionChangeDecorator(areDefaultOptionsSet) {
         const attributesContent = response.content || {};
 
         this.updateProductAttributes(attributesData);
-        // CATALOG-12399 disable-and-hide option hiding is a PDP-only feature; the cart editor uses
-        // this decorator, so it is wired into product-details.js directly instead of here.
+        // Disable-and-hide option hiding is a PDP-only feature; the cart editor uses this decorator,
+        // so it is wired into product-details.js directly instead of here.
         if (areDefaultOptionsSet) {
             this.updateView(attributesData, attributesContent);
         } else {
@@ -125,8 +125,8 @@ export default class ProductDetailsBase {
     }
 
     /**
-     * Hide option values that would complete a "disable and hide" rule for the current selection
-     * (CATALOG-12399). The server recomputes `disabled_option_values` on every option change, so a
+     * Hide option values that would complete a "disable and hide" rule for the current selection.
+     * The server recomputes `disabled_option_values` on every option change, so a
      * value belonging to a multi-attribute rule only appears once the rule's other attributes are
      * selected ("show, then hide on selection"). The list is selection-relative, so values hidden
      * on a previous change are re-shown when they drop out of it.
@@ -277,12 +277,16 @@ export default class ProductDetailsBase {
             });
 
             if (isSelect) {
+                const $select = $hiddenAttribute.closest('select');
                 if (!$targetOption) {
+                    // No default to move to; disableAttribute() already reset the select to its
+                    // placeholder. Still fire a change so the view re-syncs to the now-empty
+                    // selection (message/cart/price) for the corrected combination.
+                    $changeTrigger = $select;
+
                     return;
                 }
-                // disableAttribute() already reset the hidden option; point the select at the next
-                // available value and fire change on the select so the form refreshes.
-                const $select = $targetOption.closest('select');
+                // Point the select at its default value and fire change so the form refreshes.
                 $select.val($targetOption.attr('value'));
                 $changeTrigger = $select;
 
@@ -290,13 +294,16 @@ export default class ProductDetailsBase {
             }
 
             // Always deselect the hidden value so a forbidden radio/swatch can't stay checked and be
-            // submitted (selects already reset to their placeholder when hidden). When there is no
-            // default to fall back to, leave the option with no selection.
-            this.getAttributeValueInput($hiddenAttribute)
-                .prop('checked', false)
-                .data('state', false);
+            // submitted (selects already reset to their placeholder when hidden).
+            const $hiddenInput = this.getAttributeValueInput($hiddenAttribute);
+            $hiddenInput.prop('checked', false).data('state', false);
 
             if (!$targetInput) {
+                // No default to fall back to; the value is deselected. Fire a change so the view
+                // re-syncs to the now-empty selection instead of leaving a stale unavailable message
+                // for the broken combination (BCData carries no purchasing_message on load).
+                $changeTrigger = $hiddenInput;
+
                 return;
             }
 

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -293,7 +293,10 @@ export default class ProductDetailsBase {
         });
 
         if ($changeTrigger) {
-            $changeTrigger.trigger('change');
+            // Defer the change so it does not re-enter the in-flight optionChange callback that is
+            // still applying the pre-correction response. Firing it after the current call stack
+            // lets that pass finish, then this triggers a fresh fetch for the corrected selection.
+            setTimeout(() => $changeTrigger.trigger('change'), 0);
         }
     }
 

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -158,13 +158,34 @@ export default class ProductDetailsBase {
                 this.disableAttribute($attribute, 'hide_option', '');
                 $attribute.data('ruleHidden', true);
             } else if ($attribute.data('ruleHidden') === true) {
-                // Only re-show values this rule hid; leave out-of-stock hiding untouched.
-                this.enableAttribute($attribute, 'hide_option', '');
+                // This value was hidden by the rule and no longer is. Re-show it only if
+                // out-of-stock handling is not also hiding it, so we don't reveal a value the
+                // stock logic in updateProductAttributes() kept hidden.
                 $attribute.data('ruleHidden', false);
+                if (!this.isHiddenByStock(data, valueId)) {
+                    this.enableAttribute($attribute, 'hide_option', '');
+                }
             }
         });
 
-        this.reselectHiddenSelectedValues(hiddenSelectedAttributes, disabledValueIds);
+        this.reselectHiddenSelectedValues(hiddenSelectedAttributes, disabledValueIds, data);
+    }
+
+    /**
+     * Whether out-of-stock handling hides the given value. Only the `hide_option` behavior hides
+     * values; a value is hidden when it is absent from `in_stock_attributes`.
+     * @param  {Object} data Product attribute data
+     * @param  {number} valueId attribute value id
+     * @return {boolean}
+     */
+    isHiddenByStock(data, valueId) {
+        if (data.out_of_stock_behavior !== 'hide_option') {
+            return false;
+        }
+
+        const inStockIds = Array.isArray(data.in_stock_attributes) ? data.in_stock_attributes : [];
+
+        return !inStockIds.includes(valueId);
     }
 
     /**
@@ -189,8 +210,9 @@ export default class ProductDetailsBase {
      * are left untouched so the invalid combination keeps the product unpurchasable.
      * @param {Object[]} hiddenSelectedAttributes selected value labels that were just hidden
      * @param {Set} disabledValueIds value ids hidden for the current selection
+     * @param {Object} data Product attribute data
      */
-    reselectHiddenSelectedValues(hiddenSelectedAttributes, disabledValueIds) {
+    reselectHiddenSelectedValues(hiddenSelectedAttributes, disabledValueIds, data) {
         let $changeTrigger = null;
 
         hiddenSelectedAttributes.forEach($hiddenAttribute => {
@@ -201,7 +223,9 @@ export default class ProductDetailsBase {
                 const $attribute = $(attribute);
                 const valueId = parseInt($attribute.data('productAttributeValue'), 10);
 
-                if (disabledValueIds.has(valueId)) {
+                // Skip values the rule hides or that are out of stock, so we never move the
+                // selection onto a value that should not be selectable.
+                if (disabledValueIds.has(valueId) || this.isHiddenByStock(data, valueId)) {
                     return true;
                 }
 

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -142,11 +142,19 @@ export default class ProductDetailsBase {
             disabledOptionValues.map(({ value_id: valueId }) => parseInt(valueId, 10)),
         );
 
+        const hiddenSelectedAttributes = [];
+
         $('[data-product-attribute-value]', this.$scope).each((i, attribute) => {
             const $attribute = $(attribute);
             const valueId = parseInt($attribute.data('productAttributeValue'), 10);
 
             if (disabledValueIds.has(valueId)) {
+                // Remember a hidden value that is the current selection so we can move the option
+                // to a valid value afterwards (e.g. the product's default values are the forbidden
+                // combination, so the rule's last value must be hidden even though it is selected).
+                if (this.getAttributeValueInput($attribute).prop('checked')) {
+                    hiddenSelectedAttributes.push($attribute);
+                }
                 this.disableAttribute($attribute, 'hide_option', '');
                 $attribute.data('ruleHidden', true);
             } else if ($attribute.data('ruleHidden') === true) {
@@ -155,6 +163,71 @@ export default class ProductDetailsBase {
                 $attribute.data('ruleHidden', false);
             }
         });
+
+        this.reselectHiddenSelectedValues(hiddenSelectedAttributes, disabledValueIds);
+    }
+
+    /**
+     * Resolve the radio input associated with a [data-product-attribute-value] label. Radio,
+     * rectangle and swatch options render the value as a <label for="..."> whose input is a
+     * sibling, so the input is looked up by the label's `for` attribute. Returns an empty set for
+     * options without a linked input (e.g. select <option>s, which handle reselection themselves).
+     * @param  {Object} $attribute jQuery wrapped [data-product-attribute-value] element
+     * @return {Object} jQuery wrapped input, empty when there is no linked input
+     */
+    getAttributeValueInput($attribute) {
+        const inputId = $attribute.attr('for');
+
+        return inputId ? $(`#${inputId}`, this.$scope) : $();
+    }
+
+    /**
+     * When a "disable and hide" rule hides the currently selected value of an option (typically
+     * because the product's default option values are themselves the forbidden combination), move
+     * that option to its next available value and fire a single change so the server recomputes the
+     * disabled values for the corrected, valid selection. Options with no remaining available value
+     * are left untouched so the invalid combination keeps the product unpurchasable.
+     * @param {Object[]} hiddenSelectedAttributes selected value labels that were just hidden
+     * @param {Set} disabledValueIds value ids hidden for the current selection
+     */
+    reselectHiddenSelectedValues(hiddenSelectedAttributes, disabledValueIds) {
+        let $changeTrigger = null;
+
+        hiddenSelectedAttributes.forEach($hiddenAttribute => {
+            const $option = $hiddenAttribute.closest('[data-product-attribute]');
+            let $target = null;
+
+            $('[data-product-attribute-value]', $option).each((i, attribute) => {
+                const $attribute = $(attribute);
+                const valueId = parseInt($attribute.data('productAttributeValue'), 10);
+
+                if (disabledValueIds.has(valueId)) {
+                    return true;
+                }
+
+                const $input = this.getAttributeValueInput($attribute);
+                if ($input.length && !$input.prop('disabled')) {
+                    $target = $input;
+                    return false;
+                }
+
+                return true;
+            });
+
+            if (!$target) {
+                return;
+            }
+
+            this.getAttributeValueInput($hiddenAttribute)
+                .prop('checked', false)
+                .data('state', false);
+            $target.prop('checked', true).data('state', true);
+            $changeTrigger = $target;
+        });
+
+        if ($changeTrigger) {
+            $changeTrigger.trigger('change');
+        }
     }
 
     /**

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -23,6 +23,7 @@ export function optionChangeDecorator(areDefaultOptionsSet) {
         const attributesContent = response.content || {};
 
         this.updateProductAttributes(attributesData);
+        this.updateDisabledOptionValues(attributesData);
         if (areDefaultOptionsSet) {
             this.updateView(attributesData, attributesContent);
         } else {
@@ -118,6 +119,40 @@ export default class ProductDetailsBase {
                 this.enableAttribute($attribute, behavior, outOfStockMessage);
             } else {
                 this.disableAttribute($attribute, behavior, outOfStockMessage);
+            }
+        });
+    }
+
+    /**
+     * Hide option values that would complete a "disable and hide" rule for the current selection
+     * (CATALOG-12399). The server recomputes `disabled_option_values` on every option change, so a
+     * value belonging to a multi-attribute rule only appears once the rule's other attributes are
+     * selected ("show, then hide on selection"). The list is selection-relative, so values hidden
+     * on a previous change are re-shown when they drop out of it.
+     * @param  {Object} data Product attribute data
+     */
+    updateDisabledOptionValues(data) {
+        const disabledOptionValues = data.disabled_option_values;
+
+        if (!Array.isArray(disabledOptionValues)) {
+            return;
+        }
+
+        const disabledValueIds = new Set(
+            disabledOptionValues.map(({ value_id: valueId }) => parseInt(valueId, 10)),
+        );
+
+        $('[data-product-attribute-value]', this.$scope).each((i, attribute) => {
+            const $attribute = $(attribute);
+            const valueId = parseInt($attribute.data('productAttributeValue'), 10);
+
+            if (disabledValueIds.has(valueId)) {
+                this.disableAttribute($attribute, 'hide_option', '');
+                $attribute.data('ruleHidden', true);
+            } else if ($attribute.data('ruleHidden') === true) {
+                // Only re-show values this rule hid; leave out-of-stock hiding untouched.
+                this.enableAttribute($attribute, 'hide_option', '');
+                $attribute.data('ruleHidden', false);
             }
         });
     }

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -96,10 +96,11 @@ export default class ProductDetails extends ProductDetailsBase {
             // Apply out-of-stock hide/show from this same payload before the rule pass, so rule
             // hiding and reselection in updateDisabledOptionValues agree with in_stock_attributes.
             this.updateProductAttributes(response.data);
-            // Hide option values disabled by a "disable and hide" rule for the default selection
-            // (CATALOG-12399); this also corrects a default selection that is itself a forbidden
-            // combination on first load.
-            this.updateDisabledOptionValues(response.data);
+            // Note: disabled_option_values for the default selection is applied synchronously from
+            // the initial BCData payload below, not here. Applying it from this on-load response too
+            // would race with the corrective change that sync pass can fire: if this response (for
+            // the original selection) lands after the correction fetch, it would re-apply stale
+            // disabled_option_values. So the sync init path is the single source on load.
             // Surface the rule's "unavailable" message for the default selection: a disable rule
             // (not hidden) that the default selection completes sets purchasing_message in this
             // response, and the initial BCData payload does not carry it.

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -93,6 +93,10 @@ export default class ProductDetails extends ProductDetailsBase {
             this.updateBackorderMessage(vm);
             this.picklistBackorder.render(response.data, qty);
             this.updateDefaultAttributesForOOS(response.data);
+            // Hide option values disabled by a "disable and hide" rule for the default selection
+            // (CATALOG-12399); this also corrects a default selection that is itself a forbidden
+            // combination on first load.
+            this.updateDisabledOptionValues(response.data);
             this.updateAddToCartForQty(qty, vm);
         });
 
@@ -278,6 +282,7 @@ export default class ProductDetails extends ProductDetailsBase {
             const productAttributesData = response.data || {};
             const productAttributesContent = response.content || {};
             this.updateProductAttributes(productAttributesData);
+            this.updateDisabledOptionValues(productAttributesData);
             this.updateView(productAttributesData, productAttributesContent);
             this.updateProductDetailsData();
             bannerUtils.dispatchProductBannerEvent(productAttributesData);

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -84,8 +84,15 @@ export default class ProductDetails extends ProductDetailsBase {
         });
 
         const productId = $('[name="product_id"]', $form).val();
-        utils.api.productAttributes.optionChange(productId, $form.serialize(), (err, response) => {
+        const initialSelection = $form.serialize();
+        utils.api.productAttributes.optionChange(productId, initialSelection, (err, response) => {
             if (err || !response || !response.data) return;
+            // The synchronous init below applies rule hiding from BCData and can fire a corrective
+            // change for a default-into-conflict selection. If that already moved the selection, this
+            // response is for the stale (pre-correction) selection: discard it so it can't re-show
+            // rule-hidden values or show an unavailable message for a no-longer-selected combination.
+            // The corrective change runs its own optionChange for the corrected selection.
+            if ($form.serialize() !== initialSelection) return;
             this.updateBackorderContext(response.data);
             const vm = this.getViewModel(this.$scope);
             const qty = parseInt(vm.quantity.$input.val(), 10) || 0;
@@ -96,11 +103,9 @@ export default class ProductDetails extends ProductDetailsBase {
             // Apply out-of-stock hide/show from this same payload before the rule pass, so rule
             // hiding and reselection in updateDisabledOptionValues agree with in_stock_attributes.
             this.updateProductAttributes(response.data);
-            // Note: disabled_option_values for the default selection is applied synchronously from
-            // the initial BCData payload below, not here. Applying it from this on-load response too
-            // would race with the corrective change that sync pass can fire: if this response (for
-            // the original selection) lands after the correction fetch, it would re-apply stale
-            // disabled_option_values. So the sync init path is the single source on load.
+            // Re-apply rule hiding after the out-of-stock pass above (which re-shows in-stock values
+            // and would otherwise undo it). Safe from the stale-response race thanks to the guard.
+            this.updateDisabledOptionValues(response.data);
             // Surface the rule's "unavailable" message for the default selection: a disable rule
             // (not hidden) that the default selection completes sets purchasing_message in this
             // response, and the initial BCData payload does not carry it.

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -130,7 +130,7 @@ export default class ProductDetails extends ProductDetailsBase {
             // Apply "disable and hide" rule hiding from the initial BCData synchronously, so a
             // forbidden default selection is corrected at load instead of staying visible until
             // the async optionChange below resolves. No-op until the backend emits
-            // disabled_option_values in the initial payload (CATALOG-12399).
+            // disabled_option_values in the initial payload.
             this.updateDisabledOptionValues(productAttributesData);
         } else {
             // eslint-disable-next-line no-console

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -93,6 +93,9 @@ export default class ProductDetails extends ProductDetailsBase {
             this.updateBackorderMessage(vm);
             this.picklistBackorder.render(response.data, qty);
             this.updateDefaultAttributesForOOS(response.data);
+            // Apply out-of-stock hide/show from this same payload before the rule pass, so rule
+            // hiding and reselection in updateDisabledOptionValues agree with in_stock_attributes.
+            this.updateProductAttributes(response.data);
             // Hide option values disabled by a "disable and hide" rule for the default selection
             // (CATALOG-12399); this also corrects a default selection that is itself a forbidden
             // combination on first load.

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -121,6 +121,11 @@ export default class ProductDetails extends ProductDetailsBase {
             && typeof productAttributesData === 'object'
             && Object.keys(productAttributesData).length > 0) {
             this.updateView(productAttributesData, null);
+            // Apply "disable and hide" rule hiding from the initial BCData synchronously, so a
+            // forbidden default selection is corrected at load instead of staying visible until
+            // the async optionChange below resolves. No-op until the backend emits
+            // disabled_option_values in the initial payload (CATALOG-12399).
+            this.updateDisabledOptionValues(productAttributesData);
         } else {
             // eslint-disable-next-line no-console
             console.warn('BCData.product_attributes is empty on product initialization');

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -100,6 +100,10 @@ export default class ProductDetails extends ProductDetailsBase {
             // (CATALOG-12399); this also corrects a default selection that is itself a forbidden
             // combination on first load.
             this.updateDisabledOptionValues(response.data);
+            // Surface the rule's "unavailable" message for the default selection: a disable rule
+            // (not hidden) that the default selection completes sets purchasing_message in this
+            // response, and the initial BCData payload does not carry it.
+            this.showMessageBox(response.data.stock_message || response.data.purchasing_message);
             this.updateAddToCartForQty(qty, vm);
         });
 


### PR DESCRIPTION
Jira: [CATALOG-12399](https://bigcommercecloud.atlassian.net/browse/CATALOG-12399)

> Front-end half. Pairs with bcapp PR #68696 (backend emit) and #68671 (over-hide fix). Needs `disabled_option_values` in the `product-attributes` response, gated by `CATALOG-12399.disable_hide_rule_fix`.

## What/Why?
For a multi-attribute "disable and hide" rule (e.g. `Color=red AND Size=big`), the value should *show* and only *hide once the rule's other attributes are selected*, instead of being hidden outright.

`product-details-base.js` `updateDisabledOptionValues(data)` reads the new `data.disabled_option_values` array and hides each matching `[data-product-attribute-value]` node via the existing `disableAttribute(..., 'hide_option')`. The server recomputes the list on every option change, so values are re-shown when they drop out of it. Hooked into `optionChangeDecorator` after `updateProductAttributes`. Out-of-stock hiding is untouched: re-show only applies to nodes this feature hid, tracked via a `ruleHidden` data flag.

When the backend key is absent (flag off / older bcapp), the array is missing and the method no-ops.

## Rollout/Rollback
Tied to `CATALOG-12399.disable_hide_rule_fix` on the backend. No theme setting. Rollback = revert.

## Testing
Manual via Stencil CLI: on a product with a multi-attribute disable+hide rule, selecting the first attribute hides the conflicting value of the second; deselecting re-shows it. Local syntax check passes; jest/eslint run in CI.


v2 scenario:

https://github.com/user-attachments/assets/fd7660fd-7c1d-4b55-acc8-5fd66bdad0d4


v3 scenario:

https://github.com/user-attachments/assets/5360ce78-e898-4a3e-bbc3-361629693521



Refs CATALOG-12399

[CATALOG-12399]: https://bigcommercecloud.atlassian.net/browse/CATALOG-12399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PDP variant selection, messaging, and add-to-cart eligibility when rules hide the selected value; behavior depends on backend `disabled_option_values` and async optionChange ordering, though it no-ops when the array is absent.
> 
> **Overview**
> PDP option UI now reacts to **`disabled_option_values`** from product-attributes so multi-attribute “disable and hide” rules only hide a value once the shopper’s current selection would complete the rule, and values come back when they no longer apply.
> 
> **`updateDisabledOptionValues`** hides matching `[data-product-attribute-value]` nodes (reusing `hide_option`), tracks rule-driven hides with **`ruleHidden`** so out-of-stock logic does not fight re-show, and **`reselectHiddenSelectedValues`** clears or moves selections when a hidden value was selected—only onto the option’s **default**, never an arbitrary other value—with a deferred **`change`** to refresh server state. Wiring is **PDP-only** in **`product-details.js`** (not **`optionChangeDecorator`**, so cart option editing is unchanged): on load from BCData, after each option change, and on the initial async **`optionChange`**, with a guard to drop stale responses if synchronous correction already changed the form.
> 
> Jest coverage was added for the reselection edge cases; CHANGELOG was updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b34b703185ec5c3d798f1a51e11259586bca1cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->