### PR TITLE
feat(returns): ORDERS-7751 - add return details page data

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -471,12 +471,12 @@
             "details": {
                 "return_number": "Return #{id}",
                 "order_number": "Order #{id}",
+                "order_number_label":"Order#",
                 "date_submitted": "Return Submitted",
                 "last_update": "Last Update",
                 "sku": "SKU",
                 "quantity": "Quantity",
                 "reason": "Reason",
-                "item_status": "Status",
                 "not_found": "We couldn't find the details for this return."
             },
             "status": {

--- a/templates/pages/account/return-details.html
+++ b/templates/pages/account/return-details.html
@@ -35,9 +35,9 @@
                                       `image` field is surfaced it will render automatically. --}}
                                 {{> components/common/responsive-img
                                     image=image
-                                    default_image=../theme_settings.default_image_product
-                                    fallback_size=../theme_settings.productthumb_size
-                                    lazyload=../theme_settings.lazyload_mode
+                                    default_image=../../theme_settings.default_image_product
+                                    fallback_size=../../theme_settings.productthumb_size
+                                    lazyload=../../theme_settings.lazyload_mode
                                     class="returnDetails-itemThumbnail"
                                 }}
                             </div>
@@ -76,7 +76,7 @@
                         <dd class="returnDetails-summaryValue">{{#if return_detail.lastUpdated}}{{moment return_detail.lastUpdated format="Do MMM YYYY"}}{{else}}{{moment return_detail.dateSubmitted format="Do MMM YYYY"}}{{/if}}</dd>
                     </div>
                     <div class="returnDetails-summaryRow">
-                        <dt class="returnDetails-sr-only">Order#</dt>
+                        <dt class="returnDetails-sr-only">{{lang 'account.returns.details.order_number_label'}}</dt>
                         <dd class="returnDetails-summaryLabel">{{lang 'account.returns.details.order_number' id=return_detail.orderId}}</dd>
                     </div>
                 </dl>


### PR DESCRIPTION
#### What?

Addresses some feedback from #2680 

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [ORDERS-7751](https://bigcommercecloud.atlassian.net/browse/ORDERS-7751)

#### Screenshots (if appropriate)

<img width="1360" height="737" alt="image" src="https://github.com/user-attachments/assets/bf27c554-fd62-412b-9e83-e789f656ab7a" />

[ORDERS-7751]: https://bigcommercecloud.atlassian.net/browse/ORDERS-7751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and localization-only changes on the return details template with no auth or data-layer impact.
> 
> **Overview**
> Addresses review feedback on the account **return details** page with small i18n and template fixes.
> 
> The screen-reader label for the order number in the summary sidebar is no longer hardcoded as `Order#`; it uses a new **`account.returns.details.order_number_label`** string in `lang/en.json`. The unused **`item_status`** copy under return details was removed from English strings.
> 
> Inside the return items **`{{#each}}`** loop, **`responsive-img`** partial arguments for default product image, thumb size, and lazyload were corrected from one level up (`../theme_settings`) to two (`../../theme_settings`) so theme settings resolve correctly from the nested context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 234aed4752bed0e6f633b0b0f33acbf2ccf1f980. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->