### PR TITLE
feat(orders): ORDERS-7770 add responsive styling for returns details page for desktop/tablet/mobile views

### DIFF
--- a/assets/scss/components/stencil/returnDetails/_returnDetails.scss
+++ b/assets/scss/components/stencil/returnDetails/_returnDetails.scss
@@ -104,9 +104,16 @@
 }
 
 .returnDetails-item {
-    display: flex;
-    align-items: flex-start;
-    gap: remCalc(16px);
+    // Using grid instead of flex as it keeps the meta directly under the title instead of
+    // being pushed down by the thumbnail's height.
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-areas:
+        "thumb info"
+        "thumb meta";
+    align-items: start;
+    column-gap: remCalc(16px);
+    row-gap: remCalc(4px);
     padding: remCalc(16px) 0;
     border-bottom: container("border");
 
@@ -114,13 +121,16 @@
         border-bottom: 0;
     }
 
+    // Desktop, single row with the meta as a fixed side column.
     @include breakpoint("large") {
+        grid-template-columns: auto minmax(0, 1fr) remCalc(240px);
+        grid-template-areas: "thumb info meta";
         align-items: center;
     }
 }
 
 .returnDetails-itemThumbnailWrapper {
-    flex-shrink: 0;
+    grid-area: thumb;
     line-height: 0;
 }
 
@@ -133,7 +143,7 @@
 }
 
 .returnDetails-itemInfo {
-    flex: 1;
+    grid-area: info;
     min-width: 0;
 }
 
@@ -144,10 +154,11 @@
     color: stencilColor("color-textBase");
 }
 
-// Right-aligned key/value column for SKU / Quantity / Reason / Status.
+// Key/value column for SKU / Quantity / Reason / Status. On mobile & tablet it
+// sits in the content column directly under the name; on desktop it becomes the
+// fixed-width third column (sized by the grid template).
 .returnDetails-itemMeta {
-    flex-shrink: 0;
-    width: remCalc(240px);
+    grid-area: meta;
     margin: 0;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION


#### What?

This PR ensures that the returns details page `/account.php?action=view_return&return_id=0dfa77f9-43e3-45c0-92e5-2f80c28ddd70` has responsive design for mobile, tablet and desktop viewports.

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

https://bigcommercecloud.atlassian.net/browse/ORDERS-7770

#### Screenshots (if appropriate)

Desktop:
<img width="1126" height="759" alt="image" src="https://github.com/user-attachments/assets/3ec66d73-05f1-4fe7-b393-218b5ba94fba" />

Tablet:
<img width="1126" height="759" alt="image" src="https://github.com/user-attachments/assets/bf1f40a4-3978-442a-bbf5-da1372d802e6" />

Mobile:
<img width="1126" height="759" alt="image" src="https://github.com/user-attachments/assets/4476cd0e-65a9-419f-ba5c-3eafcab2f572" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d0671001729fea2274404456a6358baa7462f9a9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->