### PR TITLE
feat(orders): ORDERS-7965 align date format and status badge between returns listing and details page

### DIFF
--- a/assets/scss/components/stencil/returnDetails/_returnDetails.scss
+++ b/assets/scss/components/stencil/returnDetails/_returnDetails.scss
@@ -23,37 +23,11 @@
     margin: 0;
 }
 
-.returnDetails-statusBadge {
-    display: inline-block;
-    padding: spacing("eighth") spacing("quarter");
-    border-radius: remCalc(4px);
-    font-size: remCalc(11px);
-    font-weight: fontWeight("bold");
-    letter-spacing: remCalc(1px);
+// Status badge is shared with the returns list (.account-orderStatus-label);
+.returnDetails-titleGroup .account-orderStatus-label {
+    font-family: $header-font-family;
     text-transform: uppercase;
-    background-color: stencilColor("returnStatus-closed-backgroundColor");
-    color: stencilColor("returnStatus-closed-color");
-}
-
-// Status badges pair a background and text colour per variation
-.returnDetails-statusBadge--open {
-    background-color: stencilColor("returnStatus-open-backgroundColor");
-    color: stencilColor("returnStatus-open-color");
-}
-
-.returnDetails-statusBadge--in_progress {
-    background-color: stencilColor("returnStatus-inProgress-backgroundColor");
-    color: stencilColor("returnStatus-inProgress-color");
-}
-
-.returnDetails-statusBadge--closed {
-    background-color: stencilColor("returnStatus-closed-backgroundColor");
-    color: stencilColor("returnStatus-closed-color");
-}
-
-.returnDetails-statusBadge--cancelled {
-    background-color: stencilColor("returnStatus-cancelled-backgroundColor");
-    color: stencilColor("returnStatus-cancelled-color");
+    margin: 0;
 }
 
 .returnDetails-divider {

--- a/templates/pages/account/return-details.html
+++ b/templates/pages/account/return-details.html
@@ -30,16 +30,16 @@
                     <h2 class="returnDetails-title">{{lang 'account.returns.details.return_number' id=return_detail.rma}}</h2>
                     {{#if return_detail.status '===' 'OPEN'}}
                         <span class="aria-description--hidden">{{lang 'account.returns.details.status_label'}}</span>
-                        <span class="returnDetails-statusBadge returnDetails-statusBadge--open">{{lang 'account.returns.status.open'}}</span>
+                        <span class="account-orderStatus-label account-orderStatus-label--open">{{lang 'account.returns.status.open'}}</span>
                     {{else if return_detail.status '===' 'IN_PROGRESS'}}
                         <span class="aria-description--hidden">{{lang 'account.returns.details.status_label'}}</span>
-                        <span class="returnDetails-statusBadge returnDetails-statusBadge--in_progress">{{lang 'account.returns.status.in_progress'}}</span>
+                        <span class="account-orderStatus-label account-orderStatus-label--inProgress">{{lang 'account.returns.status.in_progress'}}</span>
                     {{else if return_detail.status '===' 'CLOSED'}}
                         <span class="aria-description--hidden">{{lang 'account.returns.details.status_label'}}</span>
-                        <span class="returnDetails-statusBadge returnDetails-statusBadge--closed">{{lang 'account.returns.status.closed'}}</span>
+                        <span class="account-orderStatus-label account-orderStatus-label--closed">{{lang 'account.returns.status.closed'}}</span>
                     {{else if return_detail.status '===' 'CANCELLED'}}
                         <span class="aria-description--hidden">{{lang 'account.returns.details.status_label'}}</span>
-                        <span class="returnDetails-statusBadge returnDetails-statusBadge--cancelled">{{lang 'account.returns.status.cancelled'}}</span>
+                        <span class="account-orderStatus-label account-orderStatus-label--cancelled">{{lang 'account.returns.status.cancelled'}}</span>
                     {{/if}}
                 </div>
 
@@ -94,11 +94,11 @@
                 <dl class="returnDetails-summaryList">
                     <div class="returnDetails-summaryRow">
                         <dt class="returnDetails-summaryLabel">{{lang 'account.returns.details.date_submitted'}}</dt>
-                        <dd class="returnDetails-summaryValue">{{moment return_detail.date_submitted format="MMMM D, YYYY"}}</dd>
+                        <dd class="returnDetails-summaryValue">{{moment return_detail.date_submitted format="Do MMM YYYY"}}</dd>
                     </div>
                     <div class="returnDetails-summaryRow">
                         <dt class="returnDetails-summaryLabel">{{lang 'account.returns.details.last_update'}}</dt>
-                        <dd class="returnDetails-summaryValue">{{#if return_detail.last_updated}}{{moment return_detail.last_updated format="MMMM D, YYYY"}}{{else}}{{moment return_detail.date_submitted format="MMMM D, YYYY"}}{{/if}}</dd>
+                        <dd class="returnDetails-summaryValue">{{#if return_detail.last_updated}}{{moment return_detail.last_updated format="Do MMM YYYY"}}{{else}}{{moment return_detail.date_submitted format="Do MMM YYYY"}}{{/if}}</dd>
                     </div>
                     <div class="returnDetails-summaryRow">
                         <dt class="returnDetails-summaryLabel">{{lang 'account.returns.details.order_number'}}</dt>


### PR DESCRIPTION
#### What?
This PR aligns the date format and status badge between the returns listing and details pages.

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

https://bigcommercecloud.atlassian.net/browse/ORDERS-7965

#### Screenshots (if appropriate)

Before:
<img width="3018" height="1382" alt="image" src="https://github.com/user-attachments/assets/1fcb0ef8-5d19-4f14-93c8-1c944abc01e5" />

<img width="3018" height="1590" alt="image" src="https://github.com/user-attachments/assets/27503281-fd01-46ab-823f-c71bd677f233" />


After:
<img width="3012" height="1704" alt="image" src="https://github.com/user-attachments/assets/4bf8c0f1-eb73-48ff-bf64-cf606754918a" />

<img width="3012" height="1704" alt="image" src="https://github.com/user-attachments/assets/86053a65-10c9-41c3-9ace-470ddeffd080" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only template and stylesheet changes for visual consistency; no API, auth, or data-handling impact.
> 
> **Overview**
> Return details now uses the same **status badge** styling as the returns listing (`account-orderStatus-label` and status modifiers), replacing the page-specific `returnDetails-statusBadge` markup and SCSS.
> 
> **Date submitted** and **last update** in the summary sidebar use the `Do MMM YYYY` moment format to match `returns-list-v2`, instead of `MMMM D, YYYY`.
> 
> SCSS only adds light overrides on the title group for the shared badge (header font, uppercase, margin).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 699bbfe723993ae67a8b326690f214c4ccc6495c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->