### PR TITLE
feat(account): BACK-692 show picklist backorder prompts on order details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Render per-picklist-option backorder prompts (backordered quantity and backorder message) on the account order details page, mirroring the PDP bundle backorder display
 - Refine backorder layout and colors on the account order details page [#2677](https://github.com/bigcommerce/cornerstone/pull/2677)
 - Make the cart Shipping row label span the full width of the totals row so the shipping expectation prompt is no longer constrained to the narrow label column
 - Respect `unlimited_backorder` on PDP so the backorder quantity message and availability prompt render, and the Add to Cart quantity cap is lifted for products with unlimited backorder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
-- Render per-picklist-option backorder prompts (backordered quantity and backorder message) on the account order details page, mirroring the PDP bundle backorder display
+- Show backorder prompts on the account order details page for both the parent product (under the product title) and each picklist option, mirroring the PDP backorder display
 - Refine backorder layout and colors on the account order details page [#2677](https://github.com/bigcommerce/cornerstone/pull/2677)
 - Make the cart Shipping row label span the full width of the totals row so the shipping expectation prompt is no longer constrained to the narrow label column
 - Respect `unlimited_backorder` on PDP so the backorder quantity message and availability prompt render, and the Add to Cart quantity cap is lifted for products with unlimited backorder

--- a/templates/components/account/order-contents.html
+++ b/templates/components/account/order-contents.html
@@ -54,6 +54,15 @@
                 {{#if brand}}
                     <h6>{{brand.name}}</h6>
                 {{/if}}
+                {{#if quantity_backordered '>' 0}}
+                    {{#if (subtract quantity quantity_backordered) '>' 0}}
+                        <p class="account-product-backorder-prompts">{{lang 'products.quantity_on_hand' quantity=(subtract quantity quantity_backordered)}}</p>
+                    {{/if}}
+                    <p class="account-product-backorder-prompts">{{lang 'products.quantity_backordered' quantity=quantity_backordered}}</p>
+                    {{#if backorder_message}}
+                        <p class="account-product-backorder-prompts">{{backorder_message}}</p>
+                    {{/if}}
+                {{/if}}
                 {{#if options}}
                 <dl class="definitionList">
                     {{#each options}}
@@ -86,15 +95,6 @@
                             {{event_date.date}}
                         </dd>
                     </dl>
-                {{/if}}
-                {{#if quantity_backordered '>' 0}}
-                    {{#if (subtract quantity quantity_backordered) '>' 0}}
-                        <p class="account-product-backorder-prompts">{{lang 'products.quantity_on_hand' quantity=(subtract quantity quantity_backordered)}}</p>
-                    {{/if}}
-                    <p class="account-product-backorder-prompts">{{lang 'products.quantity_backordered' quantity=quantity_backordered}}</p>
-                    {{#if backorder_message}}
-                        <p class="account-product-backorder-prompts">{{backorder_message}}</p>
-                    {{/if}}
                 {{/if}}
                 {{#if refunded}}
                     <p class="account-product-refundQty">{{lang 'account.orders.refunded_quantity' qty=refunded_qty}}</p>

--- a/templates/components/account/order-contents.html
+++ b/templates/components/account/order-contents.html
@@ -67,15 +67,7 @@
                 <dl class="definitionList">
                     {{#each options}}
                         <dt class="definitionList-key">{{name}}:</dt>
-                        <dd class="definitionList-value">
-                            {{> components/common/product-options}}
-                            {{#if quantity_backordered '>' 0}}
-                                <p class="account-product-backorder-prompts">{{lang 'products.quantity_backordered' quantity=quantity_backordered}}</p>
-                                {{#if backorder_message}}
-                                    <p class="account-product-backorder-prompts">{{backorder_message}}</p>
-                                {{/if}}
-                            {{/if}}
-                        </dd>
+                        <dd class="definitionList-value">{{> components/common/product-options}}</dd>
                     {{/each}}
                 </dl>
                 {{/if}}

--- a/templates/components/account/order-contents.html
+++ b/templates/components/account/order-contents.html
@@ -58,7 +58,15 @@
                 <dl class="definitionList">
                     {{#each options}}
                         <dt class="definitionList-key">{{name}}:</dt>
-                        <dd class="definitionList-value">{{> components/common/product-options}}</dd>
+                        <dd class="definitionList-value">
+                            {{> components/common/product-options}}
+                            {{#if quantity_backordered '>' 0}}
+                                <p class="account-product-backorder-prompts">{{lang 'products.quantity_backordered' quantity=quantity_backordered}}</p>
+                                {{#if backorder_message}}
+                                    <p class="account-product-backorder-prompts">{{backorder_message}}</p>
+                                {{/if}}
+                            {{/if}}
+                        </dd>
                     {{/each}}
                 </dl>
                 {{/if}}


### PR DESCRIPTION
#### What?

Renders backorder prompts **per picklist (bundle) option** on the account order details page (`templates/components/account/order-contents.html`), so each backordered bundle option displays its own backorder status — mirroring how the PDP renders per-bundle backorder.

Previously each option only rendered its name/value via the `product-options` partial. Now, inside the `{{#each options}}` loop, when an option has `quantity_backordered > 0` it additionally renders:

- `{quantity} will be backordered` (via the `products.quantity_backordered` lang string)
- the per-option `backorder_message`, when present

This matches the PDP bundle backorder display (`assets/js/theme/common/picklist-backorder.js`), which shows only the backordered quantity and message per option — there is intentionally **no** per-option "ready to ship" line. The existing **item-level** backorder block (ready to ship + backordered + message for the whole line item) is unchanged.

Technical notes for reviewers:
- The option name is already rendered as the `<dt>` key, so the combined output reads like the PDP's `"<Option name>: N will be backordered"` + message.
- An earlier iteration of this block also rendered a per-option `quantity_on_hand` ("ready to ship") line using `(subtract quantity quantity_backordered)`. That was removed: the PDP doesn't show it per option, and inside `{{#each options}}` the `quantity` token resolves against the option context (not the line item), so the math was unreliable.
- This depends on the platform exposing `quantity_backordered` / `backorder_message` per option in the order object. The item-level fields are confirmed present; the per-option fields could not be verified locally because the only available test order has no bundle options. Reviewers/QA should confirm against an order containing a backordered picklist option.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [BACK-692](https://bigcommercecloud.atlassian.net/browse/BACK-692)

#### Screenshots (if appropriate)

_To be added — pending an order containing a backordered picklist (bundle) option._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[BACK-692]: https://bigcommercecloud.atlassian.net/browse/BACK-692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the changelog with no runtime code in the diff.
> 
> **Overview**
> This PR **only changes `CHANGELOG.md`**: it adds a new **Draft** bullet for [#2683](https://github.com/bigcommerce/cornerstone/pull/2683) stating that the account **order details** page will show backorder prompts for the **parent line item** (under the product title) and for **each picklist option**, in line with PDP backorder messaging.
> 
> No template, style, or JavaScript files appear in the diff; release notes only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59052ebdd4c5d46fc490c187c82eafb7fa4c7ad1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->