### PR TITLE
feat(orders): ORDERS-7707 improve create return page design for mobile/tablet views

### DIFF
--- a/assets/scss/components/stencil/createReturn/_createReturn.scss
+++ b/assets/scss/components/stencil/createReturn/_createReturn.scss
@@ -25,20 +25,24 @@
 }
 
 .newReturn-title {
-    font-size: remCalc(28px);
+    font-size: remCalc(22px); // mobile: 6px smaller than the desktop/tablet size
     font-weight: fontWeight("bold");
     margin: 0;
+
+    @include breakpoint("medium") {
+        font-size: remCalc(28px);
+    }
 }
 
 .newReturn-statusBadge {
     display: inline-block;
-    padding: spacing("eighth") spacing("quarter");
-    border: remCalc(1.5px) solid color("orderStatus", "completed");
-    border-radius: remCalc(4px);
+    padding: spacing("eighth") spacing("half");
+    border-radius: remCalc(12px);
+    background-color: color("success", "light");
     font-size: remCalc(11px);
     font-weight: fontWeight("bold");
     letter-spacing: remCalc(1px);
-    color: color("orderStatus", "completed");
+    color: stencilColor("color-textBase");
     text-transform: uppercase;
 }
 
@@ -46,6 +50,11 @@
     display: flex;
     align-items: center;
     gap: spacing("half");
+    order: 2; // mobile: sits after the order date
+
+    @include breakpoint("medium") {
+        order: 0; // tablet/desktop: back to its natural position (above the order date)
+    }
 }
 
 .newReturn-headerActions .button {
@@ -55,9 +64,15 @@
 }
 
 .newReturn-orderDate {
+    flex-basis: 100%; // always on its own line within the header
+    order: 1; // mobile: above the action buttons
     font-size: remCalc(13px);
     color: color("greys", "base");
     margin: spacing("eighth") 0 spacing("single") * 0.83;
+
+    @include breakpoint("medium") {
+        order: 0; // tablet/desktop: below the buttons (natural DOM order)
+    }
 }
 
 .newReturn-divider {
@@ -67,15 +82,25 @@
 }
 
 
