### PR TITLE
feat(orders): ORDERS-7681 add Cancel return button to return-detailsjs page

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -22,8 +22,8 @@ const pageClasses = {
     account_inbox: getAccount,
     account_saved_return: getAccount,
     account_returns: getAccount,
-    account_return_detail: getAccount,
-    return_detail: getAccount,
+    account_return_detail: getReturnDetails,
+    return_detail: getReturnDetails,
     account_paymentmethods: getAccount,
     account_addpaymentmethod: getAccount,
     account_editpaymentmethod: getAccount,
@@ -57,11 +57,7 @@ const pageClasses = {
     wishlists: () => import('./theme/wishlist'),
 };
 
-const customClasses = {
-    // Loads the return-details cancel handler alongside getAccount, keyed by template
-    // so it runs regardless of the page_type assigned to the return-details page.
-    'pages/account/return-details': getReturnDetails,
-};
+const customClasses = {};
 
 /**
  * This function gets added to the global window and then called

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -4,6 +4,7 @@ import Global from './theme/global';
 
 const getAccount = () => import('./theme/account');
 const getCreateReturn = () => import('./theme/create-return');
+const getReturnDetails = () => import('./theme/return-details');
 const getLogin = () => import('./theme/auth');
 const noop = null;
 
@@ -56,7 +57,11 @@ const pageClasses = {
     wishlists: () => import('./theme/wishlist'),
 };
 
-const customClasses = {};
+const customClasses = {
+    // Loads the return-details cancel handler alongside getAccount, keyed by template
+    // so it runs regardless of the page_type assigned to the return-details page.
+    'pages/account/return-details': getReturnDetails,
+};
 
 /**
  * This function gets added to the global window and then called

--- a/assets/js/theme/return-details.js
+++ b/assets/js/theme/return-details.js
@@ -1,8 +1,12 @@
-import PageManager from './page-manager';
+import Account from './account';
 import { showAlertModal } from './global/modal';
 
-export default class ReturnDetails extends PageManager {
+export default class ReturnDetails extends Account {
     onReady() {
+        // Run the shared account-page behavior (this page is mapped to this module
+        // instead of Account in app.js).
+        super.onReady();
+
         this.root = document.querySelector('[data-return-details]');
         if (!this.root) return;
 
@@ -10,9 +14,12 @@ export default class ReturnDetails extends PageManager {
         const cancelBtn = this.root.querySelector('[data-return-cancel]');
         if (!cancelBtn) return;
 
-        // The return's entity ID is the `return_id` query param the page is reached with
-        // (/account.php?action=view_return&return_id={id}).
+        // The return's ID is the `return_id` query param the page is reached with
+        // (/account.php?action=view_return&return_id={id}). It's a UUID string.
         this.returnId = new URLSearchParams(window.location.search).get('return_id');
+
+        // Without a return ID the cancel mutation can't run, so leave the button inert.
+        if (!this.returnId) return;
 
         cancelBtn.addEventListener('click', () => this.openCancelModal(cancelBtn));
     }
@@ -35,17 +42,18 @@ export default class ReturnDetails extends PageManager {
         if (this.isCancelling) return;
         this.isCancelling = true;
 
-        this.clearError();
         const cancelBtn = this.root.querySelector('[data-return-cancel]');
+        const overlay = this.root.querySelector('.loadingOverlay');
         if (cancelBtn) cancelBtn.disabled = true;
+        if (overlay) overlay.style.display = 'block';
+        this.clearError();
 
         try {
             const response = await this.cancelReturn(this.returnId);
-            const errorMessages = this.getCancelErrorMessages(response);
+            const errorMessages = this.getErrorMessages(response);
 
-            if (errorMessages.length) {
+            if (errorMessages.length > 0) {
                 this.showError(errorMessages.join(' '));
-                if (cancelBtn) cancelBtn.disabled = false;
                 return;
             }
 
@@ -53,23 +61,29 @@ export default class ReturnDetails extends PageManager {
             window.location.reload();
         } catch (error) {
             this.showError(this.context.genericError);
-            if (cancelBtn) cancelBtn.disabled = false;
         } finally {
             this.isCancelling = false;
+            if (cancelBtn) cancelBtn.disabled = false;
+            if (overlay) overlay.style.display = '';
         }
     }
 
     showError(message) {
-        const errorBox = this.root.querySelector('[data-return-error]');
+        const errorBox = document.getElementById('return-cancel-error');
         if (!errorBox) return;
 
-        errorBox.textContent = message || '';
+        const messageEl = errorBox.querySelector('[data-return-error-message]');
+        if (messageEl) messageEl.textContent = message || '';
         errorBox.style.display = '';
     }
 
     clearError() {
-        const errorBox = this.root.querySelector('[data-return-error]');
-        if (errorBox) errorBox.style.display = 'none';
+        const errorBox = document.getElementById('return-cancel-error');
+        if (!errorBox) return;
+
+        const messageEl = errorBox.querySelector('[data-return-error-message]');
+        if (messageEl) messageEl.textContent = '';
+        errorBox.style.display = 'none';
     }
 
     // Storefront GraphQL `cancelReturn` mutation. The token is injected into the
@@ -103,7 +117,7 @@ export default class ReturnDetails extends PageManager {
         }).then(response => response.json());
     }
 
-    getCancelErrorMessages(response) {
+    getErrorMessages(response) {
         const transportErrors = Array.isArray(response?.errors) ? response.errors : [];
         const cancelErrors = Array.isArray(response?.data?.order?.return?.cancelReturn?.errors)
             ? response.data.order.return.cancelReturn.errors

--- a/assets/js/theme/return-details.js
+++ b/assets/js/theme/return-details.js
@@ -1,0 +1,117 @@
+import PageManager from './page-manager';
+import { showAlertModal } from './global/modal';
+
+export default class ReturnDetails extends PageManager {
+    onReady() {
+        this.root = document.querySelector('[data-return-details]');
+        if (!this.root) return;
+
+        // The cancel action is only server-rendered for open returns.
+        const cancelBtn = this.root.querySelector('[data-return-cancel]');
+        if (!cancelBtn) return;
+
+        // The return's entity ID is the `return_id` query param the page is reached with
+        // (/account.php?action=view_return&return_id={id}).
+        this.returnId = new URLSearchParams(window.location.search).get('return_id');
+
+        cancelBtn.addEventListener('click', () => this.openCancelModal(cancelBtn));
+    }
+
+    // Confirmation modal — uses the shared alert modal (showAlertModal), the same
+    // pattern used elsewhere (e.g. removing a cart item).
+    openCancelModal(triggerEl) {
+        const message = `${this.context.returnCancelConfirmMessage} ${this.context.returnCancelConfirmBody}`;
+
+        showAlertModal(message, {
+            icon: 'warning',
+            showCancelButton: true,
+            $preModalFocusedEl: $(triggerEl),
+            onConfirm: () => this.confirmCancel(),
+        });
+    }
+
+    async confirmCancel() {
+        // Ignore repeat clicks while the request is in flight.
+        if (this.isCancelling) return;
+        this.isCancelling = true;
+
+        this.clearError();
+        const cancelBtn = this.root.querySelector('[data-return-cancel]');
+        if (cancelBtn) cancelBtn.disabled = true;
+
+        try {
+            const response = await this.cancelReturn(this.returnId);
+            const errorMessages = this.getCancelErrorMessages(response);
+
+            if (errorMessages.length) {
+                this.showError(errorMessages.join(' '));
+                if (cancelBtn) cancelBtn.disabled = false;
+                return;
+            }
+
+            // Reload so the page reflects the updated return status.
+            window.location.reload();
+        } catch (error) {
+            this.showError(this.context.genericError);
+            if (cancelBtn) cancelBtn.disabled = false;
+        } finally {
+            this.isCancelling = false;
+        }
+    }
+
+    showError(message) {
+        const errorBox = this.root.querySelector('[data-return-error]');
+        if (!errorBox) return;
+
+        errorBox.textContent = message || '';
+        errorBox.style.display = '';
+    }
+
+    clearError() {
+        const errorBox = this.root.querySelector('[data-return-error]');
+        if (errorBox) errorBox.style.display = 'none';
+    }
+
+    // Storefront GraphQL `cancelReturn` mutation. The token is injected into the
+    // page context from `settings.storefront_api.token`.
+    cancelReturn(returnId) {
+        return fetch('/graphql', {
+            method: 'POST',
+            credentials: 'include',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${this.context.storefrontApiToken}`,
+            },
+            body: JSON.stringify({
+                query: `mutation CancelReturn($input: CancelOrderReturnInput!) {
+                    order {
+                        return {
+                            cancelReturn(input: $input) {
+                                entityId
+                                errors {
+                                    __typename
+                                    ... on Error {
+                                        message
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }`,
+                variables: { input: { returnId } },
+            }),
+        }).then(response => response.json());
+    }
+
+    getCancelErrorMessages(response) {
+        const transportErrors = Array.isArray(response?.errors) ? response.errors : [];
+        const cancelErrors = Array.isArray(response?.data?.order?.return?.cancelReturn?.errors)
+            ? response.data.order.return.cancelReturn.errors
+            : [];
+
+        return transportErrors
+            .concat(cancelErrors)
+            .map(error => error.message)
+            .filter(Boolean);
+    }
+}

--- a/assets/scss/components/stencil/returnDetails/_returnDetails.scss
+++ b/assets/scss/components/stencil/returnDetails/_returnDetails.scss
@@ -205,3 +205,29 @@
     top: auto;
     width: 1px;
 }
+
+
+// =============================================================================
+// SIDEBAR — Action (e.g. Cancel return)
+// =============================================================================
+
+.returnDetails-actions {
+    margin-top: spacing("double");
+}
+
+.returnDetails-cancelBtn {
+    margin: 0;
+}
+
+
+// =============================================================================
+// PAGE-LEVEL ERROR (e.g. failed cancellation)
+// =============================================================================
+
+.returnDetails-error {
+    margin-bottom: spacing("single");
+    padding: spacing("half") spacing("single");
+    border-radius: remCalc(4px);
+    background-color: color("error", "light");
+    color: color("error");
+}

--- a/assets/scss/components/stencil/returnDetails/_returnDetails.scss
+++ b/assets/scss/components/stencil/returnDetails/_returnDetails.scss
@@ -231,3 +231,13 @@
     background-color: color("error", "light");
     color: color("error");
 }
+
+.returnDetails-errorHeading {
+    font-weight: fontWeight("semibold");
+    margin: 0 0 spacing("eighth");
+}
+
+.returnDetails-error .alertBox-message {
+    margin: 0;
+    color: color("error");
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -478,6 +478,7 @@
             "take_me_back": "Take me back",
             "actions_heading": "Action",
             "cancel_action": "Cancel return",
+            "cancel_error_heading": "Failed to cancel return",
             "cancel_confirm_message": "Are you sure you want to cancel this return?",
             "cancel_confirm_body": "This action cannot be undone.",
             "list": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -476,6 +476,10 @@
             "confirmation_message_primary": "We've received your return request and will review it within 1-2 business days.",
             "confirmation_message_secondary": "You'll receive an email confirmation with your RMA number and return instructions.",
             "take_me_back": "Take me back",
+            "actions_heading": "Action",
+            "cancel_action": "Cancel return",
+            "cancel_confirm_message": "Are you sure you want to cancel this return?",
+            "cancel_confirm_body": "This action cannot be undone.",
             "list": {
                 "last_update":"Last Update",
                 "return_submitted": "Return Submitted",

--- a/templates/pages/account/return-details.html
+++ b/templates/pages/account/return-details.html
@@ -5,11 +5,17 @@
     storefront. Reached via /account.php?action=view_return&return_id={id}.
 --}}
 
+{{!-- Cancel action: token for the cancelReturn mutation + localized modal copy. --}}
+{{~inject 'storefrontApiToken' settings.storefront_api.token}}
+{{~inject 'returnCancelConfirmMessage' (lang 'account.returns.cancel_confirm_message')}}
+{{~inject 'returnCancelConfirmBody' (lang 'account.returns.cancel_confirm_body')}}
+
 {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
 {{> components/account/navigation account_page='returns'}}
 
 {{#if return_detail}}
-    <main class="returnDetails">
+    <main class="returnDetails" data-return-details>
+        <div class="returnDetails-error alertBox alertBox--error" data-return-error style="display: none;" role="alert"></div>
         <div class="returnDetails-layout">
 
             <section class="returnDetails-main">
@@ -80,6 +86,15 @@
                         <dd class="returnDetails-summaryLabel">{{lang 'account.returns.details.order_number' id=return_detail.orderId}}</dd>
                     </div>
                 </dl>
+
+                {{!-- Action section (e.g. Cancel return) — only shown for open returns. --}}
+                {{#if return_detail.status '===' 'OPEN'}}
+                    <div class="returnDetails-actions">
+                        <h2 class="returnDetails-sectionHeading">{{lang 'account.returns.actions_heading'}}</h2>
+                        <hr class="returnDetails-divider">
+                        <button type="button" class="button returnDetails-cancelBtn" data-return-cancel>{{lang 'account.returns.cancel_action'}}</button>
+                    </div>
+                {{/if}}
             </aside>
 
         </div>

--- a/templates/pages/account/return-details.html
+++ b/templates/pages/account/return-details.html
@@ -15,7 +15,13 @@
 
 {{#if return_detail}}
     <main class="returnDetails" data-return-details>
-        <div class="returnDetails-error alertBox alertBox--error" data-return-error style="display: none;" role="alert"></div>
+        <div class="loadingOverlay"></div>
+
+        <div id="return-cancel-error" class="alertBox alertBox--error returnDetails-error" style="display: none;" role="alert">
+            <p class="returnDetails-errorHeading">{{lang 'account.returns.cancel_error_heading'}}</p>
+            <p class="alertBox-message" data-return-error-message></p>
+        </div>
+
         <div class="returnDetails-layout">
 
             <section class="returnDetails-main">


### PR DESCRIPTION
#### What?

This PR introduces the ability for shoppers to Cancel a return that is in `OPEN` status via the new shopper facing returns portal return details page

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.
https://bigcommercecloud.atlassian.net/browse/ORDERS-7681

#### Screenshots (if appropriate)


https://github.com/user-attachments/assets/1064bc34-ad2a-4cee-b224-5afb6d32b532

The return ends up cancelled
<img width="1506" height="848" alt="image" src="https://github.com/user-attachments/assets/8838943b-7e1b-460d-ab8d-3fbdacbe7fac" />


When the cancelation errors

https://github.com/user-attachments/assets/9f84edd0-3cf5-4335-b014-e7feaffa6cb5





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mutates order return state through authenticated GraphQL; follows the same pattern as create-return but incorrect authorization or status handling could let shoppers cancel returns they should not.
> 
> **Overview**
> Shoppers with **OPEN** returns can **cancel** them from the account return-details page instead of only viewing static details.
> 
> Return detail routes (`account_return_detail`, `return_detail`) now load a dedicated **`return-details`** module (extending account behavior) that wires a sidebar **Cancel return** button to a confirmation modal, then calls the Storefront GraphQL **`cancelReturn`** mutation using the injected API token and `return_id` from the URL. Success reloads the page; failures show a page-level error with loading/disabled state while the request runs.
> 
> The template adds the cancel action (OPEN only), loading overlay, error region, and context injections; **en.json** adds cancel copy; SCSS styles the action block and error alert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b4f55fb337eceda715d44bc45433e3b2579dbfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->