### PR TITLE
feat(orders): ORDERS-7876 improve accessibility for guest-return page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Draft
 - Add accessibility to returns entry-point links on the orders list and order details pages: order-scoped `aria-label`s and correct keyboard focus order (ORDERS-7877)
+- Add accessibility to guest return portal entry form: main landmark, named form, inline error linking with `aria-invalid`, live-region lookup announcements, and focus to the first invalid field on failed submit (ORDERS-7876)
 - Add accessibility to return detail page: status-badge screen-reader context and dialog semantics on the shared alert modal (ORDERS-7875)
 - Add accessibility to returns list page and an in-repo accessibility skill (ORDERS-7878)
 - Fix accessibility issues in create-return flow: avoid double announcements on submit errors, drop a redundant focus-on-load, and simplify the submit button's ARIA description (ORDERS-7874)

--- a/assets/js/theme/guest-return-portal.js
+++ b/assets/js/theme/guest-return-portal.js
@@ -6,10 +6,11 @@ import {
 } from './common/utils/form-utils';
 import forms from './common/models/forms';
 
-// Listed in DOM order so a failed submit can focus the first field needing correction.
+// Keep in DOM order — a failed submit focuses the first invalid field.
+// Both nod and the submit handler use the same `isValid` to check a field.
 const VALIDATED_FIELDS = [
-    { input: '#guest-return-email-input', errorSpan: '#guest-return-email-error' },
-    { input: '#guest-return-order-input', errorSpan: '#guest-return-order-error' },
+    { input: '#guest-return-email-input', errorSpan: '#guest-return-email-error', isValid: val => forms.email(val) },
+    { input: '#guest-return-order-input', errorSpan: '#guest-return-order-error', isValid: val => forms.numbersOnly(val) },
 ];
 
 export default class GuestReturnPortal extends PageManager {
@@ -21,7 +22,7 @@ export default class GuestReturnPortal extends PageManager {
         this.bindSubmit(form);
     }
 
-    // Replaces stale text in the visually-hidden status region rather than appending.
+    // Replaces the message in the hidden status region that screen readers read out.
     announce(message) {
         const liveRegion = document.querySelector('[data-guest-return-status]');
         if (liveRegion) liveRegion.textContent = message || '';
@@ -39,70 +40,80 @@ export default class GuestReturnPortal extends PageManager {
         this.validator.add([
             {
                 selector: `.guest-return-portal-form input${VALIDATED_FIELDS[0].input}`,
-                validate: (cb, val) => {
-                    const result = forms.email(val);
-
-                    cb(result);
-                },
+                validate: (cb, val) => cb(VALIDATED_FIELDS[0].isValid(val)),
                 errorMessage: this.context.invalidEmail,
             },
             {
                 selector: `.guest-return-portal-form input${VALIDATED_FIELDS[1].input}`,
-                validate: (cb, val) => {
-                    const result = forms.numbersOnly(val);
-
-                    cb(result);
-                },
+                validate: (cb, val) => cb(VALIDATED_FIELDS[1].isValid(val)),
                 errorMessage: this.context.invalidOrder,
             },
         ]);
 
-        // Point nod at the template's error nodes so each message keeps the stable id its
-        // input references via aria-describedby. Left to itself nod appends an anonymous
-        // span, which nothing can point at.
+        // Have nod write errors into the template's own spans — their ids are what
+        // each input's aria-describedby points at.
         this.validator.setMessageOptions(VALIDATED_FIELDS.map(({ input, errorSpan }) => ({
             selector: `.guest-return-portal-form input${input}`,
             errorSpan,
         })));
     }
 
-    // Expose nod's result as ARIA state, so invalid fields aren't signalled by styling alone.
+    // Mirror nod's result onto aria-invalid so screen readers know the field's state.
     syncFieldValidity({ element, result }) {
         if (!element) return;
 
         element.setAttribute('aria-invalid', String(!result));
     }
 
-    focusFirstInvalidField() {
-        VALIDATED_FIELDS
-            .map(({ input }) => document.querySelector(input))
-            .find(input => input && input.getAttribute('aria-invalid') === 'true')
-            ?.focus();
+    findFirstInvalidField() {
+        return VALIDATED_FIELDS
+            .map(({ input, isValid }) => ({ element: document.querySelector(input), isValid }))
+            .find(({ element, isValid }) => element && !isValid(element.value))
+            ?.element;
+    }
+
+    // Empty the inline errors before each attempt, so a resubmit doesn't
+    // announce the same message twice.
+    resetInlineErrors() {
+        VALIDATED_FIELDS.forEach(({ errorSpan }) => {
+            const span = document.querySelector(errorSpan);
+            if (!span) return;
+
+            span.textContent = '';
+            span.style.display = 'none';
+        });
     }
 
     bindSubmit(form) {
         form.addEventListener('submit', async event => {
             event.preventDefault();
 
-            this.validator.performCheck();
+            // Start each attempt clean — errors from the last attempt no longer apply.
+            this.resetInlineErrors();
+            this.clearError();
 
-            if (!this.validator.areAll('valid')) {
-                this.focusFirstInvalidField();
+            const firstInvalidField = this.findFirstInvalidField();
+            if (firstInvalidField) {
+                // Focus the field first, then render the errors — this way the shopper
+                // hears the field, then its error, exactly once each.
+                firstInvalidField.focus();
+                this.validator.performCheck();
                 return;
             }
+
+            this.validator.performCheck();
+            if (!this.validator.areAll('valid')) return;
 
             // Ignore activations while a request is in flight
             if (this.isSubmitting) return;
             this.isSubmitting = true;
             const submitBtn = document.getElementById('return-guest-submit-btn');
             const overlay = document.querySelector('.guest-return-portal .loadingOverlay');
-            // aria-disabled instead of the native attribute: disabling the button the shopper
-            // just activated would drop focus to <body>, losing their place before the
-            // outcome is announced. Re-entry is already blocked by `isSubmitting`.
+            // aria-disabled keeps focus on the button; the native `disabled` would drop
+            // focus to the page. Repeat submits are already blocked by `isSubmitting`.
             if (submitBtn) submitBtn.setAttribute('aria-disabled', 'true');
             if (overlay) overlay.style.display = 'block';
             form.setAttribute('aria-busy', 'true');
-            this.clearError();
             this.announce(this.context.submittingMessage);
             const payload = this.buildRequestPayload();
 
@@ -126,12 +137,11 @@ export default class GuestReturnPortal extends PageManager {
                     throw new Error('Failed to start return guest session');
                 }
 
-                // Full navigation, so the browser establishes focus in the next document.
+                // Full page navigation — the browser handles focus on the next page.
                 window.location.href = `/create-return/${payload.orderEntityId}`;
             } catch (error) {
-                // Drop the in-flight message so it can't be mistaken for the current state.
-                // The failure itself is announced by the role="alert" container, which leaves
-                // focus on Submit for an immediate retry.
+                // Clear the "please wait" message; the error box announces the failure
+                // while focus stays on the button so the shopper can retry right away.
                 this.announce('');
 
                 if (error instanceof NotFoundError) {
@@ -188,13 +198,13 @@ export default class GuestReturnPortal extends PageManager {
         if (!alertBox) return;
 
         const messageElement = alertBox.querySelector('#alertBox-message-text');
+        if (messageElement) messageElement.textContent = message || '';
 
         alertBox.style.display = 'block';
-        if (messageElement) messageElement.textContent = message || '';
     }
 
-    // Hiding the box between attempts also means an identical repeat error still registers
-    // as a change in the alert region, so it is announced again.
+    // Hide the box between attempts so even a repeat of the same error
+    // counts as new content and is announced again.
     clearError() {
         const alertBox = document.querySelector('.guest-return-portal-error-container .alertBox');
         if (alertBox) alertBox.style.display = 'none';

--- a/assets/js/theme/guest-return-portal.js
+++ b/assets/js/theme/guest-return-portal.js
@@ -6,6 +6,12 @@ import {
 } from './common/utils/form-utils';
 import forms from './common/models/forms';
 
+// Listed in DOM order so a failed submit can focus the first field needing correction.
+const VALIDATED_FIELDS = [
+    { input: '#guest-return-email-input', errorSpan: '#guest-return-email-error' },
+    { input: '#guest-return-order-input', errorSpan: '#guest-return-order-error' },
+];
+
 export default class GuestReturnPortal extends PageManager {
     onReady() {
         const form = document.querySelector('[data-guest-return-portal-form]');
@@ -15,24 +21,33 @@ export default class GuestReturnPortal extends PageManager {
         this.bindSubmit(form);
     }
 
+    // Replaces stale text in the visually-hidden status region rather than appending.
+    announce(message) {
+        const liveRegion = document.querySelector('[data-guest-return-status]');
+        if (liveRegion) liveRegion.textContent = message || '';
+    }
+
     registerValidation() {
         this.validator = nod({
             submit: '.guest-return-portal-form button[type="submit"]',
-            tap: announceInputErrorMessage,
+            tap: params => {
+                announceInputErrorMessage(params);
+                this.syncFieldValidity(params);
+            },
         });
 
         this.validator.add([
             {
-                selector: '.guest-return-portal-form input#guest-return-email-input',
+                selector: `.guest-return-portal-form input${VALIDATED_FIELDS[0].input}`,
                 validate: (cb, val) => {
                     const result = forms.email(val);
 
                     cb(result);
                 },
-                errorMessage: this.context.useValidEmail,
+                errorMessage: this.context.invalidEmail,
             },
             {
-                selector: '.guest-return-portal-form input#guest-return-order-input',
+                selector: `.guest-return-portal-form input${VALIDATED_FIELDS[1].input}`,
                 validate: (cb, val) => {
                     const result = forms.numbersOnly(val);
 
@@ -41,6 +56,28 @@ export default class GuestReturnPortal extends PageManager {
                 errorMessage: this.context.invalidOrder,
             },
         ]);
+
+        // Point nod at the template's error nodes so each message keeps the stable id its
+        // input references via aria-describedby. Left to itself nod appends an anonymous
+        // span, which nothing can point at.
+        this.validator.setMessageOptions(VALIDATED_FIELDS.map(({ input, errorSpan }) => ({
+            selector: `.guest-return-portal-form input${input}`,
+            errorSpan,
+        })));
+    }
+
+    // Expose nod's result as ARIA state, so invalid fields aren't signalled by styling alone.
+    syncFieldValidity({ element, result }) {
+        if (!element) return;
+
+        element.setAttribute('aria-invalid', String(!result));
+    }
+
+    focusFirstInvalidField() {
+        VALIDATED_FIELDS
+            .map(({ input }) => document.querySelector(input))
+            .find(input => input && input.getAttribute('aria-invalid') === 'true')
+            ?.focus();
     }
 
     bindSubmit(form) {
@@ -50,16 +87,23 @@ export default class GuestReturnPortal extends PageManager {
             this.validator.performCheck();
 
             if (!this.validator.areAll('valid')) {
+                this.focusFirstInvalidField();
                 return;
             }
 
-            // Ignore clicks while a request is in flight
+            // Ignore activations while a request is in flight
             if (this.isSubmitting) return;
             this.isSubmitting = true;
             const submitBtn = document.getElementById('return-guest-submit-btn');
             const overlay = document.querySelector('.guest-return-portal .loadingOverlay');
-            if (submitBtn) submitBtn.disabled = true;
+            // aria-disabled instead of the native attribute: disabling the button the shopper
+            // just activated would drop focus to <body>, losing their place before the
+            // outcome is announced. Re-entry is already blocked by `isSubmitting`.
+            if (submitBtn) submitBtn.setAttribute('aria-disabled', 'true');
             if (overlay) overlay.style.display = 'block';
+            form.setAttribute('aria-busy', 'true');
+            this.clearError();
+            this.announce(this.context.submittingMessage);
             const payload = this.buildRequestPayload();
 
             try {
@@ -82,8 +126,14 @@ export default class GuestReturnPortal extends PageManager {
                     throw new Error('Failed to start return guest session');
                 }
 
+                // Full navigation, so the browser establishes focus in the next document.
                 window.location.href = `/create-return/${payload.orderEntityId}`;
             } catch (error) {
+                // Drop the in-flight message so it can't be mistaken for the current state.
+                // The failure itself is announced by the role="alert" container, which leaves
+                // focus on Submit for an immediate retry.
+                this.announce('');
+
                 if (error instanceof NotFoundError) {
                     this.showError(this.context.notFoundError);
                 } else {
@@ -91,8 +141,9 @@ export default class GuestReturnPortal extends PageManager {
                 }
 
                 this.isSubmitting = false;
-                if (submitBtn) submitBtn.disabled = false;
+                if (submitBtn) submitBtn.removeAttribute('aria-disabled');
                 if (overlay) overlay.style.display = '';
+                form.removeAttribute('aria-busy');
             }
         });
     }
@@ -140,5 +191,12 @@ export default class GuestReturnPortal extends PageManager {
 
         alertBox.style.display = 'block';
         if (messageElement) messageElement.textContent = message || '';
+    }
+
+    // Hiding the box between attempts also means an identical repeat error still registers
+    // as a change in the alert region, so it is announced again.
+    clearError() {
+        const alertBox = document.querySelector('.guest-return-portal-error-container .alertBox');
+        if (alertBox) alertBox.style.display = 'none';
     }
 }

--- a/assets/scss/components/stencil/guestReturnPortal/_guestReturnPortal.scss
+++ b/assets/scss/components/stencil/guestReturnPortal/_guestReturnPortal.scss
@@ -13,24 +13,15 @@
     }
 }
 
-// The spinner is the only motion on this page, and it conveys nothing that the
-// visually-hidden status region doesn't already announce, so stopping it costs
-// nothing for shoppers who ask for reduced motion.
-@media (prefers-reduced-motion: reduce) {
-    .guest-return-portal .loadingOverlay::before {
-        animation: none;
-    }
-}
-
 .guest-return-portal-error-container {
     .alertBox {
         display: none;
     }
 }
 
-// The order-ID hint is a persistent visible instruction, not SR-only text. Give it
-// its own line instead of running inline against the input. Colour and size are left
-// inherited so the instruction keeps the body text's contrast.
+// The order-ID hint is visible to everyone, not screen-reader-only text.
+// Put it on its own line under the input instead of running inline against it.
+// Colour and size are inherited so the hint keeps normal body-text contrast.
 .guest-return-portal .form-field .aria-description {
     display: block;
     margin-top: spacing("quarter");

--- a/assets/scss/components/stencil/guestReturnPortal/_guestReturnPortal.scss
+++ b/assets/scss/components/stencil/guestReturnPortal/_guestReturnPortal.scss
@@ -13,10 +13,27 @@
     }
 }
 
+// The spinner is the only motion on this page, and it conveys nothing that the
+// visually-hidden status region doesn't already announce, so stopping it costs
+// nothing for shoppers who ask for reduced motion.
+@media (prefers-reduced-motion: reduce) {
+    .guest-return-portal .loadingOverlay::before {
+        animation: none;
+    }
+}
+
 .guest-return-portal-error-container {
     .alertBox {
         display: none;
     }
+}
+
+// The order-ID hint is a persistent visible instruction, not SR-only text. Give it
+// its own line instead of running inline against the input. Colour and size are left
+// inherited so the instruction keeps the body text's contrast.
+.guest-return-portal .form-field .aria-description {
+    display: block;
+    margin-top: spacing("quarter");
 }
 
 .guest-return-portal-row {

--- a/lang/en.json
+++ b/lang/en.json
@@ -504,7 +504,9 @@
                 "order_id_description": "You can find your order ID in your order confirmation email",
                 "not_found_error": "We couldn’t find an order with that ID and email. Please double-check your details.",
                 "start_the_return": "Start the return",
-                "invalid_order": "Please enter a valid order ID (numbers only)."
+                "invalid_order": "Please enter a valid order ID (numbers only).",
+                "invalid_email": "Enter the email address you used when placing this order, such as user@example.com.",
+                "submitting": "Looking up your order, please wait."
             },
             "details": {
                 "return_number": "Return #{id}",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bigcommerce-cornerstone",
-      "version": "6.19.1",
+      "version": "6.21.0",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/stencil-utils": "6.23.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bigcommerce-cornerstone",
-  "version": "6.21.0",
+  "version": "6.19.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bigcommerce-cornerstone",
-      "version": "6.21.0",
+      "version": "6.19.1",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/stencil-utils": "6.23.0",

--- a/templates/pages/guest-return-portal.html
+++ b/templates/pages/guest-return-portal.html
@@ -1,21 +1,26 @@
 {{#partial "page"}}
 
 {{~inject 'storefrontApiToken' settings.storefront_api.token}}
-<div class="guest-return-portal">
+<main class="guest-return-portal">
     {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
     <div class="loadingOverlay"></div>
-    <h1 class="guest-return-portal-title page-heading">{{lang 'account.returns.guest.title'}}</h1>
+    <h1 id="guest-return-portal-title" class="guest-return-portal-title page-heading">{{lang 'account.returns.guest.title'}}</h1>
 
     <div class="link-row">
         <a href="/return-policy" class="">
             {{lang 'account.returns.view_return_policy'}}
         </a>
     </div>
-    
+
+    {{!-- Visually-hidden, used for announcing the progress of looking up the order. Same approach as in the create-return flow. --}}
+    <p class="aria-description--hidden" aria-live="assertive" aria-atomic="true" data-guest-return-status></p>
+
     <div class="guest-return-portal-row">
-        <form class="form guest-return-portal-form" data-guest-return-portal-form>
+        <form class="form guest-return-portal-form"
+              aria-labelledby="guest-return-portal-title"
+              data-guest-return-portal-form>
             <div class="form-field">
-                {{inject 'useValidEmail' (lang 'forms.validate.common.email_address')}}
+                {{inject 'invalidEmail' (lang 'account.returns.guest.invalid_email')}}
                 <label for="guest-return-email-input" class="form-label">
                     {{lang 'account.returns.guest.email'}}
                 </label>
@@ -24,7 +29,11 @@
                     type="email"
                     placeholder="{{lang 'account.returns.guest.email_placeholder'}}"
                     autocomplete="email"
+                    aria-describedby="guest-return-email-error"
                 />
+                {{!-- Empty, hidden error node with a stable id so aria-describedby has a
+                      permanent target; nod fills it in via setMessageOptions. --}}
+                <span class="form-inlineMessage" id="guest-return-email-error" style="display: none;"></span>
             </div>
             <div class="form-field">
                 {{inject 'invalidOrder' (lang 'account.returns.guest.invalid_order')}}
@@ -33,21 +42,26 @@
                 </label>
                 <input class="form-input"
                     id="guest-return-order-input"
+                    type="text"
                     placeholder="{{lang 'account.returns.guest.order_id_placeholder'}}"
-                    aria-describedby="guest-return-order-description"
+                    aria-describedby="guest-return-order-description guest-return-order-error"
                     inputmode="numeric"
                 />
                 <span id="guest-return-order-description" class="aria-description">
                     {{lang 'account.returns.guest.order_id_description'}}
                 </span>
+                <span class="form-inlineMessage" id="guest-return-order-error" style="display: none;"></span>
             </div>
 
             {{inject 'genericError' (lang 'common.generic_error')}}
             {{inject 'notFoundError' (lang 'account.returns.guest.not_found_error')}}
-            <div class="guest-return-portal-error-container">
+            {{inject 'submittingMessage' (lang 'account.returns.guest.submitting')}}
+            {{!-- Error announcer. role="alert" makes screen readers read the error out
+                  automatically the moment JS reveals the .alertBox inside. Same approach as in this create return flow. --}}
+            <div class="guest-return-portal-error-container" role="alert">
                 {{> components/common/alert/alert-error (lang 'common.generic_error')}}
             </div>
-    
+
             <div class="form-actions">
                 <button class="button button--primary"
                     id="return-guest-submit-btn"
@@ -58,7 +72,7 @@
             </div>
         </form>
     </div>
-</div>
+</main>
 
 {{/partial}}
 


### PR DESCRIPTION
#### What?

This PR aims to improve the accessibility for the `guest-return` portal page.

This PR adds the usage of `aria` labels for divs, and proper roles.

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

https://bigcommercecloud.atlassian.net/browse/ORDERS-7876

#### Screenshots (if appropriate)

Field Validation
Before:

https://github.com/user-attachments/assets/74fa619e-56dd-4a8c-8e2e-6a11858e1203

After:

https://github.com/user-attachments/assets/e1704dc8-ea05-4801-a55e-c53de67d3861



Submitting an order
Before:

https://github.com/user-attachments/assets/7cd3a2fc-88b4-4ef1-afdd-4b92ec4d0ed4


After:

https://github.com/user-attachments/assets/1b814096-0faf-4350-a149-e20ba4178b63


Submitting an invalid orderId

Before:

https://github.com/user-attachments/assets/2e8e1ef2-de62-4a09-89a0-6de7d99c6c51

After:

https://github.com/user-attachments/assets/6625c1e4-4e2a-4496-82f8-c89a4cc7eeb9



Submitting with an invalid field

Before:

https://github.com/user-attachments/assets/7d09a453-2833-440e-b186-483cb0c93c44



After:


https://github.com/user-attachments/assets/c5146e30-dcb7-4cf8-ac1e-afa4200e75b0




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Accessibility and validation UX changes on the guest returns entry page; no auth, payment, or broad architectural changes.
> 
> **Overview**
> Improves **screen reader and keyboard behavior** on the guest return portal entry form, aligned with the create-return accessibility work.
> 
> The page wrapper becomes a **`main` landmark**; the form is named via **`aria-labelledby`** on the page title. Email and order ID fields get **stable inline error nodes** wired through **`aria-describedby`**, with nod writing into those spans and **`aria-invalid`** updated on validation.
> 
> On failed submit, **inline errors are cleared** between attempts, focus moves to the **first invalid field** in DOM order, and a hidden **assertive live region** announces **“looking up your order”** while **`aria-busy`** is set on the form. The submit button uses **`aria-disabled`** instead of native **`disabled`** so focus stays on the button during lookup. Server/not-found errors use a **`role="alert`** container that is hidden between attempts so repeats are announced again.
> 
> Guest-specific **invalid email** and **submitting** strings replace the generic forms email inject. Order ID hint text is styled **on its own line** under the field for readability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 339dd878dcd7d945706c4a4d34b8483a75c7608d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->