+// Shared widths — keep the desktop header labels and control cells in sync.
+$newReturn-col-qty:             remCalc(120px); // desktop quantity column (select + "of N")
+$newReturn-col-select:          remCalc(240px); // desktop resolution/reason columns — fits the placeholder text
+$newReturn-qty-width:           remCalc(80px);  // quantity <select> width — consistent across all breakpoints
+$newReturn-col-controls-tablet: remCalc(320px); // tablet controls column — wide enough for the placeholder text
+
+
 .newReturn-orderLineItem {
     display: flex;
-    align-items: flex-start; // controls column is tallest when stacked (mobile/tablet)
+    flex-wrap: wrap; // mobile: thumbnail + info on top, controls wrap to a full-width row below
+    align-items: flex-start;
     gap: remCalc(16px);
     padding: remCalc(16px) 0;
 
-    @include breakpoint("large") {
-        align-items: center; // desktop: everything inline so vertical-center is fine
+    @include breakpoint("medium") {
+        flex-wrap: nowrap; // tablet: controls sit beside the info as a stacked column
     }
+    // Stays top-aligned across breakpoints so the controls don't drift to the middle
+    // when an item has several variant/option lines.
 }
 
 .newReturn-orderLineItemThumbnailWrapper {
@@ -121,25 +146,30 @@
 
 .newReturn-orderLineItemControls {
     display: flex;
-    flex-direction: column;
-    align-items: stretch;
+    flex-wrap: wrap;
+    align-items: center;
     gap: spacing("quarter");
-    flex-shrink: 0;
-    width: remCalc(180px);
+    flex-basis: 100%;
+    width: 100%;
 
+    // tablet view
+    @include breakpoint("medium") {
+        flex-wrap: nowrap;
+        flex-direction: column;
+        align-items: stretch;
+        flex-basis: auto;
+        flex-shrink: 0;
+        width: $newReturn-col-controls-tablet;
+        padding-left: spacing("half");
+    }
+
+    // desktop view
     @include breakpoint("large") {
         flex-direction: row;
         align-items: center;
         gap: spacing("half");
         width: auto;
-    }
-}
-
-.newReturn-divider--headers {
-    display: none;
-
-    @include breakpoint("large") {
-        display: block;
+        padding-left: 0;
     }
 }
 
@@ -150,6 +180,7 @@
         display: flex;
         align-items: center;
         gap: remCalc(16px);
+        padding-bottom: remCalc(16px);
         font-size: remCalc(12px);
         font-weight: fontWeight("semibold");
         color: color("greys", "base");
@@ -173,10 +204,6 @@
     gap: spacing("half");
 }
 
-// Shared widths — keeps header labels and control cells in sync.
-$newReturn-col-qty:     remCalc(120px);
-$newReturn-col-select:  remCalc(200px);
-
 .newReturn-columnHeaders-quantity {
     width: $newReturn-col-qty;
     flex-shrink: 0;
@@ -188,14 +215,31 @@ $newReturn-col-select:  remCalc(200px);
     flex-shrink: 0;
 }
 
+.newReturn-controlLabel {
+    display: none;
+
+    @include breakpoint("medium") {
+        display: block;
+        font-size: remCalc(12px);
+        font-weight: fontWeight("semibold");
+        color: color("greys", "base");
+        letter-spacing: remCalc(0.5px);
+        margin-bottom: remCalc(-4px);
+    }
+
+    @include breakpoint("large") {
+        display: none;
+    }
+}
+
 .newReturn-orderLineItemQtyWrapper {
     display: flex;
     align-items: center;
     gap: spacing("quarter");
+    flex-shrink: 0;
 
     @include breakpoint("large") {
         width: $newReturn-col-qty;
-        flex-shrink: 0;
     }
 }
 
@@ -206,20 +250,39 @@ $newReturn-col-select:  remCalc(200px);
 }
 
 .newReturn-orderLineItemControls [id^="qty-"] {
-    width: 100%;
-
-    @include breakpoint("large") {
-        width: auto;
-    }
+    width: $newReturn-qty-width;
+    flex-shrink: 0;
 }
 
