### PR TITLE
feat(orders): ORDERS-7715 add createReturn mutation and confirmation page to returnsV2 create return

### DIFF
--- a/assets/js/theme/create-return.js
+++ b/assets/js/theme/create-return.js
@@ -26,47 +26,98 @@ export default class CreateReturn extends PageManager {
             return resolutionEl && resolutionEl.value && reasonEl && reasonEl.value;
         });
 
-        document.getElementById('return-new-submitBtn').disabled = !isValid;
-    }
-
-    // Returns only row containers (not buttons) with a non-zero quantity selected.
-    getSelectedItems() {
-        return [...document.querySelectorAll('.newReturn-orderLineItem')].filter(itemRow => {
-            const itemId = itemRow.dataset?.itemId;
-            if (!itemId) return false;
-            const qtyInput = document.getElementById(`qty-${itemId}`);
-            return qtyInput && parseInt(qtyInput.value, 10) > 0;
-        });
+        const submitBtn = document.getElementById('return-new-submitBtn');
+        if (submitBtn) submitBtn.disabled = !isValid;
     }
 
     bindSubmit(form) {
-        form.addEventListener('submit', event => {
+        form.addEventListener('submit', async event => {
             event.preventDefault();
-            // TODO ORDERS-7715: invoke createReturn Storefront GQL mutation using
-            // this.buildReturnInput() to get the payload.
+
+            // TODO ORDERS-7715: handle mutation errors
+            await this.createReturn(this.buildReturnInput());
+            this.showConfirmation();
         });
     }
 
+    // Storefront GraphQL `createReturn` mutation
+    createReturn(input) {
+        return fetch('/graphql', {
+            method: 'POST',
+            credentials: 'include',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${this.context.storefrontApiToken}`,
+            },
+            body: JSON.stringify({
+                query: `mutation CreateReturn($input: CreateOrderReturnInput!) {
+                    order {
+                        return {
+                            createReturn(input: $input) {
+                                entityId
+                                errors {
+                                    __typename
+                                    ... on Error {
+                                        message
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }`,
+                variables: { input },
+            }),
+        }).then(response => response.json());
+    }
+
+    // Swaps the form view for the success confirmation view.
+    showConfirmation() {
+        const formView = document.querySelector('[data-new-return-view]');
+        const confirmation = document.querySelector('[data-new-return-confirmation]');
+
+        if (formView) formView.style.display = 'none';
+        if (confirmation) confirmation.style.display = '';
+    }
+
     /**
-     * Builds the createReturn mutation input.
-     * Called by ORDERS-7715 once the Storefront GQL mutation is wired up.
+     * Builds the `CreateOrderReturnInput` payload from the selected line items.
      *
-     * @returns {{ orderEntityId: number, additionalNote: string, items: Array }}
+     * @returns {{ orderEntityId: number, items: Array }}
      */
     buildReturnInput() {
         return {
             orderEntityId: parseInt(this.context.order?.id, 10),
-            additionalNote: document.querySelector('[data-new-return-note]')?.value || '',
             items: this.getSelectedItems().flatMap(itemRow => {
                 const itemId = itemRow.dataset?.itemId;
                 if (!itemId) return [];
                 return [{
                     lineItemEntityId: parseInt(itemId, 10),
                     quantity: parseInt(document.getElementById(`qty-${itemId}`)?.value, 10),
-                    resolution: document.getElementById(`resolution-${itemId}`)?.value,
                     reasonEntityId: document.getElementById(`reason-${itemId}`)?.value,
+                    requestedResolution: this.buildRequestedResolution(document.getElementById(`resolution-${itemId}`)?.value),
                 }];
             }),
         };
+    }
+
+    // Maps a selected resolution value to a `RequestedResolutionInput`
+    buildRequestedResolution(value) {
+        const systemResolutionTypes = ['EXCHANGE', 'REFUND', 'STORE_CREDIT'];
+
+        if (systemResolutionTypes.includes(value)) {
+            return { type: value };
+        }
+
+        return { type: 'CUSTOM', customResolutionEntityId: value };
+    }
+
+    // Returns only row containers with a non-zero quantity selected.
+    getSelectedItems() {
+        return Array.from(document.querySelectorAll('.newReturn-orderLineItem')).filter(itemRow => {
+            const itemId = itemRow.dataset?.itemId;
+            if (!itemId) return false;
+            const qtyInput = document.getElementById(`qty-${itemId}`);
+            return qtyInput && parseInt(qtyInput.value, 10) > 0;
+        });
     }
 }

--- a/assets/js/theme/create-return.js
+++ b/assets/js/theme/create-return.js
@@ -34,9 +34,21 @@ export default class CreateReturn extends PageManager {
         form.addEventListener('submit', async event => {
             event.preventDefault();
 
-            // TODO ORDERS-7715: handle mutation errors
-            await this.createReturn(this.buildReturnInput());
-            this.showConfirmation();
+            // Ignore clicks while a request is in flight
+            if (this.isSubmitting) return;
+            this.isSubmitting = true;
+
+            const submitBtn = document.getElementById('return-new-submitBtn');
+            if (submitBtn) submitBtn.disabled = true;
+
+            try {
+                // TODO ORDERS-7715: handle mutation errors
+                await this.createReturn(this.buildReturnInput());
+                this.showConfirmation();
+            } finally {
+                this.isSubmitting = false;
+                if (submitBtn) submitBtn.disabled = false;
+            }
         });
     }
 

--- a/assets/scss/components/stencil/createReturn/_createReturn.scss
+++ b/assets/scss/components/stencil/createReturn/_createReturn.scss
@@ -18,6 +18,24 @@
     margin-bottom: spacing("eighth");
 }
 
+.newReturn-confirmation {
+    padding: spacing("single") 0;
+}
+
+.newReturn-confirmationMessage {
+    font-size: remCalc(15px);
+    color: color("greys", "base");
+    margin: spacing("eighth") 0 0;
+
+    &:first-of-type {
+        margin-top: spacing("half");
+    }
+
+    & + .button {
+        margin-top: spacing("single");
+    }
+}
+
 .newReturn-titleGroup {
     display: flex;
     align-items: center;

--- a/lang/en.json
+++ b/lang/en.json
@@ -471,6 +471,10 @@
             "reason_header": "Return reason",
             "qty": "Qty:",
             "total_price": "Total:",
+            "submitted_successfully": "submitted successfully!",
+            "confirmation_message_primary": "We've received your return request and will review it within 1-2 business days.",
+            "confirmation_message_secondary": "You'll receive an email confirmation with your RMA number and return instructions.",
+            "take_me_back": "Take me back",
             "list": {
                 "last_update":"Last Update",
                 "return_submitted": "Return Submitted",

--- a/templates/pages/create-return.html
+++ b/templates/pages/create-return.html
@@ -1,9 +1,12 @@
 {{#partial "page"}}
 
 {{~inject 'order' order}}
+{{~inject 'storefrontApiToken' settings.storefront_api.token}}
 <main class="newReturn">
 
     {{#with order}}
+
+    <div data-new-return-view>
 
     <div class="newReturn-header">
         <div class="newReturn-titleGroup">
@@ -115,6 +118,15 @@
         </div>
 
     </form>
+
+    </div>
+
+    <div class="newReturn-confirmation" data-new-return-confirmation style="display: none;">
+        <h1 class="newReturn-title">{{lang 'account.returns.from_order' id=id}} {{lang 'account.returns.submitted_successfully'}}</h1>
+        <p class="newReturn-confirmationMessage">{{lang 'account.returns.confirmation_message_primary'}}</p>
+        <p class="newReturn-confirmationMessage">{{lang 'account.returns.confirmation_message_secondary'}}</p>
+        <a href="{{../urls.account.orders.all}}" class="button button--primary">{{lang 'account.returns.take_me_back'}}</a>
+    </div>
 
     {{/with}}
 


### PR DESCRIPTION
#### What?

This PR implements the createReturn mutation to the v2 create return page and displays a success page on successful return creation.

This PR does NOT include error handling and that will be done in a follow up PR.

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [Link 1](http://example.com)
- ...

#### Screenshots (if appropriate)



https://github.com/user-attachments/assets/3d5c8b54-1abc-4c10-b8eb-0e0caf0878d2

The Order return is in the DB
```
851dfe37-b793-4d05-ad5b-7565870343fc,RMA-004,OPEN,2026-06-22 00:55:10.006,2026-06-22 00:55:10.006,0,103,2026-05-18 06:00:05.000,1,Jasper - Inc Tax,Pajar,"",USD,"",0,0.0000,0.0000,200.0000,200.0000
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Creates real customer return/RMA records via GraphQL with no response or error checks before showing success, which can mislead shoppers on failure.
> 
> **Overview**
> The v2 **create return** flow now **submits** selected line items via the Storefront GraphQL **`createReturn`** mutation instead of only preventing default on the form. On submit, the page builds a **`CreateOrderReturnInput`** payload (order id, per-line quantity, reason, and **`requestedResolution`** mapped from system types or custom resolution ids), posts to **`/graphql`** with the injected **storefront API token**, and swaps the form for a **success confirmation** view when the call completes.
> 
> Submit handling adds an **in-flight guard** and disables the submit button while the request runs. **`additionalNote`** is no longer included in the mutation input. **Mutation errors are not handled yet** (still TODO); failures could still show the success UI until a follow-up PR.
> 
> Template, **en.json**, and SCSS add the hidden confirmation block and copy/styling for the post-submit state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc8b5ed1560042d96dc8df1a087859f80c7cf383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->