### PR TITLE
feat(checkout): CHECKOUT-10198 apply new style overrides for enhancedTheme in checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
-- Add checkout style overrides for enhanced checkout theme.(CHECKOUT-10198) 
+- Add checkout style overrides for enhanced checkout theme. [#2721](https://github.com/bigcommerce/cornerstone/pull/2721)
 
 ## 6.21.0 (07-21-2026)
 - Display featured promotion callouts on product listing pages (product cards and list view) and the PDP, gated by the new `show_featured_promotions` theme setting and the `featured_promotions` context [#2695](https://github.com/bigcommerce/cornerstone/pull/2695)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Add checkout style overrides for enhanced checkout theme.(CHECKOUT-10198) 
 
 ## 6.21.0 (07-21-2026)
 - Display featured promotion callouts on product listing pages (product cards and list view) and the PDP, gated by the new `show_featured_promotions` theme setting and the `featured_promotions` context [#2695](https://github.com/bigcommerce/cornerstone/pull/2695)

--- a/assets/scss/optimized-checkout.scss
+++ b/assets/scss/optimized-checkout.scss
@@ -381,6 +381,11 @@ $optimizedCheckout-input--error-boxShadow: 0 0 3px transparentize(stencilColor("
 }
 
 
+//
+// Styles for enhanced theme, which is applied when the
+// "Enhanced Checkout" option is enabled in the control panel.
+// -----------------------------------------------------------------------------
+
 .enhancedTheme {
     background-color: stencilColor("optimizedCheckout-header-backgroundColor");
 

--- a/assets/scss/optimized-checkout.scss
+++ b/assets/scss/optimized-checkout.scss
@@ -394,10 +394,13 @@ $optimizedCheckout-input--error-boxShadow: 0 0 3px transparentize(stencilColor("
         border-color: stencilColor("optimizedCheckout-formField-borderColor");
     }
 
-    .optimizedCheckout-form-checkbox:checked + .optimizedCheckout-form-label::before,
     .optimizedCheckout-form-checklist-checkbox:checked ~ .optimizedCheckout-form-label::before {
-        background-color: stencilColor("optimizedCheckout-formField-inputControlColor");
-        border-color: stencilColor("optimizedCheckout-formField-inputControlColor");
+        background-color: stencilColor("optimizedCheckout-formChecklist-color");
+        border-color: stencilColor("optimizedCheckout-formChecklist-color");
+    }
+
+    .optimizedCheckout-form-checklist-checkbox:checked ~ .optimizedCheckout-form-label::after {
+        background-color: stencilColor("optimizedCheckout-formField-backgroundColor");
     }
 
     .optimizedCheckout-form-checklist {
@@ -406,7 +409,7 @@ $optimizedCheckout-input--error-boxShadow: 0 0 3px transparentize(stencilColor("
         }
 
         .optimizedCheckout-form-checklist-item--selected {
-            border-color: stencilColor("optimizedCheckout-formField-inputControlColor");
+            border-color: stencilColor("optimizedCheckout-formChecklist-color");
             background-color: stencilColor("optimizedCheckout-formChecklist-backgroundColorSelected");
         }
     }

--- a/assets/scss/optimized-checkout.scss
+++ b/assets/scss/optimized-checkout.scss
@@ -434,6 +434,10 @@ $optimizedCheckout-input--error-boxShadow: 0 0 3px transparentize(stencilColor("
     }
 
     .optimizedCheckout-orderSummary {
+        .optimizedCheckout-orderSummary-toggle {
+            color: stencilColor("optimizedCheckout-link-color");
+        }
+
         svg {
             fill: stencilColor("optimizedCheckout-link-color");
         }

--- a/assets/scss/optimized-checkout.scss
+++ b/assets/scss/optimized-checkout.scss
@@ -389,16 +389,6 @@ $optimizedCheckout-input--error-boxShadow: 0 0 3px transparentize(stencilColor("
 .enhancedThemeV1 {
     background-color: stencilColor("optimizedCheckout-header-backgroundColor");
 
-    .optimizedCheckout-form-select,
-    .optimizedCheckout-form-input {
-        background-color: stencilColor("optimizedCheckout-formField-backgroundColor");
-    }
-
-    .form-field:not(.form-field--error) .optimizedCheckout-form-input:not(:focus):not(:hover),
-    .form-field:not(.form-field--error) .optimizedCheckout-form-select:not(:focus):not(:hover) {
-        border-color: stencilColor("optimizedCheckout-formField-borderColor");
-    }
-
     .optimizedCheckout-form-checklist-checkbox:checked ~ .optimizedCheckout-form-label::before {
         background-color: stencilColor("optimizedCheckout-formChecklist-color");
         border-color: stencilColor("optimizedCheckout-formChecklist-color");
@@ -436,10 +426,10 @@ $optimizedCheckout-input--error-boxShadow: 0 0 3px transparentize(stencilColor("
     .optimizedCheckout-orderSummary {
         .optimizedCheckout-orderSummary-toggle {
             color: stencilColor("optimizedCheckout-link-color");
-        }
 
-        svg {
-            fill: stencilColor("optimizedCheckout-link-color");
+            svg {
+                fill: stencilColor("optimizedCheckout-link-color");
+            }
         }
     }
 }

--- a/assets/scss/optimized-checkout.scss
+++ b/assets/scss/optimized-checkout.scss
@@ -427,4 +427,10 @@ $optimizedCheckout-input--error-boxShadow: 0 0 3px transparentize(stencilColor("
             }
         }
     }
+
+    .optimizedCheckout-orderSummary {
+        svg {
+            fill: stencilColor("optimizedCheckout-link-color");
+        }
+    }
 }

--- a/assets/scss/optimized-checkout.scss
+++ b/assets/scss/optimized-checkout.scss
@@ -379,3 +379,49 @@ $optimizedCheckout-input--error-boxShadow: 0 0 3px transparentize(stencilColor("
     background-color: stencilColor("optimizedCheckout-loadingToaster-backgroundColor");
     color: stencilColor("optimizedCheckout-loadingToaster-textColor");
 }
+
+
+.enhancedTheme {
+    background-color: stencilColor("optimizedCheckout-header-backgroundColor");
+
+    .optimizedCheckout-form-select,
+    .optimizedCheckout-form-input {
+        background-color: stencilColor("optimizedCheckout-formField-backgroundColor");
+    }
+
+    .form-field:not(.form-field--error) .optimizedCheckout-form-input:not(:focus),
+    .form-field:not(.form-field--error) .optimizedCheckout-form-select:not(:focus) {
+        border-color: stencilColor("optimizedCheckout-formField-borderColor");
+    }
+
+    .optimizedCheckout-form-checkbox:checked + .optimizedCheckout-form-label::before,
+    .optimizedCheckout-form-checklist-checkbox:checked ~ .optimizedCheckout-form-label::before {
+        background-color: stencilColor("optimizedCheckout-formField-inputControlColor");
+        border-color: stencilColor("optimizedCheckout-formField-inputControlColor");
+    }
+
+    .optimizedCheckout-form-checklist {
+        .optimizedCheckout-form-checklist-item {
+            border-color: stencilColor("optimizedCheckout-formChecklist-borderColor");
+        }
+
+        .optimizedCheckout-form-checklist-item--selected {
+            border-color: stencilColor("optimizedCheckout-formField-inputControlColor");
+            background-color: stencilColor("optimizedCheckout-formChecklist-backgroundColorSelected");
+        }
+    }
+
+    .optimizedCheckout-contentPrimary {
+        .optimizedCheckout-checkoutStep {
+            background-color: transparentize(stencilColor("optimizedCheckout-body-backgroundColor"), 0.5);
+
+            &.checkout-step--current {
+                background-color: stencilColor("optimizedCheckout-body-backgroundColor");
+            }
+
+            &:not(.checkout-step--current) .optimizedCheckout-buttonSecondary {
+                background-color: transparent;
+            }
+        }
+    }
+}

--- a/assets/scss/optimized-checkout.scss
+++ b/assets/scss/optimized-checkout.scss
@@ -394,8 +394,8 @@ $optimizedCheckout-input--error-boxShadow: 0 0 3px transparentize(stencilColor("
         background-color: stencilColor("optimizedCheckout-formField-backgroundColor");
     }
 
-    .form-field:not(.form-field--error) .optimizedCheckout-form-input:not(:focus),
-    .form-field:not(.form-field--error) .optimizedCheckout-form-select:not(:focus) {
+    .form-field:not(.form-field--error) .optimizedCheckout-form-input:not(:focus):not(:hover),
+    .form-field:not(.form-field--error) .optimizedCheckout-form-select:not(:focus):not(:hover) {
         border-color: stencilColor("optimizedCheckout-formField-borderColor");
     }
 

--- a/assets/scss/optimized-checkout.scss
+++ b/assets/scss/optimized-checkout.scss
@@ -386,7 +386,7 @@ $optimizedCheckout-input--error-boxShadow: 0 0 3px transparentize(stencilColor("
 // "Enhanced Checkout" option is enabled in the control panel.
 // -----------------------------------------------------------------------------
 
-.enhancedTheme {
+.enhancedThemeV1 {
     background-color: stencilColor("optimizedCheckout-header-backgroundColor");
 
     .optimizedCheckout-form-select,


### PR DESCRIPTION
#### What?

Add new style overrides to support the new enhanced checkout theme UI in dark variants as well.
Works in along with checkout-js changes https://github.com/bigcommerce/checkout-js/pull/3228

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [CHECKOUT-10198](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10198)

#### Screenshots (if appropriate)

**BEFORE**

https://github.com/user-attachments/assets/f15998c6-f7da-4cbc-b0b0-8d70c6520a07



**AFTER**

https://github.com/user-attachments/assets/5807816b-c296-4651-bbb7-0545e0b0c481



[CHECKOUT-10198]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Checkout-only SCSS scoped to `.enhancedThemeV1` with no payment or auth logic changes; risk is limited to visual regressions on Enhanced Checkout when enabled.
> 
> **Overview**
> Adds **`.enhancedThemeV1`** rules in `optimized-checkout.scss` so Optimized Checkout can match the new Enhanced Checkout UI (including dark variants), paired with checkout-js changes.
> 
> When the control panel **Enhanced Checkout** option is on, checkout-js applies this wrapper class; Cornerstone now maps **existing** `optimizedCheckout-*` theme colors to checklist radios, step panel backgrounds (current vs inactive), secondary buttons on non-current steps, and order-summary toggle text/icon fill. Header background color drives the enhanced theme page background.
> 
> CHANGELOG draft entry documents the theme update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3daa6f09059f6c230557ea99091c55dcf6de7639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->