### PR TITLE
fix(returns): ORDERS-7752 rename keys to be snake_case for consistency

### DIFF
--- a/templates/pages/account/return-details.html
+++ b/templates/pages/account/return-details.html
@@ -68,12 +68,12 @@
                                     <dt class="returnDetails-itemMetaLabel">{{lang 'account.returns.details.request'}}</dt>
                                     <dd class="returnDetails-itemMetaValue">
                                         {{~!-- Resolution label: custom resolutions show the merchant name; system ones are translated from their enum token. --~}}
-                                        {{#if requestedDiffersFromResolved}}
-                                            <span class="returnDetails-itemMetaValue--strikethrough">{{#if requestedResolutionType '===' 'CUSTOM'}}{{requestedResolutionName}}{{else}}{{lang (concat 'account.returns.details.resolution.' (toLowerCase requestedResolutionType))}}{{/if}}</span>
+                                        {{#if requested_differs_from_resolved}}
+                                            <span class="returnDetails-itemMetaValue--strikethrough">{{#if requested_resolution_type '===' 'CUSTOM'}}{{requested_resolution_name}}{{else}}{{lang (concat 'account.returns.details.resolution.' (toLowerCase requested_resolution_type))}}{{/if}}</span>
                                             <span class="returnDetails-sr-only">{{lang 'account.returns.details.resolution_changed_to'}}</span>
-                                            <span class="returnDetails-finalResolution">{{#if resolvedResolutionType '===' 'CUSTOM'}}{{resolvedResolutionName}}{{else}}{{lang (concat 'account.returns.details.resolution.' (toLowerCase resolvedResolutionType))}}{{/if}} {{lang 'account.returns.details.final_resolution'}}</span>
+                                            <span class="returnDetails-finalResolution">{{#if resolved_resolution_type '===' 'CUSTOM'}}{{resolved_resolution_name}}{{else}}{{lang (concat 'account.returns.details.resolution.' (toLowerCase resolved_resolution_type))}}{{/if}} {{lang 'account.returns.details.final_resolution'}}</span>
                                         {{else}}
-                                            {{#if requestedResolutionType '===' 'CUSTOM'}}{{requestedResolutionName}}{{else}}{{lang (concat 'account.returns.details.resolution.' (toLowerCase requestedResolutionType))}}{{/if}}
+                                            {{#if requested_resolution_type '===' 'CUSTOM'}}{{requested_resolution_name}}{{else}}{{lang (concat 'account.returns.details.resolution.' (toLowerCase requested_resolution_type))}}{{/if}}
                                         {{/if}}
                                     </dd>
                                 </div>


### PR DESCRIPTION
#### What?

Changes the keys to match the stencil context returned front the storefront api.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [ORDERS-7752](https://bigcommercecloud.atlassian.net/browse/ORDERS-7752)

[ORDERS-7752]: https://bigcommercecloud.atlassian.net/browse/ORDERS-7752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template-only property renames with no logic changes; low risk unless the API context still exposes camelCase keys, which would break resolution display.
> 
> **Overview**
> Updates **return details** item resolution fields in `return-details.html` so Handlebars reads **snake_case** keys from the storefront `return_detail.items` context instead of camelCase.
> 
> Renamed bindings include `requested_differs_from_resolved`, `requested_resolution_type`, `requested_resolution_name`, `resolved_resolution_type`, and `resolved_resolution_name`. Display logic (strikethrough when request differs from resolved, custom vs translated resolution labels) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60f0e5a00646e08ed2259d52ae2d612618a12167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->