### PR TITLE
fix(storefront): BACK-772 Fix shipping expectation message alignment

### DIFF
--- a/assets/scss/components/stencil/cart/_cart.scss
+++ b/assets/scss/components/stencil/cart/_cart.scss
@@ -444,6 +444,7 @@ $card-preview-zoom-bottom-offset:       6rem;
 // in both the legacy and multi-coupon (enhanced) cart layouts.
 .cart-shipping-expectation-message {
     clear: both;
+    text-align: left;
     width: 100%;
     margin: 0;
 }


### PR DESCRIPTION
#### What?

Fix alignment in cart shipping-expectation message. This is supposed to be left aligned, but current state shows right alignment

#### Requirements

- [X] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

[Issue 3](https://bigcommercecloud.atlassian.net/browse/BACK-772)


#### Screenshots (if appropriate)

##### Before

<img width="1569" height="980" alt="Screenshot 2026-07-10 at 11 12 35 pm" src="https://github.com/user-attachments/assets/4d751ac3-d6c6-4aea-b9ef-b7dc78306a7a" />

##### After

<img width="1322" height="870" alt="Screenshot 2026-07-10 at 11 10 36 pm" src="https://github.com/user-attachments/assets/c0139e3f-22c1-4815-8e04-b6a4811813da" />

ping @bigcommerce/team-trac 
