### PR TITLE
feat(checkout): show backorder prompts for bundled items in the my account->order detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Draft
 - Validate picklist option `available_to_sell` on PDP so Add to Cart is disabled and a "maximum purchasable quantity for {picklist} is {qty}" error is shown when the requested quantity exceeds a selected picklist item's stock, even when the main product still has enough stock [#2684](https://github.com/bigcommerce/cornerstone/pull/2684)
+- Render backorder prompts for bundled picklist options on the account order details page, using `linked_bundled_item` data per option; move parent item backorder prompts above the options list; reduce backorder prompt font size and add spacing between prompts and adjacent option rows [#2687](https://github.com/bigcommerce/cornerstone/pull/2687)
 - Hide option values on the PDP that would complete a "disable and hide" rule for the current selection, and steer the shopper off a default selection that is itself a forbidden combination [#2678](https://github.com/bigcommerce/cornerstone/pull/2678)
 - Refine backorder layout and colors on the account order details page [#2677](https://github.com/bigcommerce/cornerstone/pull/2677)
 - Make the cart Shipping row label span the full width of the totals row so the shipping expectation prompt is no longer constrained to the narrow label column

--- a/assets/scss/components/stencil/account/_account.scss
+++ b/assets/scss/components/stencil/account/_account.scss
@@ -155,8 +155,17 @@ $account-backorder-textColor: #757575;
 
 .account-product-backorder-prompts {
     color: $account-backorder-textColor;
-    font-size: fontSize("smaller");
+    font-size: fontSize("smallest");
     margin-bottom: 0;
+
+    + .definitionList {
+        margin-top: spacing("half");
+    }
+
+    + dt,
+    + dt + dd {
+        margin-top: spacing("half");
+    }
 }
 
 .account-order-backorder-expectation {

--- a/templates/components/account/order-contents.html
+++ b/templates/components/account/order-contents.html
@@ -54,11 +54,29 @@
                 {{#if brand}}
                     <h6>{{brand.name}}</h6>
                 {{/if}}
+                {{#if quantity_ready_to_ship}}
+                    <p class="account-product-backorder-prompts">{{lang 'products.quantity_on_hand' quantity=quantity_ready_to_ship}}</p>
+                {{/if}}
+                {{#if quantity_backordered}}
+                    <p class="account-product-backorder-prompts">{{lang 'products.quantity_backordered' quantity=quantity_backordered}}</p>
+                {{/if}}
+                {{#if backorder_message}}
+                    <p class="account-product-backorder-prompts">{{backorder_message}}</p>
+                {{/if}}
                 {{#if options}}
                 <dl class="definitionList">
                     {{#each options}}
                         <dt class="definitionList-key">{{name}}:</dt>
                         <dd class="definitionList-value">{{> components/common/product-options}}</dd>
+                        {{#if linked_bundled_item.quantity_ready_to_ship}}
+                            <dd class="definitionList-value account-product-backorder-prompts">{{lang 'products.quantity_on_hand' quantity=linked_bundled_item.quantity_ready_to_ship}}</dd>
+                        {{/if}}
+                        {{#if linked_bundled_item.quantity_backordered}}
+                            <dd class="definitionList-value account-product-backorder-prompts">{{lang 'products.quantity_backordered' quantity=linked_bundled_item.quantity_backordered}}</dd>
+                        {{/if}}
+                        {{#if linked_bundled_item.backorder_message}}
+                            <dd class="definitionList-value account-product-backorder-prompts">{{linked_bundled_item.backorder_message}}</dd>
+                        {{/if}}
                     {{/each}}
                 </dl>
                 {{/if}}
@@ -78,15 +96,6 @@
                             {{event_date.date}}
                         </dd>
                     </dl>
-                {{/if}}
-                {{#if quantity_backordered '>' 0}}
-                    {{#if (subtract quantity quantity_backordered) '>' 0}}
-                        <p class="account-product-backorder-prompts">{{lang 'products.quantity_on_hand' quantity=(subtract quantity quantity_backordered)}}</p>
-                    {{/if}}
-                    <p class="account-product-backorder-prompts">{{lang 'products.quantity_backordered' quantity=quantity_backordered}}</p>
-                    {{#if backorder_message}}
-                        <p class="account-product-backorder-prompts">{{backorder_message}}</p>
-                    {{/if}}
                 {{/if}}
                 {{#if refunded}}
                     <p class="account-product-refundQty">{{lang 'account.orders.refunded_quantity' qty=refunded_qty}}</p>


### PR DESCRIPTION
#### What?

- Display backorder prompts (`quantity_ready_to_ship`, `quantity_backordered`, `backorder_message`) for bundled picklist options on the account order details page, using the new `linked_bundled_item` field on each option
- Switch parent item ready-to-ship quantity to use the new `quantity_ready_to_ship` field directly instead of computing it via subtraction

Some minor styling/design changes:
- Move parent item backorder prompts to appear directly below the product name, above options
- Reduce backorder prompt font size from `smaller` to `smallest` for both parent and bundled items
- Add spacing between parent backorder prompts and the options list, and between each bundled item's backorder prompts and the next option row

> [!NOTE]
> All gating and show/hide logic for backorder fields (quantity_backordered, quantity_ready_to_ship, backorder_message, linked_bundled_item) is handled server-side; the theme renders fields purely based on their presence in the data, no need of extra gating.  

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [BACK-692](https://bigcommercecloud.atlassian.net/browse/BACK-692) [FE] Render backorder prompts for picklist items on My orders

#### Screenshots (if appropriate)

<img width="830" height="835" alt="Screenshot 2026-06-23 at 6 32 55 PM" src="https://github.com/user-attachments/assets/bb411d5e-fa3b-4ce2-8d51-fcca72c41edc" />

<img width="874" height="666" alt="Screenshot 2026-06-23 at 6 47 03 PM" src="https://github.com/user-attachments/assets/b7f957fe-e397-4921-b07f-38f863b5378a" />

[BACK-692]: https://bigcommercecloud.atlassian.net/browse/BACK-692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template and SCSS-only changes that render optional order fields; no checkout, auth, or client-side inventory logic.
> 
> **Overview**
> **My Account order details** now surfaces backorder copy for **picklist bundled options**, not just the parent line item.
> 
> Parent prompts use **`quantity_ready_to_ship`**, **`quantity_backordered`**, and **`backorder_message`** when the API sends them (replacing the old block that only showed when `quantity_backordered > 0` and derived on-hand from `quantity - quantity_backordered`). Those prompts sit **under the product title**, before the options list. Each option can show the same three fields from **`linked_bundled_item`** under its value.
> 
> **Styling:** backorder text uses **`fontSize("smallest")`**, with extra margin before the options **`definitionList`** and before the next option row when prompts precede **`dt`/`dd`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd424a7fbdeef75bf6cc0943d2585ef3ffc0c991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->