### PR TITLE
feat(returns): ORDERS-7900: strike requested with resolved resolution on returns details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix shipment info showing for cancelled orders [#2654](https://github.com/bigcommerce/cornerstone/pull/2654)
 - Render backorder prompts on My Account "Your orders" page [#2650](https://github.com/bigcommerce/cornerstone/pull/2650)
 - Gate account orders list "Return Items" link on returns settings (ORDERS-7704) [#2653](https://github.com/bigcommerce/cornerstone/pull/2653)
-- Added new Return list view (ORDERS-7717) [#2664] (https://github.com/bigcommerce/cornerstone/pull/2664) 
+- Added new Return list view (ORDERS-7717) [#2664](https://github.com/bigcommerce/cornerstone/pull/2664)
+- Added requested and resolved resolution view on return details page (ORDERS-7900) [#2697](https://github.com/bigcommerce/cornerstone/pull/2697)
 
 ## 6.19.1 (04-09-2026)
 - Update stencil-utils versionto 6.23.0 [#2638](https://github.com/bigcommerce/cornerstone/pull/2638)

--- a/assets/scss/components/stencil/returnDetails/_returnDetails.scss
+++ b/assets/scss/components/stencil/returnDetails/_returnDetails.scss
@@ -167,6 +167,15 @@
     color: stencilColor("color-textBase");
 }
 
+.returnDetails-itemMetaValue--strikethrough {
+    text-decoration: line-through;
+    color: stencilColor("color-textSecondary");
+}
+
+.returnDetails-finalResolution {
+    display: block;
+}
+
 
 // =============================================================================
 // SIDEBAR — Summary

--- a/lang/en.json
+++ b/lang/en.json
@@ -508,6 +508,9 @@
                 "sku": "SKU",
                 "quantity": "Quantity",
                 "reason": "Reason",
+                "request": "Request",
+                "final_resolution": "(Final resolution)",
+                "resolution_changed_to": "changed to",
                 "not_found": "We couldn't find the details for this return."
             },
             "status": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -511,6 +511,12 @@
                 "request": "Request",
                 "final_resolution": "(Final resolution)",
                 "resolution_changed_to": "changed to",
+                "resolution": {
+                    "refund": "Refund",
+                    "exchange": "Exchange",
+                    "store_credit": "Store credit",
+                    "decline": "Declined"
+                },
                 "not_found": "We couldn't find the details for this return."
             },
             "status": {

--- a/templates/pages/account/return-details.html
+++ b/templates/pages/account/return-details.html
@@ -68,12 +68,13 @@
                                 <div class="returnDetails-itemMetaRow">
                                     <dt class="returnDetails-itemMetaLabel">{{lang 'account.returns.details.request'}}</dt>
                                     <dd class="returnDetails-itemMetaValue">
+                                        {{~!-- Resolution label: custom resolutions show the merchant name; system ones are translated from their enum token. --~}}
                                         {{#if requestedDiffersFromResolved}}
-                                            <span class="returnDetails-itemMetaValue--strikethrough">{{requestedResolutionName}}</span>
+                                            <span class="returnDetails-itemMetaValue--strikethrough">{{#if requestedResolutionType '===' 'CUSTOM'}}{{requestedResolutionName}}{{else}}{{lang (concat 'account.returns.details.resolution.' (toLowerCase requestedResolutionType))}}{{/if}}</span>
                                             <span class="returnDetails-sr-only">{{lang 'account.returns.details.resolution_changed_to'}}</span>
-                                            <span class="returnDetails-finalResolution">{{resolvedResolutionName}} {{lang 'account.returns.details.final_resolution'}}</span>
+                                            <span class="returnDetails-finalResolution">{{#if resolvedResolutionType '===' 'CUSTOM'}}{{resolvedResolutionName}}{{else}}{{lang (concat 'account.returns.details.resolution.' (toLowerCase resolvedResolutionType))}}{{/if}} {{lang 'account.returns.details.final_resolution'}}</span>
                                         {{else}}
-                                            {{requestedResolutionName}}
+                                            {{#if requestedResolutionType '===' 'CUSTOM'}}{{requestedResolutionName}}{{else}}{{lang (concat 'account.returns.details.resolution.' (toLowerCase requestedResolutionType))}}{{/if}}
                                         {{/if}}
                                     </dd>
                                 </div>

--- a/templates/pages/account/return-details.html
+++ b/templates/pages/account/return-details.html
@@ -66,6 +66,18 @@
                                     <dd class="returnDetails-itemMetaValue">{{quantity}}</dd>
                                 </div>
                                 <div class="returnDetails-itemMetaRow">
+                                    <dt class="returnDetails-itemMetaLabel">{{lang 'account.returns.details.request'}}</dt>
+                                    <dd class="returnDetails-itemMetaValue">
+                                        {{#if requestedDiffersFromResolved}}
+                                            <span class="returnDetails-itemMetaValue--strikethrough">{{requestedResolutionName}}</span>
+                                            <span class="returnDetails-sr-only">{{lang 'account.returns.details.resolution_changed_to'}}</span>
+                                            <span class="returnDetails-finalResolution">{{resolvedResolutionName}} {{lang 'account.returns.details.final_resolution'}}</span>
+                                        {{else}}
+                                            {{requestedResolutionName}}
+                                        {{/if}}
+                                    </dd>
+                                </div>
+                                <div class="returnDetails-itemMetaRow">
                                     <dt class="returnDetails-itemMetaLabel">{{lang 'account.returns.details.reason'}}</dt>
                                     <dd class="returnDetails-itemMetaValue">{{reasonName}}</dd>
                                 </div>


### PR DESCRIPTION
#### What?

This PR utilises exposed requested and resolved item resolution mentioned in PR: https://github.com/bigcommerce/storefront/pull/5412 on return details page Stencil context for customers to view updated request status

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Jira: [ORDERS-7900](https://bigcommercecloud.atlassian.net/browse/ORDERS-7900)

#### Screenshots (if appropriate)

##### Manual testing:
Original resolution:
<img width="1617" height="925" alt="Screenshot 2026-07-10 at 11 51 21 am" src="https://github.com/user-attachments/assets/583d6b2a-6a3a-41e3-b0b4-b7989fe0bdac" />

System to system resolution:
<img width="1702" height="859" alt="Screenshot 2026-07-10 at 11 51 02 am" src="https://github.com/user-attachments/assets/eec58679-2b21-491a-bef7-3e4e6619744c" />

Custom to System resolution:
<img width="1775" height="867" alt="Screenshot 2026-07-10 at 11 51 36 am" src="https://github.com/user-attachments/assets/83ca7e55-6d2c-445b-89f9-3631aa159dc5" />


[ORDERS-7900]: https://bigcommercecloud.atlassian.net/browse/ORDERS-7900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only account return details changes driven by existing template context; no auth or checkout logic touched.
> 
> **Overview**
> **Return details** now shows each line item’s **Request** (preferred resolution) using storefront context for requested vs resolved values.
> 
> When **`requestedDiffersFromResolved`** is true, the shopper’s original resolution is **struck through** and the **final resolution** is shown with a “(Final resolution)” label; **CUSTOM** types use merchant names, system types use new **`account.returns.details.resolution.*`** strings. A screen-reader-only “changed to” phrase is included when the resolution changes.
> 
> Styling adds strikethrough/secondary color for the original request and block display for the final line. **CHANGELOG** documents ORDERS-7900 and fixes a malformed draft entry for the return list view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cc042ec074c0464eb6934fe77161a379cd20ceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->