### PR TITLE
feat(orders): ORDERS-7886 Update error message to generic message wit…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Update error message for create return page (ORDERS-7886) [#2698](https://github.com/bigcommerce/cornerstone/pull/2698)
 - Implement guest return portal page (ORDERS-7736) [#2696](https://github.com/bigcommerce/cornerstone/pull/2696)
 - Add mobile and tablet responsiveness for returns list page (ORDERS-7771)
 - Add return details page (ORDERS-7751)

--- a/assets/js/theme/create-return.js
+++ b/assets/js/theme/create-return.js
@@ -49,13 +49,13 @@ export default class CreateReturn extends PageManager {
                 const errorMessages = this.getErrorMessages(response);
 
                 if (errorMessages.length) {
-                    this.showError(errorMessages.join(' '));
+                    this.showError();
                     return;
                 }
 
                 this.showConfirmation();
             } catch (error) {
-                this.showError(this.context.genericError);
+                this.showError();
             } finally {
                 this.isSubmitting = false;
                 if (submitBtn) submitBtn.disabled = false;
@@ -76,12 +76,10 @@ export default class CreateReturn extends PageManager {
             .filter(Boolean);
     }
 
-    showError(message) {
+    showError() {
         const errorBox = document.getElementById('return-new-error');
         if (!errorBox) return;
 
-        const messageEl = errorBox.querySelector('[data-return-error-message]');
-        if (messageEl) messageEl.textContent = message || '';
         errorBox.style.display = '';
     }
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -472,6 +472,7 @@
             "qty": "Qty:",
             "total_price": "Total:",
             "error_heading": "Failed to create return",
+            "contact_merchant": "If this error persists, please contact {phone_number}",
             "submitted_successfully": "submitted successfully!",
             "confirmation_message_primary": "We've received your return request and will review it within 1-2 business days.",
             "confirmation_message_secondary": "You'll receive an email confirmation with your RMA number and return instructions.",

--- a/templates/pages/create-return.html
+++ b/templates/pages/create-return.html
@@ -25,11 +25,17 @@
 
     <div id="return-new-error" class="alertBox alertBox--error newReturn-error" style="display: none;" role="alert">
         <p class="newReturn-errorHeading">{{lang 'account.returns.error_heading'}}</p>
-        <p class="alertBox-message" data-return-error-message></p>
+        <p class="alertBox-message" data-return-error-message>
+            {{lang 'common.generic_error'}}
+            {{#if ../settings.phone_number}}
+            <p class="alertBox-message">
+                {{lang 'account.returns.contact_merchant' phone_number=../settings.phone_number }}
+            </p>
+            {{/if}}
+        </p>
     </div>
 
     <form class="form" data-new-return-form data-success-url="{{../urls.account.orders.all}}">
-
         <div class="newReturn-columnHeaders" aria-hidden="true">
             <div class="newReturn-columnHeaders-spacer"></div>
             <span class="newReturn-columnHeaders-item">{{lang 'account.orders.return.order_item'}}</span>


### PR DESCRIPTION
#### What?
Updates the error message for return creation to the generic message. As the api provided messages wont be translated into the shoppers locale and is more for 3rd party developers integrating with the storefront api.

Message also includes the channel contact phone number is available.

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- https://bigcommercecloud.atlassian.net/browse/ORDERS-7886

#### Screenshots (if appropriate)

<img width="1224" height="898" alt="image" src="https://github.com/user-attachments/assets/608676fd-aa0c-4048-a848-a477f0e0c6ca" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized copy and display-only error handling on the create-return page; no auth or data-flow changes.
> 
> **Overview**
> Create-return failures no longer surface raw GraphQL/API error text in the alert. **`create-return.js`** still detects errors but **`showError()`** only reveals the error box—no dynamic message injection.
> 
> The **`create-return.html`** alert now renders **`common.generic_error`** in the shopper’s locale, plus an optional **`account.returns.contact_merchant`** line when **`settings.phone_number`** is set. **`en.json`** adds that contact string; **`CHANGELOG.md`** documents ORDERS-7886.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ceaa9c630dd31a36feae8d34fa2d5c31dd8578f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->