### PR TITLE
feat(returns): ORDERS-7857 add loading state at return form submission

### DIFF
--- a/assets/js/theme/create-return.js
+++ b/assets/js/theme/create-return.js
@@ -39,7 +39,9 @@ export default class CreateReturn extends PageManager {
             this.isSubmitting = true;
 
             const submitBtn = document.getElementById('return-new-submitBtn');
+            const overlay = document.querySelector('[data-new-return-view] .loadingOverlay');
             if (submitBtn) submitBtn.disabled = true;
+            if (overlay) overlay.style.display = 'block';
             this.clearError();
 
             try {
@@ -57,6 +59,7 @@ export default class CreateReturn extends PageManager {
             } finally {
                 this.isSubmitting = false;
                 if (submitBtn) submitBtn.disabled = false;
+                if (overlay) overlay.style.display = '';
             }
         });
     }

--- a/templates/pages/create-return.html
+++ b/templates/pages/create-return.html
@@ -7,6 +7,7 @@
     {{#with order}}
 
     <div data-new-return-view>
+        <div class="loadingOverlay"></div>
 
     <div class="newReturn-header">
         <div class="newReturn-titleGroup">


### PR DESCRIPTION
#### What?

Add a loading state during return form submission to prevent customers from unexpected interactions and gracefully inform of loading state

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

https://bigcommercecloud.atlassian.net/browse/ORDERS-7857

#### Screenshots (if appropriate)


https://github.com/user-attachments/assets/b6633ae1-56c4-489d-af30-caf6cd09b614



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX change on the returns form with no auth, payment, or API contract changes.
> 
> **Overview**
> Shows a **loading overlay** on the create-return view while the `createReturn` GraphQL request runs, alongside the existing submit guard and disabled submit button.
> 
> The template adds a `loadingOverlay` element under `[data-new-return-view]`; submit handling toggles its visibility for the duration of the async call and clears it in `finally` so errors and success both restore the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d26293ba912012388bcfca38e39b9de20e2a7b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->