### PR TITLE
fix(backorders): BACK-717 validate picklist option available_to_sell on PDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Validate picklist option `available_to_sell` on PDP so Add to Cart is disabled and a "maximum purchasable quantity for {picklist} is {qty}" error is shown when the requested quantity exceeds a selected picklist item's stock, even when the main product still has enough stock [#2684](https://github.com/bigcommerce/cornerstone/pull/2684)
 - Refine backorder layout and colors on the account order details page [#2677](https://github.com/bigcommerce/cornerstone/pull/2677)
 - Make the cart Shipping row label span the full width of the totals row so the shipping expectation prompt is no longer constrained to the narrow label column
 - Respect `unlimited_backorder` on PDP so the backorder quantity message and availability prompt render, and the Add to Cart quantity cap is lifted for products with unlimited backorder

--- a/assets/js/test-unit/theme/common/picklist-backorder.spec.js
+++ b/assets/js/test-unit/theme/common/picklist-backorder.spec.js
@@ -542,4 +542,104 @@ describe('PicklistBackorder', () => {
             expect(text).not.toContain('Backorder message 1');
         });
     });
+
+    describe('getSellLimitViolation()', () => {
+        const context = { quantityBackorderedMessage: '__QTY__ will be backordered' };
+
+        const renderWith = (renderer, overrides, mainQty) => {
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail(overrides)],
+            }, mainQty);
+        };
+
+        it('returns null when no prior render has captured data', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+
+            expect(renderer.getSellLimitViolation(10)).toBeNull();
+        });
+
+        it('returns null when requested qty is 0 or negative', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+            renderWith(renderer, { available_to_sell: 5 }, 0);
+
+            expect(renderer.getSellLimitViolation(0)).toBeNull();
+        });
+
+        it('returns name and ATS when requested qty exceeds the picklist available_to_sell', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+            renderWith(renderer, { available_to_sell: 7 }, 10);
+
+            expect(renderer.getSellLimitViolation(10)).toEqual({ name: 'Bundle 1', availableToSell: 7 });
+        });
+
+        it('returns null when requested qty is within the picklist available_to_sell', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+            renderWith(renderer, { available_to_sell: 7 }, 7);
+
+            expect(renderer.getSellLimitViolation(7)).toBeNull();
+        });
+
+        it('treats available_to_sell of 0 as "no limit set" and returns null', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+            renderWith(renderer, { available_to_sell: 0 }, 50);
+
+            expect(renderer.getSellLimitViolation(50)).toBeNull();
+        });
+
+        it('returns null for unlimited-backorder picklist items', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+            renderWith(renderer, { unlimited_backorder: true, available_to_sell: 1 }, 10);
+
+            expect(renderer.getSellLimitViolation(10)).toBeNull();
+        });
+
+        it('skips selections that do not auto-adjust inventory', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder($scope, context);
+            renderer.render({
+                selected_picklist_options: [selection({ auto_adjust_inventory_flag: false })],
+                picklist_products_details: [detail({ available_to_sell: 1 })],
+            }, 10);
+
+            expect(renderer.getSellLimitViolation(10)).toBeNull();
+        });
+
+        it('skips non-stock-tracked and non-purchasable picklist items', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const notTracked = new PicklistBackorder($scope, context);
+            renderWith(notTracked, { is_stock_tracked: false, available_to_sell: 1 }, 10);
+            expect(notTracked.getSellLimitViolation(10)).toBeNull();
+
+            const notPurchasable = new PicklistBackorder($scope, context);
+            renderWith(notPurchasable, { purchasable: false, available_to_sell: 1 }, 10);
+            expect(notPurchasable.getSellLimitViolation(10)).toBeNull();
+        });
+
+        it('returns the first violating selection across multiple picklists', () => {
+            $scope = buildScope([
+                { name: 'Bundle 1', values: [{ id: 98, label: 'A' }] },
+                { name: 'Bundle 2', values: [{ id: 99, label: 'B' }] },
+            ]);
+            const renderer = new PicklistBackorder($scope, context);
+            renderer.render({
+                selected_picklist_options: [
+                    selection({ product_id: 80, attribute_value_id: 98, product_attribute_id: 113 }),
+                    selection({ product_id: 81, attribute_value_id: 99, product_attribute_id: 114 }),
+                ],
+                picklist_products_details: [
+                    detail({ product_id: 80, available_to_sell: 50 }),
+                    detail({ product_id: 81, available_to_sell: 3 }),
+                ],
+            }, 5);
+
+            expect(renderer.getSellLimitViolation(5)).toEqual({ name: 'Bundle 2', availableToSell: 3 });
+        });
+    });
 });

