### PR TITLE
Orders 7877 accessibility returns entry points

### DIFF
--- a/.claude/skills/accessibility/SKILL.md
+++ b/.claude/skills/accessibility/SKILL.md
@@ -110,6 +110,10 @@ Design applicable requirements into the solution, then edit.
    never use color alone; pointer targets ≥24×24 CSS px unless SC 2.5.8
    exception applies. In Cornerstone, `color("greys","base")` (#999) fails for
    text — use `color("greys","dark")` (#666).
+   - **`prefers-reduced-motion` targets substantial/auto-playing motion**
+     (parallax, carousels, looping scenes). Transient loading spinners are
+     exempt (SC 2.2.2, A) and reduced-motion coverage for them is AAA — don't
+     add per-spinner overrides.
 
 7. **Translatable strings.** No hardcoded English in ARIA. Add a key to
    `lang/en.json`, reference via `{{lang '...'}}` or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Add accessibility to returns entry-point links on the orders list and order details pages: order-scoped `aria-label`s and correct keyboard focus order (ORDERS-7877)
 - Add accessibility to return detail page: status-badge screen-reader context and dialog semantics on the shared alert modal (ORDERS-7875)
 - Add accessibility to returns list page and an in-repo accessibility skill (ORDERS-7878)
 - Fix accessibility issues in create-return flow: avoid double announcements on submit errors, drop a redundant focus-on-load, and simplify the submit button's ARIA description (ORDERS-7874)

--- a/assets/scss/components/stencil/account/_account.scss
+++ b/assets/scss/components/stencil/account/_account.scss
@@ -373,6 +373,17 @@ $account-backorder-textColor: #757575;
     }
 }
 
+// Orders list: title + status/return share a flex row so the status block reserves
+// its own space while the order link stays first in the DOM for focus order (WCAG 2.4.3).
+.account-product-heading {
+    @include breakpoint("small") {
+        align-items: flex-start;
+        display: flex;
+        gap: spacing("half");
+        justify-content: space-between;
+    }
+}
+
 .account-orderStatus-label {
     background-color: stencilColor("label-backgroundColor");
     color: stencilColor("label-color");

--- a/lang/en.json
+++ b/lang/en.json
@@ -352,6 +352,7 @@
             "refunded_quantity": "({qty} refunded)",
             "return_item": "Return",
             "return_items": "Return Items?",
+            "return_items_for": "Return Items for order #{number}",
             "order_placed": "Order Placed",
             "last_update": "Last Update",
             "list": {

--- a/templates/components/account/orders-list.html
+++ b/templates/components/account/orders-list.html
@@ -21,20 +21,24 @@
                 {{/if}}
             </div>
             <div class="account-product-body">
-                <div class="account-orderStatus">
-                    <h6 class="account-orderStatus-label">{{this.status}}</h6>
-                    {{#if this.return_url}}
-                        {{#or ../settings.returns_v2_enabled ../settings.returns_enabled}}
-                            <a class="account-orderStatus-action" href="{{this.return_url}}">
-                                {{lang 'account.orders.return_items' }}
-                            </a>
-                        {{/or}}
-                    {{/if}}
-                </div>
+                {{!-- Title and status share a flex row so focus reaches the order link before the
+                      "Return Items" action (WCAG 2.4.3) while the status block still reserves space. --}}
+                <div class="account-product-heading">
+                    <h5 class="account-product-title">
+                        <a href="{{this.details_url}}">{{lang 'account.orders.list.order_number' number=this.id}}</a>
+                    </h5>
 
-                <h5 class="account-product-title">
-                    <a href="{{this.details_url}}">{{lang 'account.orders.list.order_number' number=this.id}}</a>
-                </h5>
+                    <div class="account-orderStatus">
+                        <h6 class="account-orderStatus-label">{{this.status}}</h6>
+                        {{#if this.return_url}}
+                            {{#or ../settings.returns_v2_enabled ../settings.returns_enabled}}
+                                <a class="account-orderStatus-action" href="{{this.return_url}}" aria-label="{{lang 'account.orders.return_items_for' number=this.id}}">
+                                    {{lang 'account.orders.return_items' }}
+                                </a>
+                            {{/or}}
+                        {{/if}}
+                    </div>
+                </div>
                 <p class="account-product-description">{{lang 'account.orders.list.product_details' num_products=this.total_quantity cost=this.total.formatted}}</p>
 
                 <div class="account-product-details">

--- a/templates/pages/account/orders/details.html
+++ b/templates/pages/account/orders/details.html
@@ -185,7 +185,7 @@
                     </form>
                     {{#or settings.returns_v2_enabled settings.returns_enabled}}
                         {{#if order.is_complete}}
-                            <a href="{{order.return_url}}" class="button">{{lang 'account.orders.details.return'}}</a>
+                            <a href="{{order.return_url}}" class="button" aria-label="{{lang 'account.orders.return_items_for' number=order.id}}">{{lang 'account.orders.details.return'}}</a>
                         {{/if}}
                     {{/or}}
                 </div>


### PR DESCRIPTION
#### What?

Accessibility for returns entry points on order list and order details page

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

[ORDERS-7877](https://bigcommercecloud.atlassian.net/browse/ORDERS-7877)

#### Screenshots (if appropriate)

##### Before changes (Navigation goes to returns link first and then to order ID):

https://github.com/user-attachments/assets/01146093-9c20-4bb7-968f-e2f562e68598



##### After changes(UI remains same with fixes to aria-labels and navigation improvements):
<img width="1726" height="1030" alt="image" src="https://github.com/user-attachments/assets/4507474b-51df-4d90-a559-228756bef334" />



[ORDERS-7877]: https://bigcommercecloud.atlassian.net/browse/ORDERS-7877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template, CSS layout, and i18n-only accessibility fixes with no auth, data, or behavioral logic changes. Visual layout is preserved via flex, but focus order and screen-reader naming should be spot-checked.
> 
> **Overview**
> Improves accessibility of **returns entry points** on the orders list and order details pages (ORDERS-7877).
> 
> On the orders list, the order title link is moved **before** the status/return block in the DOM so keyboard focus reaches the order first (WCAG 2.4.3), while a new `.account-product-heading` flex row keeps the visual layout. Return links on both the list and details pages get an order-scoped `aria-label` via the new `return_items_for` string.
> 
> Also clarifies in the accessibility skill that `prefers-reduced-motion` targets substantial/auto-playing motion, not transient loading spinners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3668a6d5b0353f97bfc8d329af20753daca3033e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->