### PR TITLE
feat(orders): ORDERS-7965 fix return listing page quantity displayed

### DIFF
--- a/templates/components/account/returns-list-v2.html
+++ b/templates/components/account/returns-list-v2.html
@@ -31,7 +31,7 @@
             </div>
             <div class="account-returnsList-detail">
                 <dt class="account-returnsList-detail-heading">{{lang 'account.returns.list.return_quantity' }}</dt>
-                <dd class="account-returnsList-detail-value">{{items.length}}</dd>
+                <dd class="account-returnsList-detail-value">{{sum (pluck items 'quantity')}}</dd>
             </div>
             {{> components/account/return-items-total
                 total=total_item_price


### PR DESCRIPTION
#### What?

This PR ensures that the return items quantity is used rather than the array length to display the correct item quantity in the returns listing page.

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

https://bigcommercecloud.atlassian.net/browse/ORDERS-7965

#### Screenshots (if appropriate)

Given a return with the following item quantity of 4
<img width="3018" height="1138" alt="image" src="https://github.com/user-attachments/assets/44da9279-65bc-43d7-8746-a9de05a5d68d" />


Before:

<img width="3018" height="1138" alt="image" src="https://github.com/user-attachments/assets/4361adfa-a93a-494b-b824-3e8f369499bf" />

After:
<img width="3018" height="1138" alt="image" src="https://github.com/user-attachments/assets/1e2c9352-6d4d-4875-b803-e5a58dfdd684" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Handlebars expression change in a customer account template with no auth, payment, or data-layer impact.
> 
> **Overview**
> Fixes the **return quantity** field on the account returns listing (v2 template) so it reflects total units returned, not the number of line items.
> 
> The value now uses **`sum (pluck items 'quantity')`** instead of **`items.length`**, so a single return line with quantity 4 displays as 4 rather than 1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 251094a80bbc27add54ee6170ec77b37a5afc7b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->