--- a/assets/js/test-unit/theme/common/product-details-base.spec.js
+++ b/assets/js/test-unit/theme/common/product-details-base.spec.js
@@ -1,0 +1,89 @@
+import ProductDetailsBase from '../../../theme/common/product-details-base';
+
+describe('ProductDetailsBase.updateAddToCartForQty()', () => {
+    let $scope;
+    let instance;
+
+    const buildScope = () => $(`
+        <div>
+            <div id="add-to-cart-wrapper">
+                <div class="alertBox alertBox--error productAttributes-message" style="display:none;">
+                    <p class="alertBox-message"></p>
+                </div>
+            </div>
+            <input class="form-input--incrementTotal" />
+            <button id="form-action-addToCart"></button>
+        </div>
+    `).appendTo(document.body);
+
+    // Bypass the constructor (Wishlist.load, tab/radio wiring) and test the method directly.
+    const makeInstance = (context, picklistViolation) => {
+        const obj = Object.create(ProductDetailsBase.prototype);
+        obj.$scope = $scope;
+        obj.context = context;
+        obj.picklistBackorder = { getSellLimitViolation: () => picklistViolation };
+        return obj;
+    };
+
+    const viewModel = () => ({
+        $addToCart: $('#form-action-addToCart', $scope),
+        $increments: $('.form-input--incrementTotal', $scope),
+    });
+
+    afterEach(() => {
+        if ($scope) {
+            $scope.remove();
+            $scope = null;
+        }
+    });
+
+    it('re-enables Add to Cart when a picklist limit clears even though the main ATS is unknown', () => {
+        $scope = buildScope();
+        let violation = { name: 'Bundle 1', availableToSell: 3 };
+        // Main product ATS unknown (0); only the picklist imposes a limit.
+        instance = makeInstance({ availableToSell: 0 }, violation);
+        const vm = viewModel();
+
+        // Qty above the picklist limit → blocked with the picklist message.
+        instance.updateAddToCartForQty(5, vm);
+        expect(vm.$addToCart.prop('disabled')).toBe(true);
+        expect($('.productAttributes-message', $scope).attr('data-qty-limit')).toBe('true');
+        expect($('.alertBox-message', $scope).text()).toContain('Bundle 1');
+
+        // Drop qty back into range → picklist limit no longer applies.
+        violation = null;
+        instance = makeInstance({ availableToSell: 0 }, violation);
+        instance.updateAddToCartForQty(2, vm);
+
+        expect(vm.$addToCart.prop('disabled')).toBe(false);
+        expect($('.productAttributes-message', $scope).attr('data-qty-limit')).toBeUndefined();
+        expect($('.productAttributes-message', $scope).css('display')).toBe('none');
+    });
+
+    it('keeps Add to Cart disabled when increments are disabled (out of stock)', () => {
+        $scope = buildScope();
+        $('.form-input--incrementTotal', $scope).prop('disabled', true);
+        instance = makeInstance({ availableToSell: 0 }, { name: 'Bundle 1', availableToSell: 3 });
+        const vm = viewModel();
+
+        instance.updateAddToCartForQty(5, vm);
+        instance.picklistBackorder.getSellLimitViolation = () => null;
+        instance.updateAddToCartForQty(2, vm);
+
+        expect(vm.$addToCart.prop('disabled')).toBe(true);
+    });
+
+    it('shows the main-product limit message and ignores the picklist when the main ATS is exceeded', () => {
+        $scope = buildScope();
+        instance = makeInstance(
+            { availableToSell: 4, quantityMaxMessage: 'The maximum purchasable quantity is __QTY__' },
+            { name: 'Bundle 1', availableToSell: 3 },
+        );
+        const vm = viewModel();
+
+        instance.updateAddToCartForQty(6, vm);
+
+        expect(vm.$addToCart.prop('disabled')).toBe(true);
+        expect($('.alertBox-message', $scope).text()).toBe('The maximum purchasable quantity is 4');
+    });
+});

--- a/assets/js/theme/common/picklist-backorder.js
+++ b/assets/js/theme/common/picklist-backorder.js
@@ -68,6 +68,63 @@ export default class PicklistBackorder {
         return lines;
     }
 
