### PR TITLE
feat(returns): ORDERS-7878 add accessibility to returns list page

### DIFF
--- a/.claude/skills/accessibility/SKILL.md
+++ b/.claude/skills/accessibility/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: accessibility
+description: >-
+  Enforce WCAG 2.2 AA for Cornerstone storefront UI: semantics, accessible names,
+  forms/errors, keyboard/focus, live regions, decorative hiding, contrast, and
+  lang/en.json ARIA strings. Use whenever creating or editing anything a shopper
+  sees or interacts with — Stencil/Handlebars templates (templates/**/*.html),
+  theme JS (assets/js/theme/**), or component SCSS (assets/scss/**) — including
+  forms, buttons, links, dialogs, lists, headings, icons, images, status messages,
+  focus, visibility, layout, color, or motion. Also use when the user mentions
+  accessibility, ARIA, screen readers, keyboard navigation, focus, or WCAG, even
+  if they did not ask for an accessibility pass explicitly.
+---
+
+# Accessibility (WCAG 2.2 AA) for Cornerstone storefront UI
+
+Cornerstone ships to merchants who inherit our accessibility. Shoppers using a
+screen reader, keyboard, or magnification must complete every flow. Build
+accessibility in at authoring time — automated checks only catch part of it.
+
+This skill is an implementation guardrail, not a substitute for
+[WCAG 2.2](https://www.w3.org/WAI/WCAG22/quickref/). Deeper criteria and
+high-churn surfaces: [reference.md](reference.md). Good/bad snippets:
+[examples.md](examples.md).
+
+## Do this first
+
+Before editing, list in one line which areas the change affects:
+
+`semantics` · `names/roles/states` · `forms/errors` · `keyboard/focus` ·
+`dynamic updates` · `visual/reflow/motion` · `pointer/touch` · `images/media`
+
+Design applicable requirements into the solution, then edit.
+
+## Mandatory rules
+
+1. **Semantics before ARIA.** Use `<button>` / `<a href>` (not a clickable
+   `<div>`), `<ul>/<li>` for lists, one `<h1>` per page with non-skipping
+   heading levels, `<main>` / `<form>` landmarks. Add `role` / `aria-*` only
+   when HTML cannot express the semantics — no ARIA beats bad ARIA.
+   - **Changing a tag changes its styling — preserve it on the class.** When
+     you swap an element's tag to fix semantics, tag-dependent CSS (element
+     styles, default UA margins, and any theme rules keyed on the old tag) does
+     **not** follow. Before finishing, diff the old vs new tag's computed styling
+     and add whatever the class was relying on so appearance is preserved. Put it
+     on the **component's own class or a scoped selector** — do **not** broaden a
+     _shared_ class's contract to fix one component, which regresses any consumer
+     whose tag legitimately differs.
+
+2. **Names, forms, and errors.**
+   - Every control needs an accessible name. Prefer a persistent visible
+     `<label>`; placeholders and `title` are not labels. The accessible name
+     must contain the visible label text.
+   - Use `<fieldset>/<legend>` for related controls; valid `autocomplete`
+     tokens for user data; keep instructions available while completing the field.
+   - Inside `{{#each}}`, derive ids from the item id (`id="qty-{{id}}"`) —
+     never a static id in a loop.
+   - If the visible label is `display:none` at any breakpoint, use
+     `aria-labelledby` instead of `<label for>` (hidden labels drop from the
+     accessibility tree; `aria-labelledby` does not).
+   - Keep required/invalid and ARIA state (`expanded`, `selected`, `pressed`,
+     `current`, etc.) synchronized with the UI. Link hints/errors with
+     `aria-describedby`. Errors identify the field, explain the problem,
+     suggest correction, and preserve entered values.
+
+3. **Keyboard and focus.**
+   - Prefer native controls. Links: Enter. Buttons: Enter/Space. Custom widgets:
+     follow the applicable WAI-ARIA Authoring Practices pattern (Escape/arrows
+     where specified).
+   - All functionality works without a pointer; no keyboard traps. Focus order
+     matches DOM order; avoid positive `tabindex`.
+   - Focus is visible, ≥3:1 against adjacent colors, and not entirely obscured.
+     Prefer `:focus-visible` with a 2px outline.
+   - Use native `disabled` when unavailable. Use `aria-disabled="true"` only
+     when the control must stay focusable/discoverable — then block click,
+     keyboard, and submit in JS. Never put `aria-disabled` on a container with
+     active descendants.
+   - Failed submit: error summary with `tabindex="-1"`, move focus to it.
+     Do **not** also give that focused summary `role="alert"`. For urgent async
+     errors where focus should stay put, use a pre-existing `role="alert"`
+     region. Set `aria-invalid="true"` on invalid fields.
+   - Success / major view change: move focus only when needed to establish
+     context; avoid focusing whole containers. Never use timing hacks to wait
+     for screen-reader speech.
+
+4. **Announce dynamic changes.** Loading, progress, and success use a concise,
+   pre-existing status region, e.g.:
+
+   ```html
+   <p class="aria-description--hidden" role="status" aria-atomic="true" data-status></p>
+   ```
+
+   Replace stale text rather than accumulating messages. Set `aria-busy="true"`
+   on the affected region while processing. Default to polite (`role="status"`
+   or `aria-live="polite"`); use assertive (`aria-live="assertive"`) only when a
+   shopper acting on stale info could cause a real problem — e.g. Cornerstone's
+   return submission uses assertive so shoppers don't double-submit or navigate
+   away mid-request (see [examples.md](examples.md#4-announce-progress-move-focus-for-success)).
+   Prefer assertive over `role="alert"` for this — `alert` implies an error.
+
+5. **The two “hiddens” are opposites.**
+   - `aria-hidden="true"`: seen, not heard. Never on a focusable element.
+   - `.aria-description--hidden`: heard, not seen (SR-only text and live regions).
+   - Informative images: concise `alt`. Decorative `<img>`: `alt=""`. Decorative
+     SVG/icons: `aria-hidden="true"`, not focusable. Icon-only controls need a
+     translatable accessible name.
+
+6. **Visual, motion, pointer, media.** Preserve content under zoom, reflow,
+   text-spacing, forced colors, and `prefers-reduced-motion`. Meet contrast;
+   never use color alone; pointer targets ≥24×24 CSS px unless SC 2.5.8
+   exception applies. In Cornerstone, `color("greys","base")` (#999) fails for
+   text — use `color("greys","dark")` (#666).
+
+7. **Translatable strings.** No hardcoded English in ARIA. Add a key to
+   `lang/en.json`, reference via `{{lang '...'}}` or
+   `{{~inject 'x' (lang '...')}}` for JS. Remove unused keys.
+
+8. **Cornerstone conventions.**
+   - Reuse `form-select`, `form-input`, `form-label`, `button`,
+     `aria-description--hidden` — they carry focus/contrast/state styling.
+   - Merchant/customer strings: `{{value}}` (auto-escapes). Never
+     `{{{sanitize value}}}` for those strings.
+
+## Verification checklist
+
+Copy and track. Never claim a manual check passed unless it was performed.
+
+```
+A11y progress:
+- [ ] Affected areas listed (Do this first)
+- [ ] Semantics / names / roles / states correct
+- [ ] Forms, errors, ids (incl. loops) correct
+- [ ] Keyboard / focus plan implemented
+- [ ] Dynamic updates announced (or N/A)
+- [ ] Decorative content hidden correctly
+- [ ] Contrast / motion / targets checked as applicable
+- [ ] lang/en.json keys added; unused keys removed
+- [ ] Diff audit (below) done
+- [ ] Lighthouse audit run manually against a rendered URL
+- [ ] Manual checks still required: _______________
+```
+
+1. **Static / diff audit (always):** unique and unorphaned ids; no focusable
+   `aria-hidden`; no stale ARIA state; no a11y behavior removed by responsive
+   CSS; translatable ARIA strings.
+2. **Lighthouse (manual — there's no automated pipeline for this; run it
+   yourself against a rendered URL when one is available):**
+   `URL=<page-url> npm run lighthouse` (target 100% accessibility). Use axe
+   DevTools when available. A clean Lighthouse run ≠ WCAG conformance.
+3. **Keyboard / responsive (when interactive environment available):** full
+   flow without pointer; focus visibility/order; no traps; zoom/reflow;
+   reduced motion as applicable.
+4. **Screen reader (when available):** VoiceOver (macOS ⌘F5) or NVDA — changed
+   names, states, errors, announcements.
+
+If keyboard, screen reader, or Lighthouse could not run, say so explicitly in
+your response and list what remains for the human.
+
+## Project pattern references
+
+Validate patterns against the rules above — existing code may predate guidance:
+
+- `templates/pages/create-return.html`
+- `templates/pages/account/returns.html`
+- `templates/components/account/returns-list-v2.html`
+- `templates/components/carousel-content-announcement.html`
+- `templates/components/carousel-play-pause-button.html`
+
+Canonical recent examples of form/focus/live-region work: returns templates.
+Carousel files show announcement + play/pause naming patterns.

--- a/.claude/skills/accessibility/examples.md
+++ b/.claude/skills/accessibility/examples.md
@@ -1,0 +1,277 @@
+# Accessibility examples (Cornerstone)
+
+Concrete good/bad patterns. Prefer these shapes over inventing new ARIA.
+See also returns templates listed in [SKILL.md](SKILL.md).
+
+## 1. Loop ids — never static
+
+**Bad** — duplicate ids across rows:
+
+```html
+{{#each items}}
+  <label for="qty">{{lang 'account.orders.return.quantity'}}</label>
+  <input id="qty" name="qty[{{id}}]" type="number">
+{{/each}}
+```
+
+**Good** — id derived from item id (real pattern, `templates/pages/create-return.html`):
+
+```html
+{{#each items}}
+  <label id="newReturn-qtyLabel-{{id}}" for="qty-{{id}}">{{lang 'account.orders.return.quantity'}}</label>
+  <select id="qty-{{id}}" aria-labelledby="newReturn-qtyLabel-{{id}} newReturn-itemName-{{id}}">...</select>
+{{/each}}
+```
+
+## 2. Label hidden at a breakpoint → `aria-labelledby`
+
+**Bad** — `<label for>` on a label class that is `display:none` outside the
+`medium` breakpoint (`.newReturn-controlLabel` in
+`assets/scss/components/stencil/createReturn/_createReturn.scss` — name
+disappears from the accessibility tree on small and large screens):
+
+```html
+<label class="newReturn-controlLabel" for="resolution-{{id}}">
+  {{lang 'account.returns.request'}}
+</label>
+<select id="resolution-{{id}}" class="form-select">...</select>
+```
+
+**Good** — name via `aria-labelledby`, unaffected by the label's `display:none`
+(real pattern, `templates/pages/create-return.html`):
+
+```html
+<label class="newReturn-controlLabel" id="newReturn-resolutionLabel-{{id}}" for="resolution-{{id}}">
+  {{lang 'account.returns.request'}}
+</label>
+<select
+  class="form-select form-select--small"
+  id="resolution-{{id}}"
+  aria-labelledby="newReturn-resolutionLabel-{{id}}"
+>
+  ...
+</select>
+```
+
+Real code keeps `for` on the label too — harmless once `aria-labelledby` is
+present, since `aria-labelledby` wins the accessible-name computation.
+
+Compose multiple name sources when needed:
+
+```html
+aria-labelledby="newReturn-qtyLabel-{{id}} newReturn-itemName-{{id}}"
+```
+
+## 3. The two “hiddens”
+
+**Bad** — `aria-hidden` on a focusable control (removes it from AT while still
+in tab order):
+
+```html
+<button aria-hidden="true" type="button">{{lang 'common.close'}}</button>
+```
+
+**Good** — decorative glyph hidden; control keeps a real name:
+
+```html
+<button type="button">
+  <span aria-hidden="true">&rarr;</span>
+  <span class="aria-description--hidden">{{lang 'common.next'}}</span>
+</button>
+```
+
+| Goal | Class / attribute |
+|------|-------------------|
+| Seen, not heard | `aria-hidden="true"` |
+| Heard, not seen | `aria-description--hidden` |
+
+## 4. Announce progress; move focus for success
+
+**Bad** — visual-only state; nothing for AT:
+
+```html
+<!-- only a spinner in the DOM; nothing for AT -->
+<div class="loadingSpinner"></div>
+```
+
+**Good, less urgent (`templates/components/carousel-content-announcement.html`)**
+— polite status, pre-existing node, text replaced in place:
+
+```html
+<span data-carousel-content-change-message class="aria-description--hidden"
+      aria-live="polite" role="status"></span>
+```
+
+**Good, must interrupt (`templates/pages/create-return.html` +
+`assets/js/theme/create-return.js`)** — the returns flow uses `aria-live="assertive"`
+instead of polite, because letting the shopper keep reading while a submit is in
+flight risks a duplicate submit or navigating away mid-request:
+
+```html
+<p class="aria-description--hidden" aria-live="assertive" aria-atomic="true" data-new-return-status></p>
+```
+
+```js
+form.setAttribute('aria-busy', 'true');
+this.announce(this.context.submittingMessage); // updates data-new-return-status
+// ...on error, clear it:
+this.announce('');
+// on success: no text update — focus moves to the confirmation heading instead (see #9)
+form.removeAttribute('aria-busy');
+```
+
+Default to polite for progress/success text. Reach for assertive only when a
+shopper acting on stale information could cause a real problem — and prefer it
+to `role="alert"`, which is meant for errors, not routine progress.
+
+## 5. Failed submit — two valid patterns, don't mix them
+
+Rule 3 gives two options for a failed submit. Pick one per error box — don't
+combine them on the same node.
+
+**Bad** — nothing happens for AT users; error is visual only:
+
+```html
+<div id="error-box" class="alertBox alertBox--error" style="display: none;"></div>
+```
+```js
+errorBox.style.display = ''; // no role, no focus move — silent to screen readers
+```
+
+**Option A — focus the summary** (use when you want to pull the shopper
+straight to the error, e.g. it's far from the trigger control):
+
+```html
+<div id="error-box" class="alertBox alertBox--error" style="display: none;" tabindex="-1">...</div>
+```
+```js
+errorBox.style.display = '';
+errorBox.focus(); // do NOT also add role="alert" here — double announcement risk
+```
+
+**Option B — keep focus on the control, let the alert announce it** (real
+pattern, `templates/pages/create-return.html` — focus stays on Submit so the
+shopper can immediately retry without navigating back to it):
+
+```html
+<div id="return-new-error" class="alertBox alertBox--error" style="display: none;" role="alert">
+  <p class="newReturn-errorHeading">{{lang 'account.returns.error_heading'}}</p>
+  <p class="alertBox-message">{{lang 'common.generic_error'}}</p>
+</div>
+```
+```js
+errorBox.style.display = ''; // pre-existing node + role="alert" announces this; no .focus() call
+```
+
+Field-level errors (when a flow has per-field validation) apply regardless of
+which option you pick: `aria-invalid="true"` on the invalid control,
+`aria-describedby` pointing at its error text, and a real `lang/en.json` key
+for that message. The additional-note character-limit error
+(`newReturn-additionalNote-error`) is a real example of this in `create-return.html`.
+
+## 6. Disabled submit that stays explainable
+
+**Bad** — `aria-disabled` on a wrapper (screen reader still reaches an
+enabled-looking button inside it; state isn't exposed on the control):
+
+```html
+<div aria-disabled="true">
+  <button type="submit">{{lang 'account.returns.submit'}}</button>
+</div>
+```
+
+**Good** (real pattern, `templates/pages/create-return.html`) — `aria-disabled`
+on the control itself, kept focusable/discoverable, hint linked via
+`aria-describedby`, JS blocks activation:
+
+```html
+<p id="return-new-submitHint-disabled" class="aria-description--hidden">
+  {{lang 'account.returns.submit_hint'}}
+</p>
+<input class="button button--primary" id="return-new-submitBtn" type="submit"
+       value="{{lang 'account.returns.submit'}}"
+       aria-disabled="true"
+       aria-describedby="return-new-submitHint-disabled">
+```
+
+```js
+// create-return.js: removes the hint once valid so the label alone is
+// announced — avoids a stale "why is this disabled" hint once it isn't.
+submitBtn.setAttribute('aria-disabled', String(!isValid));
+submitBtn[isValid ? 'removeAttribute' : 'setAttribute']('aria-describedby', 'return-new-submitHint-disabled');
+```
+
+```js
+// gate activation in JS — aria-disabled does not block click/Enter natively
+form.addEventListener('submit', event => {
+  event.preventDefault();
+  if (submitBtn.getAttribute('aria-disabled') === 'true') return;
+  // ...proceed
+});
+```
+
+If the control can genuinely be removed from the tab order instead (no need to
+explain why it's inactive), prefer plain `disabled` — it's simpler and native.
+Reach for `aria-disabled` specifically when shoppers benefit from discovering
+*why* a control is inactive, as here.
+
+## 7. Translatable ARIA — no hardcoded English
+
+**Bad:**
+
+```html
+<button type="button" aria-label="Close dialog">×</button>
+```
+
+**Good — template:**
+
+```html
+<button type="button" aria-label="{{lang 'common.close'}}">
+  <span aria-hidden="true">×</span>
+</button>
+```
+
+**Good — JS string from inject:**
+
+```html
+{{~inject 'carouselPlayPauseButtonAriaPlay' (lang 'carousel.play_pause_button_aria_play')}}
+```
+
+```js
+button.setAttribute('aria-label', this.context.carouselPlayPauseButtonAriaPlay);
+```
+
+## 8. Merchant/customer content escaping
+
+**Bad:**
+
+```html
+<h2>{{{sanitize product.name}}}</h2>
+```
+
+**Good:**
+
+```html
+<h2>{{product.name}}</h2>
+```
+
+## 9. Success / confirmation focus
+
+**Bad** — focus the entire confirmation container or nothing at all:
+
+```js
+document.querySelector('.confirmation').focus();
+```
+
+**Good** — focus the confirmation heading (`tabindex="-1"`):
+
+```html
+<h1 class="newReturn-title" data-new-return-confirmation-heading tabindex="-1">
+  {{lang 'account.returns.from_order' id=id}}
+  {{lang 'account.returns.submitted_successfully'}}
+</h1>
+```
+
+```js
+document.querySelector('[data-new-return-confirmation-heading]').focus();
+```

--- a/.claude/skills/accessibility/reference.md
+++ b/.claude/skills/accessibility/reference.md
@@ -1,0 +1,109 @@
+# Accessibility reference (Cornerstone)
+
+Read this when a change needs deeper WCAG detail or touches a high-churn
+surface. Keep [SKILL.md](SKILL.md) as the authority for mandatory rules;
+validate every pattern against those rules.
+
+## WCAG areas → what to verify
+
+| Area | Verify |
+|------|--------|
+| Semantics / content | Correct elements; heading order; lists; landmarks; link purpose in context |
+| Names, roles, values, states | Accessible name; role only if needed; `expanded`/`selected`/`pressed`/`current`/`invalid` match UI |
+| Forms / errors | Labels; fieldset/legend; autocomplete; `aria-describedby` for hints/errors; values preserved |
+| Keyboard / focus | No pointer-only ops; no traps; DOM order; visible focus; focus moves on submit failure / major view change |
+| Dynamic updates | Polite status for progress/success by default; assertive only when acting on stale info causes harm; `aria-busy` while processing |
+| Visual / reflow / motion | Zoom to 200%; narrow reflow; text spacing; forced colors; `prefers-reduced-motion` |
+| Pointer / touch | ≥24×24 CSS px targets (or SC 2.5.8 exception); non-dragging alternative if drag is required |
+| Images / media | Meaningful `alt`; decorative empty/`aria-hidden`; captions/transcripts where applicable |
+
+## High-churn Cornerstone surfaces
+
+If you touch one of these, also check the paired concerns:
+
+| Surface | Also check |
+|---------|------------|
+| Modals / drawers / filters | Focus trap to dialog only while open; Escape closes; restore focus to opener; initial focus to dialog (not a random control inside unless pattern requires); `aria-modal` / labelling |
+| Carousels / sliders | Play/pause control; slide announcements via status region; arrow/dot names from `lang` injects; respect reduced motion |
+| Product options / swatches | Selected state exposed; each option named; keyboard selection matches pointer |
+| Mini-cart / cart qty | Live updates announced; qty inputs labelled per line item; remove controls named |
+| Account forms / returns | Loop ids; error summary focus; disabled submit + hint; confirmation heading focus |
+| Responsive show/hide | Labels not `display:none` if used with `<label for>`; no interactive content inside `aria-hidden` |
+
+## Keyboard & composite widgets
+
+- Prefer native elements so the browser supplies keyboard behavior.
+- For custom composites (tabs, menus, listboxes, grids), implement the matching
+  [ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/) pattern —
+  including Escape, arrow keys, Home/End, and typeahead where specified.
+- `tabindex="-1"` is for programmatic focus targets (error summaries,
+  confirmation headings). Do not use positive `tabindex`.
+
+## Focus management nuances
+
+| Situation | Pattern |
+|-----------|---------|
+| Sync validation failure on submit | Focus error summary (`tabindex="-1"`). Do not add `role="alert"` to that same focused node. |
+| Urgent async error; focus stays on control | Update a pre-existing `role="alert"` (or assertive live) region. |
+| Success / view swap (e.g. confirmation) | Focus a heading or primary landmark control that establishes context. |
+| Open modal | Move focus into dialog; on close, return to invoking control. |
+
+Never `setTimeout` / polling to “wait until the screen reader finishes.”
+
+## Live regions
+
+| Need | Use |
+|------|-----|
+| Loading / progress / success (default) | Pre-existing polite `role="status"` (or `aria-live="polite"`), `aria-atomic="true"` — e.g. `carousel-content-announcement.html` |
+| Progress where stale info risks a real problem (e.g. double-submit) | `aria-live="assertive"` without `role="status"`/`role="alert"` — e.g. `create-return.html`'s `data-new-return-status` region |
+| Immediate danger / blocking mistake | Pre-existing `role="alert"` (reserve for actual errors, not routine progress) |
+| Stale messages | Replace text; do not append endlessly |
+| Busy UI | `aria-busy="true"` on the updating region while processing |
+
+Note success doesn't always need a text announcement: `create-return.html`
+clears its status text on error but, on success, relies on moving focus to the
+confirmation heading rather than updating the live region (see
+[examples.md #4](examples.md#4-announce-progress-move-focus-for-success)).
+
+Cornerstone off-screen class for SR-only / live text:
+`aria-description--hidden`.
+
+## Decorative vs informative
+
+| Intent | Technique |
+|--------|-----------|
+| Visible decoration, ignore for AT | `aria-hidden="true"` (never on focusable nodes) |
+| SR-only text | `.aria-description--hidden` |
+| Decorative image | `<img alt="">` (no redundant `title`) |
+| Decorative SVG/icon | `aria-hidden="true"`; not in tab order |
+| Icon-only control | Accessible name via SR-only text or `aria-label` from `lang` |
+| Wrapper hide | Only if every descendant is decorative and none is interactive |
+
+## Contrast (Cornerstone tokens)
+
+| Token | Approx | On white | Text |
+|-------|--------|----------|------|
+| `color("greys","base")` | #999 | ~2.84:1 | Fails for body/UI text |
+| `color("greys","dark")` | #666 | ~5.74:1 | Prefer for text |
+
+Focus indicators need ≥3:1 against adjacent colors. Prefer `:focus-visible`
+with a 2px outline as a strong baseline.
+
+## i18n for accessibility strings
+
+- Template: `{{lang 'key.path'}}`
+- JS: `{{~inject 'camelKey' (lang 'key.path')}}` then read from injected context
+- Applies to `aria-label`, SR-only hints, live-region messages, dialog labels
+- Remove keys with no remaining consumer when deleting UI
+
+## Escaping
+
+For merchant- or customer-controlled strings in templates, use `{{value}}`
+(double-curly, auto-escapes). Do not use `{{{sanitize value}}}` for those
+strings — double-curly is the reliable Cornerstone pattern.
+
+## Authority ladder
+
+1. [SKILL.md](SKILL.md) mandatory rules  
+2. WCAG 2.2 AA + ARIA APG for the widget type  
+3. Existing Cornerstone templates as structural examples (may predate guidance)

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,43 @@
+# Cornerstone Theme - Bugbot Configuration
+
+## Project Overview
+
+This is **Cornerstone** - BigCommerce's reference [Stencil](https://developer.bigcommerce.com/stencil-docs) storefront theme. Merchants inherit this theme's markup, behavior, and **accessibility**, so UI regressions ship to real storefronts.
+
+**Key Directories:**
+- **templates/** - Handlebars (`.html`) page and component templates
+- **assets/js/theme/** - Theme JavaScript (PageManager modules)
+- **assets/scss/** - Component and foundation SCSS
+- **lang/** - Translatable strings (`en.json` is the source of truth for all user-visible / ARIA text)
+
+## ⚠️ CRITICAL: Report ALL Violations
+
+**IMPORTANT**: When reviewing PRs, report ALL violations found, not just the first one.
+
+### Review Behavior Requirements
+
+1. **Check ALL applicable rules**: For each changed file, check every rule whose glob pattern matches
+2. **Report ALL violations**: Comment on every violation found
+3. **Create INLINE comments**: For file-specific rules, create separate inline comments ON EACH FILE
+4. **Group violations by rule**: Organize violations by rule type for clarity
+5. **Prioritize by severity**: Report CRITICAL violations first, then WARNINGS
+6. **Follow exact output format**: Each rule specifies an exact output format - use it precisely
+
+## 📁 Project Rules
+
+All rules are defined in `.cursor/rules/` with individual `RULE.md` files:
+
+### Warning Rules (Flag for Review)
+| Rule                            | Description                                                                 | Scope                     |
+|---------------------------------|-----------------------------------------------------------------------------|---------------------------|
+| `template-accessibility`        | Semantics, headings, accessible names, translatable ARIA strings, unique ids | `templates/**/*.html`     |
+
+## 🔍 Rule Application
+
+Rules are scoped using glob patterns in their frontmatter:
+- Rules with `globs` only apply to matching files
+- Rules with `alwaysApply: true` apply to every PR
+
+The authoritative accessibility guidance for this repo lives in
+[`.claude/skills/accessibility/SKILL.md`](../.claude/skills/accessibility/SKILL.md); these rules are the
+review-time subset of it.

--- a/.cursor/rules/template-accessibility/RULE.md
+++ b/.cursor/rules/template-accessibility/RULE.md
@@ -1,0 +1,49 @@
+---
+description: Accessibility semantics, headings, names, and translatable strings in templates
+globs:
+  - "templates/**/*.html"
+alwaysApply: false
+---
+
+# Template Accessibility
+
+⚠️ **WARNING** - Flag for review if violated
+
+Cornerstone ships to merchants who inherit its accessibility. Flag template changes that
+break the checks below. Full guidance:
+[`.claude/skills/accessibility/SKILL.md`](../../../.claude/skills/accessibility/SKILL.md).
+
+## Headings
+- Exactly **one `<h1>` per page**; heading levels MUST NOT skip (`h1`→`h3` is a violation).
+  - ✅ page `<h1>` → per-item `<h2>` when there is no section heading between them
+  - ❌ page `<h1>` → per-item `<h3>` (skips `h2`)
+- Do **not** repeat the page `<h1>` text as a section heading — a second identical heading is
+  duplicate noise for screen-reader users. Drop it or give it distinct text.
+- A **status / label is not a heading** — use `<span>`, never `<h5>`/`<h6>`, for status badges.
+
+## Semantics
+- Use `<button>` / `<a href>` for actions, `<ul>/<li>` for lists, `<dl>/<dt>/<dd>` for
+  label→value pairs. Add `role`/`aria-*` only when HTML can't express the semantics.
+
+## Accessible names
+- Every interactive control needs an accessible name.
+- Repeated links/buttons with identical visible text MUST carry a distinguishing `aria-label`
+  that includes context (the entity id/name) so their purpose is clear out of context.
+  - ✅ `<a aria-label="{{lang 'some.key.action_for' id=item.id}}">{{lang 'some.key.action'}}</a>`
+  - ❌ many identical `<a>Edit</a>` / `<a>View</a>` links with no distinguishing label
+
+## Translatable strings
+- No hardcoded English in ARIA/label attributes. Add a key to `lang/en.json` and reference via
+  `{{lang '...'}}` (or `{{~inject 'x' (lang '...')}}` for JS).
+- Remove `lang/en.json` keys that no longer have a consumer.
+
+## Unique ids in loops
+- Inside `{{#each}}`, derive ids from the item id — never a static id in a loop.
+  - ✅ `id="field-{{id}}"`   ❌ `id="field"`
+
+## Output Format
+
+For each violation, comment inline on the element:
+
+> **Accessibility**: `<which check>` — `<what's wrong>`. `<how to fix>` (see
+> `.claude/skills/accessibility/SKILL.md`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Add accessibility to returns list page and an in-repo accessibility skill (ORDERS-7878)
+- Fix accessibility issues in create-return flow: avoid double announcements on submit errors, drop a redundant focus-on-load, and simplify the submit button's ARIA description (ORDERS-7874)
 - Add accessibility to create return page (ORDERS-7874) [#2712](https://github.com/bigcommerce/cornerstone/pull/2712)
 - Add product images to return detail page (ORDERS-7890) [#2713](https://github.com/bigcommerce/cornerstone/pull/2713)
 - Update returns navigation to support returns_v2_enabled [#2714](https://github.com/bigcommerce/cornerstone/pull/2714/changes)

--- a/assets/js/theme/create-return.js
+++ b/assets/js/theme/create-return.js
@@ -7,15 +7,9 @@ export default class CreateReturn extends PageManager {
         const form = document.querySelector('[data-new-return-form]');
         if (!form) return;
 
-        this.focusOnLoad();
         this.bindOrderLineItemEvents();
         this.bindAdditionalNoteEvents();
         this.bindSubmit(form);
-    }
-
-    // Focus the page heading on load so screen-reader/keyboard users start at the page context.
-    focusOnLoad() {
-        document.getElementById('newReturn-heading')?.focus({ preventScroll: true });
     }
 
     announce(message) {
@@ -54,10 +48,15 @@ export default class CreateReturn extends PageManager {
         if (!submitBtn) return;
 
         // aria-disabled (not the native disabled attr) keeps the button keyboard/SR reachable while invalid.
-        // The described-by hint swaps between "what to select" and "press Enter to submit".
+        // Only describe why it's inactive; when valid the button label ("Submit Return") is enough on
+        // its own, so drop the description to avoid a redundant duplicate announcement.
         const isValid = hasValidItems && this.isAdditionalNoteValid();
         submitBtn.setAttribute('aria-disabled', String(!isValid));
-        submitBtn.setAttribute('aria-describedby', isValid ? 'return-new-submitHint-enabled' : 'return-new-submitHint-disabled');
+        if (isValid) {
+            submitBtn.removeAttribute('aria-describedby');
+        } else {
+            submitBtn.setAttribute('aria-describedby', 'return-new-submitHint-disabled');
+        }
     }
 
     bindSubmit(form) {
@@ -115,15 +114,14 @@ export default class CreateReturn extends PageManager {
     }
 
     showError() {
-        // The error box has role="alert" (announced on display); clear the in-flight status and
-        // move focus to the summary so keyboard users land on the error.
+        // The error box is a pre-existing role="alert" region; unhiding it announces the error
+        // without moving focus, so keyboard/SR users stay on Submit and can retry immediately.
         this.announce('');
 
         const errorBox = document.getElementById('return-new-error');
         if (!errorBox) return;
 
         errorBox.style.display = '';
-        errorBox.focus();
     }
 
     clearError() {

--- a/assets/scss/components/stencil/returnsList/_returnsList.scss
+++ b/assets/scss/components/stencil/returnsList/_returnsList.scss
@@ -2,6 +2,16 @@
 // RETURNS LIST PAGE
 // =============================================================================
 
+.account-returnsList {
+    .account-listItem:first-child {
+        border-top: container("border");
+    }
+
+    .account-orderStatus-label {
+        font-family: $header-font-family;
+        text-transform: uppercase;
+    }
+}
 
 .account-returnsList-title {
     margin: 0 0 spacing("eighth");
@@ -24,7 +34,8 @@
 .account-returnsList-details {
     display: flex;
     flex-direction: column;
-    
+    margin: 0;
+
     @include breakpoint("medium") {
         flex-direction: row;
         gap: spacing("double");
@@ -46,6 +57,11 @@
     color: stencilColor("color-textSecondary");
     font-family: fontFamily("sans");
     font-size: fontSize("tiny");
+    text-transform: uppercase;
     margin: 0 0 spacing("eighth");
+}
+
+.account-returnsList-detail-value {
+    margin: 0;
 }
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -453,7 +453,6 @@
             "select_resolution": "Select preferred resolution",
             "select_reason": "Select a return reason",
             "submit_hint": "Select a quantity, preferred resolution, and reason for at least one item to submit your return.",
-            "submit_ready": "Submit your return",
             "submitting": "Submitting your return request",
             "date_requested": "Return Requested",
             "successful_heading": "Return Request Submitted",
@@ -492,7 +491,8 @@
                 "return_number": "Return #{id}",
                 "product_details": "Returning {num_products}",
                 "return_items": "Return Items",
-                "view_details": "View details"
+                "view_details": "View details",
+                "view_details_for": "View details for return #{id}"
             },
             "guest": {
                 "email": "Email",

--- a/templates/components/account/returns-list-v2.html
+++ b/templates/components/account/returns-list-v2.html
@@ -1,38 +1,39 @@
-<h3 class="account-heading">{{lang 'account.returns.heading' }}</h3>
-
-<ul class="account-list">
+<ul class="account-list account-returnsList">
     {{#each returns}}
     <li class="account-listItem">
         <div class="account-listItem-summary">
             <div class="account-listItem-summary-main">
-                <h5 class="account-returnsList-title">{{lang 'account.returns.list.return_number' id=rma}}</h5>
+                <h2 class="account-returnsList-title">{{lang 'account.returns.list.return_number' id=rma}}</h2>
                 {{#if status '===' 'OPEN'}}
-                    <h6 class="account-orderStatus-label account-orderStatus-label--open">{{lang 'account.returns.status.open'}}</h6>
+                    <span class="account-orderStatus-label account-orderStatus-label--open">{{lang 'account.returns.status.open'}}</span>
                 {{else if status '===' 'IN_PROGRESS'}}
-                    <h6 class="account-orderStatus-label account-orderStatus-label--inProgress">{{lang 'account.returns.status.in_progress'}}</h6>
+                    <span class="account-orderStatus-label account-orderStatus-label--inProgress">{{lang 'account.returns.status.in_progress'}}</span>
                 {{else if status '===' 'CLOSED'}}
-                    <h6 class="account-orderStatus-label account-orderStatus-label--closed">{{lang 'account.returns.status.closed'}}</h6>
+                    <span class="account-orderStatus-label account-orderStatus-label--closed">{{lang 'account.returns.status.closed'}}</span>
                 {{else if status '===' 'CANCELLED'}}
-                    <h6 class="account-orderStatus-label account-orderStatus-label--cancelled">{{lang 'account.returns.status.cancelled'}}</h6>
+                    <span class="account-orderStatus-label account-orderStatus-label--cancelled">{{lang 'account.returns.status.cancelled'}}</span>
                {{/if}}
             </div>
-            <a class="button button--small" href="/account.php?action=view_return&return_id={{id}}">{{lang 'account.returns.list.view_details'}}</a>
+            {{!-- aria-label carries the return number so the link's purpose is clear out of context;
+                  the page has many identical "View details" links. --}}
+            <a class="button button--small" href="/account.php?action=view_return&return_id={{id}}" aria-label="{{lang 'account.returns.list.view_details_for' id=rma}}">{{lang 'account.returns.list.view_details'}}</a>
         </div>
 
-        <div class="account-returnsList-details">
+        {{!-- Description list so each label is programmatically associated with its value. --}}
+        <dl class="account-returnsList-details">
             <div class="account-returnsList-detail">
-                <h6 class="account-returnsList-detail-heading">{{lang 'account.returns.list.return_submitted' }}</h6>
-                <span>{{moment dateSubmitted format="Do MMM YYYY"}}</span>
+                <dt class="account-returnsList-detail-heading">{{lang 'account.returns.list.return_submitted' }}</dt>
+                <dd class="account-returnsList-detail-value">{{moment dateSubmitted format="Do MMM YYYY"}}</dd>
             </div>
             <div class="account-returnsList-detail">
-                <h6 class="account-returnsList-detail-heading">{{lang 'account.returns.list.last_update' }}</h6>
-                <span>{{#if lastUpdated}}{{moment lastUpdated format="Do MMM YYYY"}}{{else}}{{moment dateSubmitted format="Do MMM YYYY"}}{{/if}}</span>
+                <dt class="account-returnsList-detail-heading">{{lang 'account.returns.list.last_update' }}</dt>
+                <dd class="account-returnsList-detail-value">{{#if lastUpdated}}{{moment lastUpdated format="Do MMM YYYY"}}{{else}}{{moment dateSubmitted format="Do MMM YYYY"}}{{/if}}</dd>
             </div>
             <div class="account-returnsList-detail">
-                <h6 class="account-returnsList-detail-heading">{{lang 'account.returns.list.return_items' }}</h6>
-                <span>{{items.length}}</span>
+                <dt class="account-returnsList-detail-heading">{{lang 'account.returns.list.return_items' }}</dt>
+                <dd class="account-returnsList-detail-value">{{items.length}}</dd>
             </div>
-        </div>
+        </dl>
     </li>
     {{/each}}
 </ul>

--- a/templates/pages/create-return.html
+++ b/templates/pages/create-return.html
@@ -13,7 +13,7 @@
 
     <div class="newReturn-header">
         <div class="newReturn-titleGroup">
-            <h1 class="newReturn-title" id="newReturn-heading" tabindex="-1">{{lang 'account.returns.from_order' id=id}}</h1>
+            <h1 class="newReturn-title">{{lang 'account.returns.from_order' id=id}}</h1>
             {{#if status}}<span class="newReturn-statusBadge">{{status}}</span>{{/if}}
         </div>
         {{#if date}}<p class="newReturn-orderDate">{{lang 'account.returns.order_date'}}: {{date}}</p>{{/if}}
@@ -25,7 +25,7 @@
 
     <hr class="newReturn-divider" aria-hidden="true">
 
-    <div id="return-new-error" class="alertBox alertBox--error newReturn-error" style="display: none;" role="alert" tabindex="-1">
+    <div id="return-new-error" class="alertBox alertBox--error newReturn-error" style="display: none;" role="alert">
         <p class="newReturn-errorHeading">{{lang 'account.returns.error_heading'}}</p>
         <p class="alertBox-message" data-return-error-message>{{lang 'common.generic_error'}}</p>
         {{#if ../settings.phone_number}}
@@ -127,9 +127,8 @@
 
             <div class="form-actions">
                 {{!-- Submit uses aria-disabled (not the native disabled attr) so keyboard/SR users can
-                      still reach it and hear why it's inactive; the hint swaps once it's ready. --}}
+                      still reach it and hear why it's inactive. --}}
                 <p id="return-new-submitHint-disabled" class="aria-description--hidden">{{lang 'account.returns.submit_hint'}}</p>
-                <p id="return-new-submitHint-enabled" class="aria-description--hidden">{{lang 'account.returns.submit_ready'}}</p>
                 <input class="button button--primary"
                        id="return-new-submitBtn"
                        type="submit"


### PR DESCRIPTION
#### What?
- Create accessibility skill for the repo
- Add accessibility support on returns list page.
- Fix accessibility on create returns page


#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

[ORDERS-7878](https://bigcommercecloud.atlassian.net/browse/ORDERS-7878)

#### Screenshots (if appropriate)

##### Manual Testing

###### Before implementation
Lighthouse report:
<img width="608" height="858" alt="image" src="https://github.com/user-attachments/assets/809e8c25-114e-4fd1-b05e-8cfb90dfe949" />

Old user behavior and navigation:
- Navigation not properly announced
- Confusing screen reader labels for "view details" details.

https://github.com/user-attachments/assets/76332959-3d47-4cc1-b05a-b38d1a9f7311


###### After implementation:
Lighthouse report:
<img width="610" height="858" alt="image" src="https://github.com/user-attachments/assets/1d9026d5-a1e3-41e7-b502-4e2ab17d30eb" />

New user behavior and navigation:


https://github.com/user-attachments/assets/e1f3074a-3170-451b-944a-11f5f7d18e2c






[ORDERS-7878]: https://bigcommercecloud.atlassian.net/browse/ORDERS-7878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation, template semantics, i18n, and focused JS focus/ARIA behavior on returns flows—no auth, payments, or broad architectural shifts.
> 
> **Overview**
> Adds an in-repo **accessibility skill** (`.claude/skills/accessibility/`) plus Cursor **Bugbot** config and a `template-accessibility` rule so reviews align with WCAG 2.2 AA Cornerstone patterns.
> 
> **Returns list (`returns-list-v2.html`)** — Removes the duplicate section heading; fixes heading hierarchy (`h2` per return, status as `span`); uses a `dl/dt/dd` for metadata; adds a translatable `aria-label` on repeated “View details” links; SCSS preserves look after tag changes.
> 
> **Create return** — Drops initial focus on the page `h1` and `tabindex` on the error alert; submit errors rely on `role="alert"` without moving focus or double announcements; submit button only uses `aria-describedby` when disabled; removes the “ready to submit” hint and `submit_ready` lang key.
> 
> **CHANGELOG** — Draft entries for ORDERS-7878 and ORDERS-7874.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8a0a111ab322e5ba4ebc6e52673830a3d490673. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->