### PR TITLE
feat(storefront): BACK-779 Decouple Show backorder message from Qty on Backorder settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Decouple "Show backorder message" from "Qty on Backorder" settings so each works independently on PDP [#2701](https://github.com/bigcommerce/cornerstone/pull/2701)
 
 ## 6.20.0 (07-02-2026)
 - Display the cart shipping expectation prompt on its own full-width row beneath the Shipping label, keeping the shipping cost on the same row as the Shipping label [#2692](https://github.com/bigcommerce/cornerstone/pull/2692)

--- a/assets/js/test-unit/theme/common/picklist-backorder.spec.js
+++ b/assets/js/test-unit/theme/common/picklist-backorder.spec.js
@@ -424,11 +424,35 @@ describe('PicklistBackorder', () => {
             expect($('[data-picklist-backorder-list] li', $scope).length).toBe(0);
         });
 
-        it('skips the entire line when context.showQuantityOnBackorder is false', () => {
+        it('shows only the backorder message when showQuantityOnBackorder is false', () => {
             $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
             const renderer = new PicklistBackorder(
                 $scope,
                 { ...context, showQuantityOnBackorder: false },
+            );
+
+            renderer.render({
+                selected_picklist_options: [selection()],
+                picklist_products_details: [detail({
+                    available_on_hand: 0,
+                    available_for_backorder: 10,
+                    backorder_message_id: 2,
+                })],
+            }, 5);
+
+            const $items = $('[data-picklist-backorder-list] li', $scope);
+            expect($items.length).toBe(1);
+            const text = $items.eq(0).text();
+            expect(text).toContain('Backorder message 1');
+            expect(text).not.toContain('will be backordered');
+            expect(text).not.toContain('|');
+        });
+
+        it('hides the list when showQuantityOnBackorder is false and no backorder message exists', () => {
+            $scope = buildScope(oneAttr('Bundle 1', 98, 'opt'));
+            const renderer = new PicklistBackorder(
+                $scope,
+                { ...context, showQuantityOnBackorder: false, showBackorderMessage: false },
             );
 
             renderer.render({

--- a/assets/js/theme/common/picklist-backorder.js
+++ b/assets/js/theme/common/picklist-backorder.js
@@ -33,10 +33,6 @@ export default class PicklistBackorder {
     }
 
     buildLines(selections, detailsByProductId, mainQty) {
-        if (this.context.showQuantityOnBackorder === false) {
-            return [];
-        }
-
         const lines = [];
         const requestedQty = parseInt(mainQty, 10) || 0;
 
@@ -143,24 +139,32 @@ export default class PicklistBackorder {
             return;
         }
 
+        const showQty = this.context.showQuantityOnBackorder !== false;
         const qtyTemplate = this.context.quantityBackorderedMessage
             || '__QTY__ will be backordered';
 
         lines.forEach(({ name, qty, productId }) => {
-            const qtyMsg = qtyTemplate.replace('__QTY__', qty);
+            const qtyMsg = showQty ? qtyTemplate.replace('__QTY__', qty) : '';
             const messageText = this.lookupBackorderMessage(productId);
-            const suffix = messageText ? ` | ${messageText}` : '';
+
+            if (!qtyMsg && !messageText) return;
+
             const $li = $('<li>', {
                 class: 'productView-picklist-backorder-item',
             });
             $('<span>', {
                 class: 'productView-picklist-backorder-name',
             }).text(`${name}:`).appendTo($li);
-            $li.append(document.createTextNode(` ${qtyMsg}${suffix}`));
+            const parts = [qtyMsg, messageText].filter(Boolean);
+            $li.append(document.createTextNode(` ${parts.join(' | ')}`));
             this.$list.append($li);
         });
 
-        this.$list.show();
+        if (this.$list.children().length) {
+            this.$list.show();
+        } else {
+            this.$list.hide();
+        }
     }
 
     lookupBackorderMessage(productId) {

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -433,12 +433,6 @@ export default class ProductDetailsBase {
 
         if (!viewModel.$backordered.length) return;
 
-        if (this.context.showQuantityOnBackorder === false) {
-            viewModel.$backorderedQtyMessage.text('');
-            this.toggleBackorderedContainer(viewModel);
-            return;
-        }
-
         const contextOnHand = parseInt(this.context.availableOnHand, 10);
         const stockFromDom = parseInt(viewModel.stock.$input.text(), 10);
         let onHand = 0;
@@ -453,18 +447,16 @@ export default class ProductDetailsBase {
         const availableForBackorder = unlimited
             ? Infinity
             : parseInt(this.context.availableForBackorder, 10) || 0;
-        const backordered = Math.max(0, Math.min(qty - onHand, availableForBackorder));
+        this.backorderedQty = Math.max(0, Math.min(qty - onHand, availableForBackorder));
 
-        if (backordered > 0) {
+        if (this.context.showQuantityOnBackorder !== false && this.backorderedQty > 0) {
             const message = this.context.quantityBackorderedMessage
-                ? this.context.quantityBackorderedMessage.replace('__QTY__', backordered)
-                : `${backordered} will be backordered`;
+                ? this.context.quantityBackorderedMessage.replace('__QTY__', this.backorderedQty)
+                : `${this.backorderedQty} will be backordered`;
             viewModel.$backorderedQtyMessage.text(message);
         } else {
             viewModel.$backorderedQtyMessage.text('');
         }
-
-        this.toggleBackorderedContainer(viewModel);
     }
 
     updateBackorderMessage(passedViewModel) {
@@ -472,9 +464,7 @@ export default class ProductDetailsBase {
 
         if (!viewModel.$backordered.length) return;
 
-        const hasQtyMessage = viewModel.$backorderedQtyMessage.text().trim() !== '';
-
-        if (!hasQtyMessage) {
+        if (!this.backorderedQty || this.backorderedQty <= 0) {
             viewModel.$backorderMessage.text('');
             return;
         }
@@ -493,9 +483,10 @@ export default class ProductDetailsBase {
     }
 
     toggleBackorderedContainer(viewModel) {
-        const hasQtyMessage = viewModel.$backorderedQtyMessage.text().trim() !== '';
+        const hasContent = viewModel.$backorderedQtyMessage.text().trim() !== ''
+            || viewModel.$backorderMessage.text().trim() !== '';
 
-        if (hasQtyMessage) {
+        if (hasContent) {
             viewModel.$backordered.show();
         } else {
             viewModel.$backordered.hide();
@@ -667,6 +658,7 @@ export default class ProductDetailsBase {
         const currentQty = parseInt(viewModel.quantity.$input.val(), 10) || 0;
         this.updateQtyBackorderedMessage(currentQty, viewModel);
         this.updateBackorderMessage(viewModel);
+        this.toggleBackorderedContainer(viewModel);
         this.picklistBackorder.render(data, currentQty);
 
         this.updateDefaultAttributesForOOS(data);

--- a/assets/js/theme/common/product-details.js
+++ b/assets/js/theme/common/product-details.js
@@ -93,11 +93,13 @@ export default class ProductDetails extends ProductDetailsBase {
             // rule-hidden values or show an unavailable message for a no-longer-selected combination.
             // The corrective change runs its own optionChange for the corrected selection.
             if ($form.serialize() !== initialSelection) return;
+
             this.updateBackorderContext(response.data);
             const vm = this.getViewModel(this.$scope);
             const qty = parseInt(vm.quantity.$input.val(), 10) || 0;
             this.updateQtyBackorderedMessage(qty, vm);
             this.updateBackorderMessage(vm);
+            this.toggleBackorderedContainer(vm);
             this.picklistBackorder.render(response.data, qty);
             this.updateDefaultAttributesForOOS(response.data);
             // Apply out-of-stock hide/show from this same payload before the rule pass, so rule
@@ -417,6 +419,7 @@ export default class ProductDetails extends ProductDetailsBase {
             this.updateProductDetailsData();
             this.updateQtyBackorderedMessage(qty, viewModel);
             this.updateBackorderMessage(viewModel);
+            this.toggleBackorderedContainer(viewModel);
             this.updateAddToCartForQty(qty, viewModel);
             this.picklistBackorder.rerender(qty);
         });
@@ -437,6 +440,7 @@ export default class ProductDetails extends ProductDetailsBase {
             this.updateProductDetailsData();
             this.updateQtyBackorderedMessage(qty, viewModel);
             this.updateBackorderMessage(viewModel);
+            this.toggleBackorderedContainer(viewModel);
             this.updateAddToCartForQty(qty, viewModel);
             this.picklistBackorder.rerender(qty);
         });

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -231,7 +231,7 @@
     font-weight: fontWeight("bold");
 }
 
-[data-backorder-message]:not(:empty)::before {
+[data-qty-backordered-message]:not(:empty) + [data-backorder-message]:not(:empty)::before {
     content: "| ";
 }
 


### PR DESCRIPTION
#### What?

Decouple the `backorder message` and `Qty on backorder` settings. Both these settings are independent settings on the merchant inventory settings page. These are two separate concepts and should be treated as such.

#### Requirements

- [X] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [BACK-779](https://bigcommercecloud.atlassian.net/browse/BACK-779)

The issue showing that the backorder message is tied to the qty on backorder checkbox.

https://github.com/user-attachments/assets/f2f75d51-2e7d-4b20-9e88-c86008146358


#### Screenshots (if appropriate)

The fix now shows the backorder message is separate from the qty on backorder checkbox.

https://github.com/user-attachments/assets/4e9f0139-1f1a-46cd-ba56-9503dd179936

ping @bigcommerce/team-trac @animesh1987 


[BACK-779]: https://bigcommercecloud.atlassian.net/browse/BACK-779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> PDP display logic and unit tests only; no auth, checkout, or server-side inventory changes.
> 
> **Overview**
> **Decouples merchant inventory toggles** so **Show backorder message** and **Qty on backorder** work independently on the product page (main product and picklist bundles).
> 
> On the main PDP, backorder quantity is still computed for messaging logic, but the **“N will be backordered”** line only renders when **Qty on backorder** is enabled; the **custom backorder message** can still show when **Show backorder message** is on. The backorder block stays visible if **either** line has content, and `toggleBackorderedContainer` runs after both updates (including on qty change and initial option load).
> 
> **Picklist backorder** no longer bails out entirely when qty display is off—it can show **message-only** lines, omits qty/`|` when appropriate, and hides the list when nothing would display.
> 
> **SCSS** only adds the `|` separator between qty and message when **both** elements are non-empty, so message-only layouts don’t get a stray pipe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b89916cd4979511f92a8093cf6435d7416414497. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->