### PR TITLE
feat(orders): ORDERS-7736 add client side validation for guest return…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Add client side validation on guest return portal (ORDERS-7736) [#2703](https://github.com/bigcommerce/cornerstone/pull/2703)
 - Update error message for create return page (ORDERS-7886) [#2698](https://github.com/bigcommerce/cornerstone/pull/2698)
 - Implement guest return portal page (ORDERS-7736) [#2696](https://github.com/bigcommerce/cornerstone/pull/2696)
 - Add mobile and tablet responsiveness for returns list page (ORDERS-7771)

--- a/assets/js/theme/guest-return-portal.js
+++ b/assets/js/theme/guest-return-portal.js
@@ -1,17 +1,58 @@
 import PageManager from './page-manager';
 import NotFoundError from './not-found-error';
+import nod from './common/nod';
+import {
+    announceInputErrorMessage,
+} from './common/utils/form-utils';
+import forms from './common/models/forms';
 
 export default class GuestReturnPortal extends PageManager {
     onReady() {
         const form = document.querySelector('[data-guest-return-portal-form]');
         if (!form) return;
 
+        this.registerValidation();
         this.bindSubmit(form);
+    }
+
+    registerValidation() {
+        this.validator = nod({
+            submit: '.guest-return-portal-form button[type="submit"]',
+            tap: announceInputErrorMessage,
+        });
+
+        this.validator.add([
+            {
+                selector: '.guest-return-portal-form input#guest-return-email-input',
+                validate: (cb, val) => {
+                    const result = forms.email(val);
+
+                    cb(result);
+                },
+                errorMessage: this.context.useValidEmail,
+            },
+            {
+                selector: '.guest-return-portal-form input#guest-return-order-input',
+                validate: (cb, val) => {
+                    const result = forms.numbersOnly(val);
+
+                    cb(result);
+                },
+                errorMessage: this.context.invalidOrder,
+            },
+        ]);
     }
 
     bindSubmit(form) {
         form.addEventListener('submit', async event => {
             event.preventDefault();
+
+            this.validator.performCheck();
+
+            if (!this.validator.areAll('valid')) {
+                return;
+            }
+
             // Ignore clicks while a request is in flight
             if (this.isSubmitting) return;
             this.isSubmitting = true;

--- a/lang/en.json
+++ b/lang/en.json
@@ -498,7 +498,8 @@
                 "order_id_placeholder": "E.g. 39456",
                 "order_id_description": "You can find your order ID in your order confirmation email",
                 "not_found_error": "We couldn’t find an order with that ID and email. Please double-check your details.",
-                "start_the_return": "Start the return"
+                "start_the_return": "Start the return",
+                "invalid_order": "Please enter a valid order ID (numbers only)."
             },
             "details": {
                 "return_number": "Return #{id}",

--- a/templates/pages/guest-return-portal.html
+++ b/templates/pages/guest-return-portal.html
@@ -15,6 +15,7 @@
     <div class="guest-return-portal-row">
         <form class="form guest-return-portal-form" data-guest-return-portal-form>
             <div class="form-field">
+                {{inject 'useValidEmail' (lang 'forms.validate.common.email_address')}}
                 <label for="guest-return-email-input" class="form-label">
                     {{lang 'account.returns.guest.email'}}
                 </label>
@@ -26,6 +27,7 @@
                 />
             </div>
             <div class="form-field">
+                {{inject 'invalidOrder' (lang 'account.returns.guest.invalid_order')}}
                 <label for="guest-return-order-input" class="form-label">
                     {{lang 'account.returns.guest.order_id'}}
                 </label>


### PR DESCRIPTION
… portal

#### What?

Adds client side validation to check inputs are valid before making network request

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- https://bigcommercecloud.atlassian.net/browse/ORDERS-7736

#### Screenshots (if appropriate)

<img width="594" height="484" alt="image" src="https://github.com/user-attachments/assets/dfb4910f-ee34-48ce-91b5-7fe73fef9d27" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only validation on the guest returns form; no auth, payment, or server contract changes beyond skipping invalid submits.
> 
> **Overview**
> Adds **client-side validation** on the guest return portal so email and order ID are checked before the GraphQL `startReturnGuestSession` request runs.
> 
> `guest-return-portal.js` wires **nod** with `forms.email` and `forms.numbersOnly`, uses `announceInputErrorMessage` for accessibility, and blocks submit when `performCheck()` / `areAll('valid')` fail. The template **injects** `useValidEmail` and `invalidOrder` from lang keys; **en.json** adds `account.returns.guest.invalid_order` for numeric-only order IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3d41496a7e027d1786ccc65eeaa1f1aa87d41a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->