### PR TITLE
feat(orders): ORDERS-7859 add error message on failed return creation

### DIFF
--- a/assets/js/theme/create-return.js
+++ b/assets/js/theme/create-return.js
@@ -40,16 +40,51 @@ export default class CreateReturn extends PageManager {
 
             const submitBtn = document.getElementById('return-new-submitBtn');
             if (submitBtn) submitBtn.disabled = true;
+            this.clearError();
 
             try {
-                // TODO ORDERS-7715: handle mutation errors
-                await this.createReturn(this.buildReturnInput());
+                const response = await this.createReturn(this.buildReturnInput());
+                const errorMessages = this.getErrorMessages(response);
+
+                if (errorMessages.length) {
+                    this.showError(errorMessages.join(' '));
+                    return;
+                }
+
                 this.showConfirmation();
+            } catch (error) {
+                this.showError(this.context.genericError);
             } finally {
                 this.isSubmitting = false;
                 if (submitBtn) submitBtn.disabled = false;
             }
         });
+    }
+
+    getErrorMessages(response) {
+        const transportErrors = Array.isArray(response?.errors) ? response.errors : [];
+        const returnErrors = Array.isArray(response?.data?.order?.return?.createReturn?.errors)
+            ? response.data.order.return.createReturn.errors
+            : [];
+
+        return transportErrors
+            .concat(returnErrors)
+            .map(error => error.message)
+            .filter(Boolean);
+    }
+
+    showError(message) {
+        const errorBox = document.getElementById('return-new-error');
+        if (!errorBox) return;
+
+        const messageEl = errorBox.querySelector('[data-return-error-message]');
+        if (messageEl) messageEl.textContent = message || '';
+        errorBox.style.display = '';
+    }
+
+    clearError() {
+        const errorBox = document.getElementById('return-new-error');
+        if (errorBox) errorBox.style.display = 'none';
     }
 
     // Storefront GraphQL `createReturn` mutation

--- a/assets/scss/components/stencil/createReturn/_createReturn.scss
+++ b/assets/scss/components/stencil/createReturn/_createReturn.scss
@@ -18,6 +18,24 @@
     margin-bottom: spacing("eighth");
 }
 
+.newReturn-error {
+    margin-bottom: spacing("single");
+    padding: spacing("half") spacing("single");
+    border-radius: remCalc(4px);
+    background-color: color("error", "light");
+    color: color("error");
+}
+
+.newReturn-errorHeading {
+    font-weight: fontWeight("semibold");
+    margin: 0 0 spacing("eighth");
+}
+
+.newReturn-error .alertBox-message {
+    margin: 0;
+    color: color("error");
+}
+
 .newReturn-confirmation {
     padding: spacing("single") 0;
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -471,6 +471,7 @@
             "reason_header": "Return reason",
             "qty": "Qty:",
             "total_price": "Total:",
+            "error_heading": "Failed to create return",
             "submitted_successfully": "submitted successfully!",
             "confirmation_message_primary": "We've received your return request and will review it within 1-2 business days.",
             "confirmation_message_secondary": "You'll receive an email confirmation with your RMA number and return instructions.",

--- a/templates/pages/create-return.html
+++ b/templates/pages/create-return.html
@@ -22,6 +22,11 @@
 
     <hr class="newReturn-divider">
 
+    <div id="return-new-error" class="alertBox alertBox--error newReturn-error" style="display: none;" role="alert">
+        <p class="newReturn-errorHeading">{{lang 'account.returns.error_heading'}}</p>
+        <p class="alertBox-message" data-return-error-message></p>
+    </div>
+
     <form class="form" data-new-return-form data-success-url="{{../urls.account.orders.all}}">
 
         <div class="newReturn-columnHeaders" aria-hidden="true">
@@ -90,10 +95,6 @@
         {{/each}}
 
         <hr class="newReturn-divider">
-
-        <div id="return-new-error" class="alertBox alertBox--error" style="display:none" role="alert">
-            <p class="alertBox-message" data-return-error-message></p>
-        </div>
 
         <div class="newReturn-footer">
             <div class="form-field">


### PR DESCRIPTION
#### What?

This PR introduces error handling for failed return creation mutations in the V2 shopper facing returns portal create return page.

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

https://bigcommercecloud.atlassian.net/browse/ORDERS-7859

- [Link 1](http://example.com)
- ...

#### Screenshots (if appropriate)

https://github.com/user-attachments/assets/13baedf5-2886-48d1-9a71-27bc8640ba9f




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only error handling on the returns form; no auth or payment changes, and failed submissions no longer advance to the confirmation view.
> 
> **Overview**
> Shoppers on the V2 **create return** page now see feedback when return submission fails instead of silently doing nothing.
> 
> On submit, `create-return.js` clears any prior error, inspects the GraphQL response for top-level `errors` and `createReturn.errors`, and surfaces joined messages in `#return-new-error`. Network or unexpected failures use the existing **generic error** string. The success confirmation path is unchanged when no errors are returned.
> 
> The error alert moves **above the form** (from the footer), adds a localized **"Failed to create return"** heading, and new `.newReturn-error` styles for the banner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aa1d8b3c8497033e48edd17c3328a9a170c331e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->