### PR TITLE
fix(storefront): BACK-885 Change PDP stock message cursor from pointer to default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Draft
+- Fix pointer cursor on PDP stock/backorder message text [#2737](https://github.com/bigcommerce/cornerstone/pull/2737)
 - Show option-set rule message on rule-blocked options. [#2735](https://github.com/bigcommerce/cornerstone/pull/2735)
 - Add checkout style overrides for enhanced checkout theme. [#2721](https://github.com/bigcommerce/cornerstone/pull/2721)
 

--- a/assets/scss/components/stencil/productView/_productView.scss
+++ b/assets/scss/components/stencil/productView/_productView.scss
@@ -257,6 +257,7 @@
 // Unify vertical rhythm across the four stacked lines (stock, main-product
 // backordered, per-picklist bundles) so the group reads as one cluster.
 .form-field--stock .form-label--alternate {
+    cursor: default;
     margin: 0;
 }
 


### PR DESCRIPTION
#### What?

- Update PDP stock message cursor from pointer to default.
   - When shoppers mouse over the stock count and backorder message on the PDP page the pointer turns from a pointer to a clickable hand

#### Requirements

#### Tickets / Documentation

https://bigcommercecloud.atlassian.net/browse/BACK-885

#### Screenshots (if appropriate)

##### Before

https://github.com/user-attachments/assets/5d124c5b-0f53-4529-874a-bf6a4a142174

##### After

https://github.com/user-attachments/assets/1c8d3575-214b-471d-9eb3-6952279378cb

ping @animesh1987 @bigcommerce/team-trac 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS override on non-interactive PDP copy; no behavior or data changes.
> 
> **Overview**
> Sets **`cursor: default`** on PDP stock/backorder alternate labels (`.form-field--stock .form-label--alternate`) so hovering stock count and backorder text no longer shows a pointer hand when those lines are not links.
> 
> Documents the fix in the **Draft** section of `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8fe7eb38cde5012fd8ad21651b162449424536c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->