### PR TITLE
fix(storefront): TRAC-1466 Show option-set rule message on rule-blocked options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Show option-set rule message on rule-blocked options. [#2735](https://github.com/bigcommerce/cornerstone/pull/2735)
 - Add checkout style overrides for enhanced checkout theme. [#2721](https://github.com/bigcommerce/cornerstone/pull/2721)
 
 ## 6.21.0 (07-21-2026)

--- a/assets/js/theme/common/product-details-base.js
+++ b/assets/js/theme/common/product-details-base.js
@@ -502,10 +502,18 @@ export default class ProductDetailsBase {
             ? Infinity
             : parseInt(this.context.availableToSell, 10) || 0;
 
+        // If increment buttons are already disabled for a reason unrelated to quantity
+        // (e.g. out-of-stock), don't override that with a quantity limit.
+        const alreadyBlocked = viewModel.$increments.prop('disabled');
+
         // The main product's sell-limit takes priority over any picklist limit.
         if (availableToSell > 0 && qty > availableToSell) {
-            const template = this.context.quantityMaxMessage || 'The maximum purchasable quantity is __QTY__';
-            this.showQtyLimitMessage(viewModel, $variantMessage, template.replace('__QTY__', availableToSell));
+            if (alreadyBlocked) {
+                viewModel.$addToCart.prop('disabled', true);
+            } else {
+                const template = this.context.quantityMaxMessage || 'The maximum purchasable quantity is __QTY__';
+                this.showQtyLimitMessage(viewModel, $variantMessage, template.replace('__QTY__', availableToSell));
+            }
             return;
         }
 
@@ -515,12 +523,16 @@ export default class ProductDetailsBase {
             && this.picklistBackorder.getSellLimitViolation(qty);
 
         if (picklistLimit) {
-            const template = this.context.quantityMaxPicklistMessage
-                || 'The maximum purchasable quantity for __NAME__ is __QTY__';
-            const message = template
-                .replace('__NAME__', picklistLimit.name)
-                .replace('__QTY__', picklistLimit.availableToSell);
-            this.showQtyLimitMessage(viewModel, $variantMessage, message);
+            if (alreadyBlocked) {
+                viewModel.$addToCart.prop('disabled', true);
+            } else {
+                const template = this.context.quantityMaxPicklistMessage
+                    || 'The maximum purchasable quantity for __NAME__ is __QTY__';
+                const message = template
+                    .replace('__NAME__', picklistLimit.name)
+                    .replace('__QTY__', picklistLimit.availableToSell);
+                this.showQtyLimitMessage(viewModel, $variantMessage, message);
+            }
             return;
         }
 
@@ -607,8 +619,6 @@ export default class ProductDetailsBase {
     updateView(data, content = null) {
         const viewModel = this.getViewModel(this.$scope);
 
-        this.showMessageBox(data.stock_message || data.purchasing_message);
-
         if (data.price instanceof Object) {
             this.updatePriceView(viewModel, data.price);
         } else {
@@ -663,6 +673,9 @@ export default class ProductDetailsBase {
         this.picklistBackorder.render(data, currentQty);
 
         this.updateDefaultAttributesForOOS(data);
+        // Must run after the stock check above, which hides this box whenever the
+        // product is sellable - even if this option is rule-blocked.
+        this.showMessageBox(data.stock_message || data.purchasing_message);
         this.updateAddToCartForQty(currentQty, viewModel);
         this.updateWalletButtonsView(data);
 
@@ -749,6 +762,9 @@ export default class ProductDetailsBase {
             return;
         }
 
+        // Remove the "belongs to quantity limit" flag from this message box - it now
+        // shows this method's own variant-level message, not a quantity limit.
+        $variantErrorBox.removeAttr('data-qty-limit');
         $('.alertBox-message', $variantErrorBox).text(message);
         $variantErrorBox.show();
     }


### PR DESCRIPTION
#### What?
Cornerstone versions after 6.19.0 stopped showing an option-set rule's custom "unavailable" message (e.g. "This Size Temporarily Sold Out"), even though Add to Cart and the quantity input still correctly
  disabled. This affects legacy-catalog (v2) products with no SKUs, an option-set rule set to "unavailable for purchase" with a custom message, and product-level inventory tracking off.

**Root cause:** in product-details-base.js, updateView() called showMessageBox() (which renders the rule's message) before updateDefaultAttributesForOOS(). The latter calls toggleSoldOutAlert(), which
  unconditionally hides that same message box whenever the product itself is sellable (instock: true) - regardless of whether the specific option combination is blocked by a rule (purchasable: false). The backend
  sends exactly this combination (instock: true + purchasable: false) when inventory isn't tracked at the product level, so the rule's message was shown and then immediately hidden on every option change.

**Fixes:**
  1. Moved the showMessageBox() call to run after updateDefaultAttributesForOOS(), so the rule message is set last and isn't overwritten by the stock check.
  2. showMessageBox() now clears a stale data-qty-limit flag when it sets its own message, so a later quantity-limit check (updateAddToCartForQty) doesn't mistake this message for its own and delete it.
  3. updateAddToCartForQty() now skips overwriting the box with a "maximum purchasable quantity" message when Add to Cart/quantity are already disabled for a more fundamental reason (a rule or true out-of-stock) - a customer who can't buy an item at all shouldn't see a quantity-limit message instead of the actual reason. This check is based on the button's disabled state (set earlier by the OOS/rule check), so it stays correct for backorderable items that can still show a stale stock_message while remaining purchasable (see BACK-633 / commit 083e45f4).

**Testing:**
  Verified both with unit tests and manually on two live stores, since option-set rules (no-SKU products) and backorder limits (SKU-level) can't coexist on the same product:
  - Legacy v2 catalog store, rule-blocked option: the custom rule message now shows and stays visible (**fix 1**).
  - Backorder-enabled store, switching between a qty-limited variant and an out-of-stock/unavailable variant with a leftover quantity in the field: the correct message (rule/unavailable/OOS) is preserved instead of being wiped by a stale data-qty-limit flag (**fix 2**), and instead of being overwritten by a "maximum purchasable quantity" message when the variant is separately marked unpurchasable (**fix 3**).
  - Confirmed no regression for normal backorder quantity limits (over-limit quantity on a purchasable backorderable variant still shows the correct "maximum purchasable quantity" message and disables Add to Cart).


#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

- Jira: [TRAC-1466](https://bigcommercecloud.atlassian.net/browse/TRAC-1466)

#### Screenshots (if appropriate)

**FIX 1**
Tested using bundle with the fixes in staff sandbox that has legacy product catalogue (v2)

<img width="1512" height="811" alt="Screenshot 2026-09-02 at 14 35 12" src="https://github.com/user-attachments/assets/25cad17b-e1bf-447a-86a1-2d5e8bf75884" />

**before:**

https://github.com/user-attachments/assets/2e2bbe7c-a091-415f-bd75-bee21726f064

**after:**

https://github.com/user-attachments/assets/862b33ed-9261-4232-8ce5-1e22e2d320f1

---

**FIX 2**

<img width="919" height="726" alt="Screenshot 2026-09-02 at 20 49 14" src="https://github.com/user-attachments/assets/cf88a01d-d045-48c3-bbf5-c46800c8cf23" />
<img width="1322" height="263" alt="Screenshot 2026-09-02 at 20 49 41" src="https://github.com/user-attachments/assets/32e2a714-dbd3-444b-bd66-e5530d5a218a" />

**before:**

https://github.com/user-attachments/assets/6bd0fe4c-a4e4-4d45-9789-15e1b9c1a99d

**after:**

https://github.com/user-attachments/assets/1ac5a1d3-385a-4991-bed6-20e40fae6b2b

---

**FIX 3**

<img width="919" height="728" alt="Screenshot 2026-09-02 at 20 47 34" src="https://github.com/user-attachments/assets/1840102d-b82d-42e4-891d-5194c119c9f8" />
<img width="1322" height="274" alt="Screenshot 2026-09-02 at 20 47 13" src="https://github.com/user-attachments/assets/977c899c-c8a4-447e-9501-0f7001b517b1" />

**before:**

https://github.com/user-attachments/assets/3cabceb7-b850-45eb-8558-e8973e913bb1

**after:**

https://github.com/user-attachments/assets/eef05b33-2348-4fa6-846b-01fb114d65a2


[TRAC-1466]: https://bigcommercecloud.atlassian.net/browse/TRAC-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PDP option-change messaging and add-to-cart/qty-limit ordering; regression risk for backorder quantity limits and OOS flows, though changes are narrowly scoped to message box timing and flags.
> 
> **Overview**
> Restores **custom option-set rule messages** on the PDP when a combination is unpurchasable but the product still looks sellable (e.g. legacy v2, no SKUs, inventory not tracked at product level). Add to Cart and quantity were already disabled; the alert text was missing or wrong.
> 
> In `product-details-base.js`, **`showMessageBox`** now runs **after** `updateDefaultAttributesForOOS`, so `toggleSoldOutAlert` no longer hides the variant alert whenever `instock` / ATS says the product can sell while the selected options are rule-blocked.
> 
> **`showMessageBox`** clears **`data-qty-limit`** when it sets a rule/stock message so **`updateAddToCartForQty`** does not treat that box as its own and clear or replace it.
> 
> **`updateAddToCartForQty`** skips the “maximum purchasable quantity” message when quantity controls are already disabled (rule or true OOS); it only keeps Add to Cart disabled instead of swapping the shopper’s real reason for a qty-cap message.
> 
> CHANGELOG Draft entry added for [#2735].
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 781a01418ac781e78f4f22418bd9ba909da1e3e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->