### PR TITLE
feat(orders): ORDERS-7647 update return list navigation to work with …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Update returns navigation to support returns_v2_enabled [#2714](https://github.com/bigcommerce/cornerstone/pull/2714/changes)
 - Add client side validation on guest return portal (ORDERS-7736) [#2703](https://github.com/bigcommerce/cornerstone/pull/2703)
 - Update error message for create return page (ORDERS-7886) [#2698](https://github.com/bigcommerce/cornerstone/pull/2698)
 - Implement guest return portal page (ORDERS-7736) [#2696](https://github.com/bigcommerce/cornerstone/pull/2696)

--- a/templates/components/account/navigation.html
+++ b/templates/components/account/navigation.html
@@ -3,11 +3,11 @@
         <li class="navBar-item {{#if account_page '===' 'orders'}}is-active{{/if}}">
             <a class="navBar-action" href="{{urls.account.orders.all}}">{{lang 'account.nav.orders'}}</a>
         </li>
-        {{#if settings.returns_enabled}}
+        {{#or settings.returns_enabled settings.returns_v2_enabled}}
             <li class="navBar-item {{#if account_page '===' 'returns'}}is-active{{/if}}">
                 <a class="navBar-action" href="{{urls.account.returns}}">{{lang 'account.nav.returns'}}</a>
             </li>
-        {{/if}}
+        {{/or}}
         <li class="navBar-item {{#if account_page '===' 'messages'}}is-active{{/if}}">
             <a class="navBar-action" href="{{urls.account.inbox}}">{{lang 'account.nav.messages' num_new_messages=customer.num_new_messages}}</a>
         </li>

--- a/templates/components/common/navigation-menu.html
+++ b/templates/components/common/navigation-menu.html
@@ -129,7 +129,7 @@
                                 {{lang 'account.nav.orders'}}
                             </a>
                         </li>
-                        {{#if settings.returns_enabled}}
+                        {{#or settings.returns_enabled settings.returns_v2_enabled}}
                             <li class="navPage-subMenu-item">
                                 <a class="navPage-subMenu-action navPages-action"
                                    href="{{urls.account.returns}}"
@@ -138,7 +138,7 @@
                                     {{lang 'account.nav.returns'}}
                                 </a>
                             </li>
-                        {{/if}}
+                        {{/or}}
                         <li class="navPage-subMenu-item">
                             <a class="navPage-subMenu-action navPages-action"
                                href="{{urls.account.inbox}}"


### PR DESCRIPTION
…v2 returns

#### What?

Update logic for displaying return navigation to also display for v2 returns setting.
#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

NA

#### Screenshots (if appropriate)

When settings enabled
<img width="979" height="329" alt="image" src="https://github.com/user-attachments/assets/84d2f79b-c5d4-436f-855b-c4275a9b5897" />

Returns listed in accounts nav

<img width="780" height="151" alt="image" src="https://github.com/user-attachments/assets/4539a3e6-050d-46e3-bd8a-5622aa163f9d" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template-only visibility change for existing nav links; no new URLs or auth logic.
> 
> **Overview**
> **Returns navigation** now appears when either legacy **`settings.returns_enabled`** or **`settings.returns_v2_enabled`** is on, instead of only the legacy flag.
> 
> The same **`{{#or ...}}`** guard is applied in the **account sub-nav** (`navigation.html`) and the **mobile/storefront account submenu** (`navigation-menu.html`), so shoppers with v2 returns enabled can reach the returns list without turning on the old setting. **CHANGELOG** documents the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bd0137dec98a436c0735c34bac2b28d3db05d06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->