### PR TITLE
feat(orders): ORDERS-7837 add additional note field to mutation when creating a return

### DIFF
--- a/assets/js/theme/create-return.js
+++ b/assets/js/theme/create-return.js
@@ -1,11 +1,14 @@
 import PageManager from './page-manager';
 
+const MAX_ADDITIONAL_NOTE_LENGTH = 1000;
+
 export default class CreateReturn extends PageManager {
     onReady() {
         const form = document.querySelector('[data-new-return-form]');
         if (!form) return;
 
         this.bindOrderLineItemEvents();
+        this.bindAdditionalNoteEvents();
         this.bindSubmit(form);
     }
 
@@ -16,9 +19,19 @@ export default class CreateReturn extends PageManager {
         });
     }
 
+    bindAdditionalNoteEvents() {
+        const noteEl = document.querySelector('[data-new-return-note]');
+        if (!noteEl) return;
+
+        noteEl.addEventListener('input', () => {
+            this.renderAdditionalNoteValidation();
+            this.updateSubmitState();
+        });
+    }
+
     updateSubmitState() {
         const selectedItems = this.getSelectedItems();
-        const isValid = selectedItems.length > 0 && selectedItems.every(itemRow => {
+        const hasValidItems = selectedItems.length > 0 && selectedItems.every(itemRow => {
             const itemId = itemRow.dataset?.itemId;
             if (!itemId) return false;
             const resolutionEl = document.getElementById(`resolution-${itemId}`);
@@ -27,12 +40,16 @@ export default class CreateReturn extends PageManager {
         });
 
         const submitBtn = document.getElementById('return-new-submitBtn');
-        if (submitBtn) submitBtn.disabled = !isValid;
+        if (submitBtn) submitBtn.disabled = !(hasValidItems && this.isAdditionalNoteValid());
     }
 
     bindSubmit(form) {
         form.addEventListener('submit', async event => {
             event.preventDefault();
+
+            // Block submission when the additional note exceeds the max length.
+            this.renderAdditionalNoteValidation();
+            if (!this.isAdditionalNoteValid()) return;
 
             // Ignore clicks while a request is in flight
             if (this.isSubmitting) return;
@@ -133,7 +150,7 @@ export default class CreateReturn extends PageManager {
      * @returns {{ orderEntityId: number, items: Array }}
      */
     buildReturnInput() {
-        return {
+        const input = {
             orderEntityId: parseInt(this.context.order?.id, 10),
             items: this.getSelectedItems().flatMap(itemRow => {
                 const itemId = itemRow.dataset?.itemId;
@@ -146,6 +163,37 @@ export default class CreateReturn extends PageManager {
                 }];
             }),
         };
+
+        // Do not send the note when it is empty or a whitespace
+        const additionalNote = this.getAdditionalNote();
+        if (additionalNote) {
+            input.note = additionalNote;
+        }
+
+        return input;
+    }
+
+    // Trimmed value of the additional-note textarea (empty string when absent).
+    getAdditionalNote() {
+        const noteEl = document.querySelector('[data-new-return-note]');
+        return noteEl ? noteEl.value.trim() : '';
+    }
+
+    isAdditionalNoteValid() {
+        return this.getAdditionalNote().length <= MAX_ADDITIONAL_NOTE_LENGTH;
+    }
+
+    // Toggles the inline error state on the additional-note field.
+    renderAdditionalNoteValidation() {
+        const field = document.querySelector('[data-new-return-note-field]');
+        const errorEl = document.querySelector('[data-new-return-note-error]');
+        const isValid = this.isAdditionalNoteValid();
+
+        if (field) field.classList.toggle('form-field--error', !isValid);
+        if (errorEl) {
+            errorEl.textContent = isValid ? '' : (this.context.additionalNoteTooLongError || '');
+            errorEl.style.display = isValid ? 'none' : '';
+        }
     }
 
     // Maps a selected resolution value to a `RequestedResolutionInput`

--- a/lang/en.json
+++ b/lang/en.json
@@ -462,6 +462,7 @@
             "comments": "Your Comments",
             "submit_request": "Submit Return Request",
             "additional_note_placeholder": "Please describe any additional details of this return request.",
+            "additional_note_too_long": "Note must not exceed {maxNoteLength} characters",
             "submit": "Submit Return",
             "summary": "Summary",
             "back": "Back",

--- a/templates/pages/create-return.html
+++ b/templates/pages/create-return.html
@@ -2,6 +2,7 @@
 
 {{~inject 'order' order}}
 {{~inject 'storefrontApiToken' settings.storefront_api.token}}
+{{~inject 'additionalNoteTooLongError' (lang 'account.returns.additional_note_too_long' maxNoteLength=1000)}}
 <main class="newReturn">
 
     {{#with order}}
@@ -104,7 +105,7 @@
         <hr class="newReturn-divider">
 
         <div class="newReturn-footer">
-            <div class="form-field">
+            <div class="form-field" data-new-return-note-field>
                 <label for="newReturn-additionalNote" class="form-label">
                     {{lang 'account.returns.additional_note'}}
                 </label>
@@ -113,7 +114,9 @@
                           name="additional_note"
                           rows="4"
                           data-new-return-note
+                          aria-describedby="newReturn-additionalNote-error"
                           placeholder="{{lang 'account.returns.additional_note_placeholder'}}"></textarea>
+                <span class="form-inlineMessage" id="newReturn-additionalNote-error" data-new-return-note-error role="alert" style="display: none;"></span>
             </div>
 
             <div class="form-actions">


### PR DESCRIPTION


#### What?

This PR ensures that we take the value of the additional note field when a shopper creates a return, and include it as part of the mutation.

We also validate client-side if the note exceeds 1000 characters and block submission if it does, as well as strip any white space.

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

https://bigcommercecloud.atlassian.net/browse/ORDERS-7837

#### Screenshots (if appropriate)

When I create a return with a note

https://github.com/user-attachments/assets/7121ac55-36aa-4c62-b543-d4e79d9f50a0

Then the return is created with the input note
<img width="1494" height="851" alt="image" src="https://github.com/user-attachments/assets/d7408e97-e07e-484a-a8b9-39e2f2893f49" />


**Validation**

more than 1000 characters
https://github.com/user-attachments/assets/70cdc90e-e7a6-4bc3-9856-fb79bc5bc59e

whitespace only (button is disabled)
<img width="1494" height="851" alt="image" src="https://github.com/user-attachments/assets/a2cf68df-5aba-42c9-8bdc-9965c9211c75" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped storefront return-form UX and payload shaping; no auth or payment changes, with validation aligned to expected API limits.
> 
> **Overview**
> Shopper **additional notes** on the create-return form are now sent to the **`createReturn`** GraphQL mutation as a trimmed `note` on `CreateOrderReturnInput`; empty or whitespace-only values are omitted.
> 
> **Client-side validation** enforces a **1000-character** limit: the submit button stays disabled when the note is too long, submit is blocked on attempt, and the note field shows an inline error using a new lang string and context injected from the template.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56d13731691270a5c1e542819c56fb2069124797. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->