### PR TITLE
feat(returns): ORDERS-7945 add page title to returns related pages for accessibility and seo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Add a translatable page `<title>` to the create return and guest return portal pages for accessibility (WCAG 2.4.2) and SEO (ORDERS-7945)
 - Add accessibility to return detail page: status-badge screen-reader context and dialog semantics on the shared alert modal (ORDERS-7875)
 - Add accessibility to returns list page and an in-repo accessibility skill (ORDERS-7878)
 - Fix accessibility issues in create-return flow: avoid double announcements on submit errors, drop a redundant focus-on-load, and simplify the submit button's ARIA description (ORDERS-7874)

--- a/lang/en.json
+++ b/lang/en.json
@@ -444,6 +444,12 @@
         },
         "returns": {
             "heading": "Returns",
+            "titles": {
+                "create": "Request a Return",
+                "detail": "Return details",
+                "guest": "Start a return",
+                "list": "Your returns"
+            },
             "instructions": "Return Instructions",
             "error_no_qty": "Please select one or more items to return.",
             "none": "You haven't placed any returns with us. When you do, they will appear on this page.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -446,9 +446,7 @@
             "heading": "Returns",
             "titles": {
                 "create": "Request a Return",
-                "detail": "Return details",
-                "guest": "Start a return",
-                "list": "Your returns"
+                "guest": "Start a return"
             },
             "instructions": "Return Instructions",
             "error_no_qty": "Please select one or more items to return.",

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -1,7 +1,24 @@
 <!DOCTYPE html>
 <html class="no-js" lang="{{ locale_name }}">
     <head>
-        <title>{{ head.title }}</title>
+        {{!-- Shopper-facing returns routes are served by the storefront without a server-set head.title,
+              so fall back to a descriptive, translatable title per page (WCAG 2.4.2).
+              Only fires when head.title is empty, so titled pages are unaffected. --}}
+        <title>
+            {{~#if head.title~}}
+                {{head.title}}
+            {{~else if page_type '===' 'create_return'~}}
+                {{lang 'account.returns.titles.create'}}
+            {{~else if page_type '===' 'return_detail'~}}
+                {{lang 'account.returns.titles.detail'}}
+            {{~else if page_type '===' 'account_return_detail'~}}
+                {{lang 'account.returns.titles.detail'}}
+            {{~else if page_type '===' 'guest_return_portal'~}}
+                {{lang 'account.returns.titles.guest'}}
+            {{~else if page_type '===' 'account_returns'~}}
+                {{lang 'account.returns.titles.list'}}
+            {{~/if~}}
+        </title>
         {{{ resourceHints }}}
         {{{ head.meta_tags }}}
         {{{ head.config }}}

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -1,22 +1,15 @@
 <!DOCTYPE html>
 <html class="no-js" lang="{{ locale_name }}">
     <head>
-        {{!-- Shopper-facing returns routes are served by the storefront without a server-set head.title,
-              so fall back to a descriptive, translatable title per page (WCAG 2.4.2).
-              Only fires when head.title is empty, so titled pages are unaffected. --}}
+        {{!-- Create Return and Guest Return Portal are standalone storefront routes with no server-set
+              head.title, so fall back to a descriptive, translatable title (WCAG 2.4.2). --}}
         <title>
             {{~#if head.title~}}
                 {{head.title}}
             {{~else if page_type '===' 'create_return'~}}
                 {{lang 'account.returns.titles.create'}}
-            {{~else if page_type '===' 'return_detail'~}}
-                {{lang 'account.returns.titles.detail'}}
-            {{~else if page_type '===' 'account_return_detail'~}}
-                {{lang 'account.returns.titles.detail'}}
             {{~else if page_type '===' 'guest_return_portal'~}}
                 {{lang 'account.returns.titles.guest'}}
-            {{~else if page_type '===' 'account_returns'~}}
-                {{lang 'account.returns.titles.list'}}
             {{~/if~}}
         </title>
         {{{ resourceHints }}}


### PR DESCRIPTION
#### What?

Add title on returns pages for accessibility and seo. 

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

[ORDERS-7945](https://bigcommercecloud.atlassian.net/browse/ORDERS-7945)

#### Screenshots (if appropriate)

Before implementation:

No title on create return page:
<img width="1612" height="923" alt="image" src="https://github.com/user-attachments/assets/3186aeb7-f81c-4d1e-a89c-05b6c253ccf4" />

No title on guest return page:
<img width="1911" height="995" alt="image" src="https://github.com/user-attachments/assets/a14ff65f-798d-4f6b-9926-32900ea89e45" />



Lighthouse score:
<img width="1613" height="910" alt="image" src="https://github.com/user-attachments/assets/62cc13b8-cf8d-445b-a2dc-9f8aa72fe103" />


After implementation:

Title on create return page:
<img width="1610" height="904" alt="image" src="https://github.com/user-attachments/assets/3599130a-52ab-45a1-9aef-7073227ec7ac" />

Title on guest return page:
<img width="1917" height="850" alt="image" src="https://github.com/user-attachments/assets/6bf76750-f79a-490e-9e83-efac4fd72719" />

Other return related pages where title already comes from BCApp:
<img width="1905" height="976" alt="image" src="https://github.com/user-attachments/assets/b7d0ce65-657e-4f9a-9b76-101b46aa002b" />

<img width="1915" height="1003" alt="image" src="https://github.com/user-attachments/assets/c50d88ec-737d-4237-8262-d08e9c123138" />




Lighthouse score:
<img width="1614" height="922" alt="image" src="https://github.com/user-attachments/assets/12679225-69aa-43bc-88a2-5bcbab5dca41" />




[ORDERS-7945]: https://bigcommercecloud.atlassian.net/browse/ORDERS-7945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template and translation-only change to document metadata; no changes to auth, checkout, or return submission logic.
> 
> **Overview**
> **Adds descriptive, translatable `<title>` text** for two returns routes that previously had no server-provided `head.title`, addressing WCAG 2.4.2 and SEO (Lighthouse document title checks).
> 
> In `base.html`, the layout still uses `head.title` when present; otherwise it sets the title from `page_type`: **Request a Return** for `create_return` and **Start a return** for `guest_return_portal` via new `account.returns.titles` strings in `en.json`. Other return-related pages that already receive titles from BCApp are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5b343e1af67c953b63910767fbf8d001508b8c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->