### PR TITLE
chore(promotions): PROMO-1562 fix plural for featured promotion callouts

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -837,7 +837,7 @@
         },
         "card_default_image_alt": "Image coming soon",
         "featured_promotions": {
-            "more_offers": "more offers"
+            "more_offers": "{count, plural, one {more offer} other {more offers}}"
         }
     },
     "invoice": {

--- a/templates/components/products/promotion-callout.html
+++ b/templates/components/products/promotion-callout.html
@@ -5,7 +5,7 @@
         <span class="promotionCallout-text">{{promotions.[0].text}}</span>
         {{#if promotions.[1]}}
         <span class="promotionCallout-more">
-            +{{subtract promotions.length 1}} {{lang 'products.featured_promotions.more_offers'}}
+            +{{subtract promotions.length 1}} {{lang 'products.featured_promotions.more_offers' count=(subtract promotions.length 1)}}
         </span>
         {{/if}}
     </div>


### PR DESCRIPTION
#### What?

**Before fix**: show plural incorrectly "+1 more offers": 

<img width="668" height="938" alt="SCR-20260714-no9" src="https://github.com/user-attachments/assets/3dddd6bd-eaae-4884-86dd-d5902a9c4051" />

**After fix**: no plural for 1, and show plural for many: 

<img width="688" height="952" alt="SCR-20260714-np6" src="https://github.com/user-attachments/assets/2bc0c332-88ea-4984-bb59-7d474243607c" />

<img width="614" height="888" alt="SCR-20260714-nv6" src="https://github.com/user-attachments/assets/3cae2f63-f671-459c-85a6-032274cf8b09" />


#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- https://bigcommercecloud.atlassian.net/browse/PROMO-1562

#### Screenshots (if appropriate)

As above

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and template-only change for compact promotion callouts; no auth, checkout, or data-path impact.
> 
> **Overview**
> Fixes incorrect plural copy on **compact** product promotion callouts (e.g. "+1 more offers") by wiring the extra-offer count into i18n plural rules.
> 
> `products.featured_promotions.more_offers` in `lang/en.json` now uses `{count, plural, one {more offer} other {more offers}}`, and `promotion-callout.html` passes `count=(subtract promotions.length 1)` into the `lang` helper so singular shows for one additional offer and plural for two or more.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16d495620b40b270a0ec417410978d1b04a6620c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->