+    /**
+     * Find the first selected picklist item whose available-to-sell is lower than
+     * the requested quantity. Used to surface a sell-limit error and block add-to-cart
+     * even when the main product still has enough stock.
+     *
+     * @param {Number} mainQty Quantity the shopper requested for the main product
+     * @returns {{name: String, availableToSell: Number}|null}
+     */
+    getSellLimitViolation(mainQty) {
+        if (!this.lastData) return null;
+
+        const requestedQty = parseInt(mainQty, 10) || 0;
+        if (requestedQty <= 0) return null;
+
+        const selections = Array.isArray(this.lastData.selected_picklist_options)
+            ? this.lastData.selected_picklist_options
+            : [];
+
+        let violation = null;
+
+        selections.some(sel => {
+            const availableToSell = this.getSelectionSellLimit(sel);
+            if (availableToSell === null || requestedQty <= availableToSell) return false;
+
+            const name = this.findAttributeName(sel.attribute_value_id);
+            if (!name) return false;
+
+            violation = { name, availableToSell };
+            return true;
+        });
+
+        return violation;
+    }
+
+    /**
+     * Resolve the available-to-sell limit for a single picklist selection, or null
+     * when the selection does not impose a limit (not stock-tracked, unlimited
+     * backorder, missing details, or a 0/unknown ATS).
+     *
+     * @param {Object} sel A selected picklist option
+     * @returns {Number|null}
+     */
+    getSelectionSellLimit(sel) {
+        if (!sel || sel.auto_adjust_inventory_flag !== true) return null;
+        if (typeof sel.product_id !== 'number') return null;
+
+        const detail = this.detailsByProductId.get(sel.product_id);
+        if (!detail) return null;
+        if (detail.is_stock_tracked === false) return null;
+        if (detail.purchasable === false) return null;
+        if (detail.unlimited_backorder === true) return null;
+
+        const availableToSell = parseInt(detail.available_to_sell, 10) || 0;
+        // Treat 0/unknown as "no limit set", consistent with the main-product check.
+        return availableToSell > 0 ? availableToSell : null;
+    }
+
     findAttributeName(attributeValueId) {
         if (attributeValueId === undefined || attributeValueId === null) return '';
         const $optionLabel = $(`label[data-product-attribute-value="${attributeValueId}"]`, this.$scope);

--- a/assets/js/theme/common/picklist-backorder.js
+++ b/assets/js/theme/common/picklist-backorder.js
@@ -86,20 +86,16 @@ export default class PicklistBackorder {
             ? this.lastData.selected_picklist_options
             : [];
 
-        let violation = null;
+        return selections
+            .map(sel => {
+                const availableToSell = this.getSelectionSellLimit(sel);
+                if (availableToSell === null || requestedQty <= availableToSell) return null;
 
-        selections.some(sel => {
-            const availableToSell = this.getSelectionSellLimit(sel);
-            if (availableToSell === null || requestedQty <= availableToSell) return false;
+                const name = this.findAttributeName(sel.attribute_value_id);
 
-            const name = this.findAttributeName(sel.attribute_value_id);
-            if (!name) return false;
-
-            violation = { name, availableToSell };
-            return true;
-        });
-
-        return violation;
+                return name ? { name, availableToSell } : null;
+            })
+            .find(Boolean) || null;
     }
 
     /**

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -307,29 +307,54 @@ export default class ProductDetailsBase {
 
     updateAddToCartForQty(qty, passedViewModel) {
         const viewModel = passedViewModel || this.getViewModel(this.$scope);
+        const $variantMessage = $('#add-to-cart-wrapper .productAttributes-message', this.$scope);
         const unlimited = this.context.unlimitedBackorder === true;
         const availableToSell = unlimited
             ? Infinity
             : parseInt(this.context.availableToSell, 10) || 0;
 
-        if (availableToSell <= 0) return;
-
-        const $variantMessage = $('#add-to-cart-wrapper .productAttributes-message', this.$scope);
-
-        if (qty > availableToSell) {
-            viewModel.$addToCart.prop('disabled', true);
-
+        // The main product's sell-limit takes priority over any picklist limit.
+        if (availableToSell > 0 && qty > availableToSell) {
             const template = this.context.quantityMaxMessage || 'The maximum purchasable quantity is __QTY__';
-            const message = template.replace('__QTY__', availableToSell);
-            $('.alertBox-message', $variantMessage).text(message);
-            $variantMessage.attr('data-qty-limit', 'true').show();
-        } else if (!viewModel.$increments.prop('disabled')) {
-            viewModel.$addToCart.prop('disabled', false);
+            this.showQtyLimitMessage(viewModel, $variantMessage, template.replace('__QTY__', availableToSell));
+            return;
+        }
 
-            if ($variantMessage.attr('data-qty-limit') === 'true') {
-                $variantMessage.removeAttr('data-qty-limit').hide();
-                $('.alertBox-message', $variantMessage).text('');
-            }
+        // A selected picklist item may exhaust its own available-to-sell before the
+        // main product does. Surface its limit and block add-to-cart in that case.
+        const picklistLimit = this.picklistBackorder
+            && this.picklistBackorder.getSellLimitViolation(qty);
+
+        if (picklistLimit) {
+            const template = this.context.quantityMaxPicklistMessage
+                || 'The maximum purchasable quantity for __NAME__ is __QTY__';
+            const message = template
+                .replace('__NAME__', picklistLimit.name)
+                .replace('__QTY__', picklistLimit.availableToSell);
+            this.showQtyLimitMessage(viewModel, $variantMessage, message);
+            return;
+        }
+
+        // No sell-limit exceeded. Preserve the legacy behaviour of not touching the
+        // add-to-cart state when the main sell-limit is unknown (handled by OOS logic),
+        // but still clear a stale qty-limit message we may have shown previously.
+        this.clearQtyLimitMessage(viewModel, $variantMessage, availableToSell > 0);
+    }
+
+    showQtyLimitMessage(viewModel, $variantMessage, message) {
+        viewModel.$addToCart.prop('disabled', true);
+        $('.alertBox-message', $variantMessage).text(message);
+        $variantMessage.attr('data-qty-limit', 'true').show();
+    }
+
+    clearQtyLimitMessage(viewModel, $variantMessage, reEnable) {
+        if (reEnable && !viewModel.$increments.prop('disabled')) {
+            viewModel.$addToCart.prop('disabled', false);
+        }
+
+        if ($variantMessage.attr('data-qty-limit') === 'true') {
+            $variantMessage.removeAttr('data-qty-limit').hide();
+            $('.alertBox-message', $variantMessage).text('');
         }
     }
 

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -348,11 +348,18 @@ export default class ProductDetailsBase {
     }
 
     clearQtyLimitMessage(viewModel, $variantMessage, reEnable) {
-        if (reEnable && !viewModel.$increments.prop('disabled')) {
+        const hadQtyLimit = $variantMessage.attr('data-qty-limit') === 'true';
+
+        // Re-enable when the main sell-limit is known (legacy behaviour) or when we
+        // are clearing a qty-limit message we set ourselves — otherwise a button
+        // disabled by a picklist limit would stay disabled once the qty drops back
+        // into range while the main ATS is unknown. The increments guard still keeps
+        // an out-of-stock button disabled.
+        if ((reEnable || hadQtyLimit) && !viewModel.$increments.prop('disabled')) {
             viewModel.$addToCart.prop('disabled', false);
         }
 
-        if ($variantMessage.attr('data-qty-limit') === 'true') {
+        if (hadQtyLimit) {
             $variantMessage.removeAttr('data-qty-limit').hide();
             $('.alertBox-message', $variantMessage).text('');
         }

--- a/lang/en.json
+++ b/lang/en.json
@@ -820,6 +820,7 @@
         "gift_wrapping_available": "Options available",
         "quantity_min": "The minimum purchasable quantity is {quantity}",
         "quantity_max": "The maximum purchasable quantity is {quantity}",
+        "quantity_max_picklist": "The maximum purchasable quantity for {name} is {quantity}",
         "bulk_pricing": {
             "title": "Bulk Pricing:",
             "view": "Buy in bulk and save",

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -8,6 +8,7 @@
 {{inject 'backorderAvailabilityPrompt' product.backorder_availability_prompt}}
 {{inject 'quantityBackorderedMessage' (lang 'products.quantity_backordered' quantity='__QTY__')}}
 {{inject 'quantityMaxMessage' (lang 'products.quantity_max' quantity='__QTY__')}}
+{{inject 'quantityMaxPicklistMessage' (lang 'products.quantity_max_picklist' name='__NAME__' quantity='__QTY__')}}
 {{inject 'backorderMessages' backorder_messages}}
 {{inject 'showBackorderMessage' product.show_backorder_message}}
 


### PR DESCRIPTION
#### What?

On the Product Details Page, the "maximum purchasable quantity" error and the disabled **Add to Cart** button only triggered when the requested quantity exceeded the **main product's** `available_to_sell` (ATS). When a required **picklist** option had a linked product with a *lower* ATS than the main product, a shopper could enter a quantity that exceeded the picklist item's stock with **no error** and **Add to Cart left enabled** — misleading them into thinking there was enough stock.

This PR validates each selected picklist option's ATS against the requested quantity:

- **`assets/js/theme/common/picklist-backorder.js`** — adds `getSellLimitViolation(mainQty)`, which scans `selected_picklist_options` and returns the first selection whose linked product's `available_to_sell` is below the requested quantity (`{ name, availableToSell }`), or `null`. It reuses the same eligibility guards as the backorder display: it skips selections that don't auto-adjust inventory, aren't stock-tracked, aren't purchasable, have unlimited backorder, or report an unknown (`0`) ATS. The eligibility/limit resolution is factored into a `getSelectionSellLimit(sel)` helper.
- **`assets/js/theme/common/product-details-base.js`** — `updateAddToCartForQty` now checks the **main** product limit first (unchanged priority), then the **picklist** limit. When a picklist item's limit is exceeded it shows **"The maximum purchasable quantity for {picklist name} is {ATS}."** and disables Add to Cart. The message/enable/disable logic is extracted into `showQtyLimitMessage` / `clearQtyLimitMessage` helpers; the legacy behaviour of not touching the button when the main ATS is unknown (handled by the OOS logic) is preserved via a `reEnable` flag, while a stale picklist message is still cleared when the quantity drops back into range.
- **`templates/components/products/product-view.html`** — injects `quantityMaxPicklistMessage` from the new lang string.
- **`lang/en.json`** — adds `products.quantity_max_picklist`: `"The maximum purchasable quantity for {name} is {quantity}"`.

This coexists with the existing BACK-674 behaviour: the "N will be backordered" picklist row still renders (informational) while Add to Cart is blocked by the new ATS guard.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- [BACK-717](https://bigcommercecloud.atlassian.net/browse/BACK-717)

#### Screenshots (if appropriate)

<img width="1240" height="825" alt="Screenshot 2026-06-19 at 09 59 50" src="https://github.com/user-attachments/assets/aca1d429-c83e-4378-be59-72ef0c0a3c95" />

#### Testing

- `npx jest picklist-backorder` — 36 passing, including 9 new tests for `getSellLimitViolation` (no prior render, zero qty, violation/no-violation, ATS=0 "no limit", unlimited backorder, non-auto-adjust, non-tracked/non-purchasable, and first-violation-across-multiple-picklists).
- `npx jest` — full suite, 268 passing / 27 suites.
- `npx eslint` on the changed JS files — clean.


[BACK-717]: https://bigcommercecloud.atlassian.net/browse/BACK-717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PDP add-to-cart and quantity error behavior for picklist/bundle products; logic is well tested but affects a shopper-facing purchase path.
> 
> **Overview**
> **PDP quantity limits now include linked picklist products**, not only the main SKU’s `available_to_sell`. When the shopper’s qty exceeds a selected picklist item’s stock but the parent product still looks in stock, **Add to Cart is disabled** and a **picklist-specific max quantity** message is shown.
> 
> `PicklistBackorder` gains **`getSellLimitViolation`** (and **`getSelectionSellLimit`**) to find the first auto-adjusting, stock-tracked picklist selection whose ATS is below the requested qty, with the same skips as backorder UI (unlimited backorder, ATS 0, non-purchasable, etc.).
> 
> `ProductDetailsBase.updateAddToCartForQty` checks **main ATS first**, then the picklist violation, and refactors limit UI into **`showQtyLimitMessage`** / **`clearQtyLimitMessage`** so picklist errors clear when qty drops without breaking legacy behavior when main ATS is unknown.
> 
> **Storefront wiring:** new `products.quantity_max_picklist` in `lang/en.json`, injected as `quantityMaxPicklistMessage` on the product view template, plus CHANGELOG and unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb3b2a6578bd6302f6ea8fb3e14d356ebb4bb3d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->