### PR TITLE
feat(orders): ORDERS-7935 add badge for CANCELLED order returns

### DIFF
--- a/assets/scss/components/stencil/account/_account.scss
+++ b/assets/scss/components/stencil/account/_account.scss
@@ -398,6 +398,11 @@ $account-backorder-textColor: #757575;
     color: stencilColor("color-textBase");
 }
 
+.account-orderStatus-label--cancelled {
+    background-color: color("greys", "darker");
+    color: color("whites", "bright");
+}
+
 .account-orderStatus-action {
     color: stencilColor("color-textSecondary");
     display: inline-block;

--- a/assets/scss/components/stencil/returnDetails/_returnDetails.scss
+++ b/assets/scss/components/stencil/returnDetails/_returnDetails.scss
@@ -50,6 +50,11 @@
     color: stencilColor("color-textBase");
 }
 
+.returnDetails-statusBadge--cancelled {
+    background-color: color("greys", "darker");
+    color: color("whites", "bright");
+}
+
 .returnDetails-divider {
     border: 0;
     border-top: container("border");

--- a/templates/components/account/returns-list-v2.html
+++ b/templates/components/account/returns-list-v2.html
@@ -12,6 +12,8 @@
                     <h6 class="account-orderStatus-label account-orderStatus-label--inProgress">{{lang 'account.returns.status.in_progress'}}</h6>
                 {{else if status '===' 'CLOSED'}}
                     <h6 class="account-orderStatus-label account-orderStatus-label--closed">{{lang 'account.returns.status.closed'}}</h6>
+                {{else if status '===' 'CANCELLED'}}
+                    <h6 class="account-orderStatus-label account-orderStatus-label--cancelled">{{lang 'account.returns.status.cancelled'}}</h6>
                {{/if}}
             </div>
             <a class="button button--small" href="/account.php?action=view_return&return_id={{id}}">{{lang 'account.returns.list.view_details'}}</a>

--- a/templates/pages/account/return-details.html
+++ b/templates/pages/account/return-details.html
@@ -33,6 +33,8 @@
                         <span class="returnDetails-statusBadge returnDetails-statusBadge--in_progress">{{lang 'account.returns.status.in_progress'}}</span>
                     {{else if return_detail.status '===' 'CLOSED'}}
                         <span class="returnDetails-statusBadge returnDetails-statusBadge--closed">{{lang 'account.returns.status.closed'}}</span>
+                    {{else if return_detail.status '===' 'CANCELLED'}}
+                        <span class="returnDetails-statusBadge returnDetails-statusBadge--cancelled">{{lang 'account.returns.status.cancelled'}}</span>
                     {{/if}}
                 </div>
 


### PR DESCRIPTION
#### What?

This PR adds the `CANCELLED` badge and displays it for order returns that have been cancelled.

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

https://bigcommercecloud.atlassian.net/browse/ORDERS-7935

#### Screenshots (if appropriate)

Returns listing page
<img width="1512" height="844" alt="image" src="https://github.com/user-attachments/assets/ccc19a31-b3f9-45dd-856f-0aa10939f41e" />


Returns details page
<img width="1512" height="844" alt="image" src="https://github.com/user-attachments/assets/c96b1e2b-bcba-4a5e-802b-0dc2d0c9b470" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only template and stylesheet updates for an additional return status; no auth, API, or data-flow changes.
> 
> **Overview**
> **Cancelled returns** now show a dedicated status badge on the account returns list and return details pages when status is `CANCELLED`, using the same pattern as open, in progress, and closed.
> 
> New **SCSS modifiers** (`account-orderStatus-label--cancelled` and `returnDetails-statusBadge--cancelled`) apply a dark grey background with bright white text so cancelled returns are visually distinct from closed returns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd27939bc0c0df28b06811bc091fed63a5afcef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->