-.newReturn-orderLineItemControls [id^="resolution-"],
-.newReturn-orderLineItemControls [id^="reason-"] {
-    width: 100%;
+.newReturn-orderLineItemControls [id^="resolution-"] {
+    flex: 1 1 auto; // mobile: fill the rest of the first card row beside quantity
+    width: auto;
+    max-width: none;
+    min-width: 0;
+
+    @include breakpoint("medium") {
+        flex: 0 0 auto; // tablet: full-width within the stacked column
+        width: 100%;
+    }
 
     @include breakpoint("large") {
         width: $newReturn-col-select;
-        flex-shrink: 0;
+    }
+}
+
+.newReturn-orderLineItemControls [id^="reason-"] {
+    flex-basis: 100%; // mobile: wraps onto its own full-width row below qty + resolution
+    width: 100%;
+    max-width: none;
+
+    @include breakpoint("medium") {
+        flex-basis: auto;
+        width: 100%;
+    }
+
+    @include breakpoint("large") {
+        flex: 0 0 auto;
+        width: $newReturn-col-select;
     }
 }
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -339,7 +339,7 @@
                 "back_button": "Go back",
                 "order_item": "Item",
                 "item_price": "Price",
-                "quantity": "Qty To Return",
+                "quantity": "Quantity",
                 "of_max": "of {max}",
                 "items_label": "Items in this order",
                 "why": "Why are you returning these items?",

--- a/templates/pages/create-return.html
+++ b/templates/pages/create-return.html
@@ -14,8 +14,8 @@
             <a href="{{../urls.account.orders.all}}" class="button">{{lang 'account.returns.back'}}</a>
             <a href="/return-policy" class="button button--primary">{{lang 'account.returns.view_return_policy'}} &rarr;</a>
         </div>
+        {{#if date}}<p class="newReturn-orderDate">{{lang 'account.returns.order_date'}}: {{date}}</p>{{/if}}
     </div>
-    {{#if date}}<p class="newReturn-orderDate">{{lang 'account.returns.order_date'}}: {{date}}</p>{{/if}}
 
     <hr class="newReturn-divider">
 
@@ -30,8 +30,6 @@
                 <span class="newReturn-columnHeaders-reason">{{lang 'account.returns.reason_header'}}</span>
             </div>
         </div>
-
-        <hr class="newReturn-divider newReturn-divider--headers">
 
         {{#each items}}
             <div class="newReturn-orderLineItem" data-item-id="{{id}}">
@@ -59,6 +57,7 @@
                 </div>
 
                 <div class="newReturn-orderLineItemControls">
+                    <label class="newReturn-controlLabel" for="qty-{{id}}">{{lang 'account.orders.return.quantity'}}</label>
                     <div class="newReturn-orderLineItemQtyWrapper">
                         <select class="form-select form-select--small form-select--short"
                                 id="qty-{{id}}"
@@ -69,12 +68,14 @@
                         </select>
                         <span class="newReturn-orderLineItemMaxQty">{{lang 'account.orders.return.of_max' max=returnableQuantity}}</span>
                     </div>
+                    <label class="newReturn-controlLabel" for="resolution-{{id}}">{{lang 'account.returns.request'}}</label>
                     <select class="form-select form-select--small" id="resolution-{{id}}" aria-label="{{lang 'account.returns.select_resolution'}}">
                         <option value="">{{lang 'account.returns.select_resolution'}}</option>
                         {{#each ../../resolutions}}
                             <option value="{{resolutionType}}">{{label}}</option>
                         {{/each}}
                     </select>
+                    <label class="newReturn-controlLabel" for="reason-{{id}}">{{lang 'account.returns.reason_header'}}</label>
                     <select class="form-select form-select--small" id="reason-{{id}}" aria-label="{{lang 'account.returns.select_reason'}}">
                         <option value="">{{lang 'account.returns.select_reason'}}</option>
                         {{#each ../../reasons}}


### PR DESCRIPTION
#### What?

This PR improves the design of the create return page for mobile and tablet views



#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [Link 1](http://example.com)
- ...

#### Screenshots (if appropriate)

Desktop
<img width="2566" height="1466" alt="image" src="https://github.com/user-attachments/assets/0b0a8c7d-7172-4d51-85e6-007ec8d01231" />


Tablet
<img width="1008" height="992" alt="image" src="https://github.com/user-attachments/assets/c3278425-ada3-4db7-81f3-05c9250c82e1" />


Mobile
<img width="323" height="718" alt="image" src="https://github.com/user-attachments/assets/a8aff683-8b09-421d-92b1-96c420b2b23b" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to SCSS, template markup, and a single locale string; return form JS and submission flow are untouched.
> 
> **Overview**
> **Responsive layout and styling** for the account **create return** page so header, line items, and quantity/resolution/reason controls read clearly on mobile and tablet without changing form behavior.
> 
> The header **reorders** on small screens (order date above action buttons), uses a **smaller title** on mobile, and moves the order date **inside** the header flex container. The status badge switches from an outlined style to a **filled success** pill.
> 
> Line items **wrap** on mobile (product info on top, controls full-width below), use a **stacked controls column** on tablet, and keep the **desktop row** with wider synced column widths. **Tablet-only visible labels** were added for each select (hidden on desktop where column headers show); the extra divider under desktop headers was removed.
> 
> Copy updates the quantity column/label string from **"Qty To Return"** to **"Quantity"**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 372a2e0002c4e7e564e33df02e8c82c0ef0c7bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->